### PR TITLE
fix: normalize command names to lowercase for Discord slash commands

### DIFF
--- a/discord/src/cli.ts
+++ b/discord/src/cli.ts
@@ -441,7 +441,8 @@ async function registerCommands({
     }
 
     // Sanitize command name: oh-my-opencode uses MCP commands with colons, which Discord doesn't allow
-    const sanitizedName = cmd.name.replace(/:/g, '-')
+    // Also convert to lowercase since Discord only allows lowercase in command names
+    const sanitizedName = cmd.name.toLowerCase().replace(/:/g, '-')
     const commandName = `${sanitizedName}-cmd`
     const description = cmd.description || `Run /${cmd.name} command`
 


### PR DESCRIPTION
Discord slash command names must only contain lowercase letters, numbers, and hyphens. This commit adds `.toLowerCase()` to the command name sanitization logic to ensure compatibility with Discord's naming requirements.

Previously, custom commands with uppercase letters (e.g., 'Omarchy') would fail validation when converted to slash command names (e.g., 'Omarchy-cmd'), causing the 'Invalid string format' error during bot initialization.

Fixes the issue where user-defined OpenCode commands with uppercase letters would prevent slash command registration.