### PR TITLE
fix: sanitize command names with colons for Discord slash commands

### DIFF
--- a/discord/src/cli.ts
+++ b/discord/src/cli.ts
@@ -279,7 +279,9 @@ async function registerCommands(token: string, appId: string, userCommands: Open
       continue
     }
 
-    const commandName = `${cmd.name}-cmd`
+    // Sanitize command name: oh-my-opencode uses MCP commands with colons, which Discord doesn't allow
+    const sanitizedName = cmd.name.replace(/:/g, '-')
+    const commandName = `${sanitizedName}-cmd`
     const description = cmd.description || `Run /${cmd.name} command`
 
     commands.push(


### PR DESCRIPTION
## Summary
- Sanitize user-defined command names by replacing colons (`:`) with hyphens (`-`)
- Fixes Discord slash command registration failures when oh-my-opencode uses MCP commands with colons
## Problem
Discord slash command names cannot contain colons (`:`), but oh-my-opencode's MCP command names sometimes include colons in their naming convention. This causes command registration to fail silently or throw validation errors.
## Solution
Add a sanitization step that replaces all colons in command names with hyphens before registering with Discord:
const sanitizedName = cmd.name.replace(/:/g, '-')
## Changes
- discord/src/cli.ts: Add colon-to-hyphen sanitization in registerCommands()