### PR TITLE
feat: add --trusted-bot-ids flag for multi-agent orchestration

### DIFF
--- a/discord/src/cli.ts
+++ b/discord/src/cli.ts
@@ -101,6 +101,7 @@ import {
   setVerboseOpencodeServer,
   getMemoryEnabled,
   setMemoryEnabled,
+  setTrustedBotIds,
   getProjectsDir,
 } from './config.js'
 import { sanitizeAgentName } from './commands/agent.js'
@@ -1978,6 +1979,10 @@ cli
     '--mention-mode',
     'Bot only responds when @mentioned (default for all channels)',
   )
+  .option(
+    '--trusted-bot-ids <ids>',
+    'Comma-separated list of bot user IDs allowed to interact with this bot (bypasses bot message filter)',
+  )
   .option('--memory', 'Enable memory sync and persistent memory features')
   .option(
     '--no-critique',
@@ -2001,6 +2006,7 @@ cli
       enableVoiceChannels?: boolean
       verbosity?: string
       mentionMode?: boolean
+      trustedBotIds?: string
       memory?: boolean
       noCritique?: boolean
       autoRestart?: boolean
@@ -2038,6 +2044,14 @@ cli
           setDefaultMentionMode(true)
           cliLogger.log(
             'Default mention mode: enabled (bot only responds when @mentioned)',
+          )
+        }
+
+        if (options.trustedBotIds) {
+          const ids = options.trustedBotIds.split(',').map((id) => id.trim()).filter(Boolean)
+          setTrustedBotIds(ids)
+          cliLogger.log(
+            `Trusted bot IDs: ${ids.join(', ')} (these bots can interact with this bot)`,
           )
         }
 

--- a/discord/src/config.ts
+++ b/discord/src/config.ts
@@ -94,6 +94,19 @@ export function setVerboseOpencodeServer(enabled: boolean): void {
   verboseOpencodeServer = enabled
 }
 
+// Trusted bot IDs that bypass the bot message filter.
+// Set via --trusted-bot-ids CLI flag at startup.
+// Allows specific bots (e.g. orchestration agents) to interact with Kimaki.
+let trustedBotIds: Set<string> = new Set()
+
+export function getTrustedBotIds(): Set<string> {
+  return trustedBotIds
+}
+
+export function setTrustedBotIds(ids: string[]): void {
+  trustedBotIds = new Set(ids)
+}
+
 // Whether memory sync/instructions are enabled.
 // Disabled by default; enabled via --memory CLI flag.
 let memoryEnabled = false

--- a/discord/src/discord-bot.ts
+++ b/discord/src/discord-bot.ts
@@ -16,6 +16,7 @@ import {
   setThreadSession,
   getPrisma,
 } from './database.js'
+import { getTrustedBotIds } from './config.js'
 import {
   initializeOpencodeForDirectory,
   getOpencodeServers,
@@ -282,7 +283,7 @@ export async function startDiscordBot({
         ? promptMarker?.model
         : undefined
 
-      if (message.author?.bot && !isCliInjectedPrompt) {
+      if (message.author?.bot && !isCliInjectedPrompt && !getTrustedBotIds().has(message.author.id)) {
         return
       }
 


### PR DESCRIPTION
## Summary

Adds a `--trusted-bot-ids` CLI flag that allows specific bot user IDs to bypass the bot message filter in `discord-bot.ts`. This enables multi-agent Discord setups where an orchestration bot needs to @mention and interact with Kimaki bots.

## Usage

```bash
kimaki --trusted-bot-ids 123456789,987654321
```

Comma-separated list of Discord bot user IDs that should be treated like human users (their messages are processed instead of silently dropped).

## Changes

- **`config.ts`** — New `trustedBotIds` Set with getter/setter (follows existing pattern for `mentionMode`, `verbosity`, etc.)
- **`cli.ts`** — New `--trusted-bot-ids <ids>` option, parsed and passed to config
- **`discord-bot.ts`** — One-line change to the bot filter condition: trusted bot IDs bypass the `message.author?.bot` check

## Use Case

Running a fleet of AI agents on a Discord server — an orchestration agent (e.g. OpenClaw) commanding multiple Kimaki coding agents, each managing a different project/server. The orchestrator @mentions Kimaki bots to dispatch tasks and receive responses, all visible in Discord threads for a clean audit trail.

Resolves #45