### PR TITLE
feat(discord): add /model command for per-session model switching

### DIFF
--- a/discord/src/cli.ts
+++ b/discord/src/cli.ts
@@ -180,6 +180,19 @@ async function registerCommands(token: string, appId: string) {
       .setName('share')
       .setDescription('Share the current session as a public URL')
       .toJSON(),
+    new SlashCommandBuilder()
+      .setName('model')
+      .setDescription('Change the model for this session')
+      .addStringOption((option) => {
+        option
+          .setName('model')
+          .setDescription('Select a model (provider/model format)')
+          .setRequired(true)
+          .setAutocomplete(true)
+
+        return option
+      })
+      .toJSON(),
   ]
 
   const rest = new REST().setToken(token)


### PR DESCRIPTION
## Summary
- Added a new `/model` slash command to the Discord bot.
- Allows users to change the model for the current session (thread) without affecting project-wide configuration.
- Persists model preferences per thread in a new `thread_models` database table.
- Automatically passes the selected model to the OpenCode `session.prompt` API.
- Includes autocomplete support for selecting from all available models across configured providers.