### PR TITLE
fix: Windows support for OpenCode binary detection and server spawn

### DIFF
--- a/discord/src/cli.ts
+++ b/discord/src/cli.ts
@@ -608,9 +608,14 @@ async function run({ restart, addChannels, useWorktrees, enableVoiceChannels }: 
   intro('🤖 Discord Bot Setup')
 
   // Step 0: Check if OpenCode CLI is available
-  const opencodeCheck = spawnSync('which', ['opencode'], { shell: true })
-
-  if (opencodeCheck.status !== 0) {
+  // Skip check if user set OPENCODE_PATH (for custom forks like shuvcode)
+  if (!process.env.OPENCODE_PATH) {
+    const opencodeCheck = spawnSync(
+      process.platform === 'win32' ? 'where' : 'which',
+      ['opencode'],
+      { shell: true }
+    )
+    if (opencodeCheck.status !== 0) {
     note('OpenCode CLI is required but not found in your PATH.', '⚠️  OpenCode Not Found')
 
     const shouldInstall = await confirm({
@@ -669,6 +674,7 @@ async function run({ restart, addChannels, useWorktrees, enableVoiceChannels }: 
       s.stop('Failed to install OpenCode CLI')
       cliLogger.error('Installation error:', error instanceof Error ? error.message : String(error))
       process.exit(EXIT_NO_RESTART)
+    }
     }
   }
 

--- a/discord/src/opencode.ts
+++ b/discord/src/opencode.ts
@@ -128,6 +128,7 @@ export async function initializeOpencodeForDirectory(directory: string): Promise
     stdio: 'pipe',
     detached: false,
     cwd: directory,
+    shell: true, // Required for .cmd files on Windows
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify({


### PR DESCRIPTION
# Windows: Multiple issues prevent bot from running

Kimaki does not work on Windows due to two issues:

## Issue 1: OpenCode binary detection uses Unix-only `which`

`cli.ts` uses `which opencode` to check if OpenCode is installed. This fails on Windows because `which` doesn't exist (Windows uses `where`).

**Fix:** Use `where` on Windows, skip check if `OPENCODE_PATH` is set (for custom forks).

## Issue 2: OpenCode server spawn fails for .cmd files

`opencode.ts` uses `spawn()` without `shell: true`. On Windows, npm-installed binaries create `.cmd` wrapper files which Node.js can't execute without `shell: true`.

**Fix:** Add `shell: true` to spawn options.

## Summary

Both fixes are required for Windows support:

1. **cli.ts** - Use `where` instead of `which`, optionally skip check when `OPENCODE_PATH` is set
2. **opencode.ts** - Add `shell: true` to spawn options