### PR TITLE
fix: make pending worktree writes atomic

### DIFF
--- a/discord/src/database.ts
+++ b/discord/src/database.ts
@@ -739,27 +739,29 @@ export async function createPendingWorktree({
   projectDirectory: string
 }): Promise<void> {
   const prisma = await getPrisma()
-  await prisma.thread_sessions.upsert({
-    where: { thread_id: threadId },
-    create: { thread_id: threadId, session_id: '' },
-    update: {},
-  })
-  await prisma.thread_worktrees.upsert({
-    where: { thread_id: threadId },
-    create: {
-      thread_id: threadId,
-      worktree_name: worktreeName,
-      project_directory: projectDirectory,
-      status: 'pending',
-    },
-    update: {
-      worktree_name: worktreeName,
-      project_directory: projectDirectory,
-      status: 'pending',
-      worktree_directory: null,
-      error_message: null,
-    },
-  })
+  await prisma.$transaction([
+    prisma.thread_sessions.upsert({
+      where: { thread_id: threadId },
+      create: { thread_id: threadId, session_id: '' },
+      update: {},
+    }),
+    prisma.thread_worktrees.upsert({
+      where: { thread_id: threadId },
+      create: {
+        thread_id: threadId,
+        worktree_name: worktreeName,
+        project_directory: projectDirectory,
+        status: 'pending',
+      },
+      update: {
+        worktree_name: worktreeName,
+        project_directory: projectDirectory,
+        status: 'pending',
+        worktree_directory: null,
+        error_message: null,
+      },
+    }),
+  ])
 }
 
 /**


### PR DESCRIPTION
Every worktree open fails for me

![](https://cdn.discordapp.com/attachments/1472010728121831668/1477056069363695819/image.png?ex=69a35f29&is=69a20da9&hm=7a2e59aadd5aa2a012d23b16e61ce62f657f0fed39bd43ca2e7f2b9b79b317e6&)


## Summary
- Make `createPendingWorktree` atomic by wrapping parent `thread_sessions.upsert` and child `thread_worktrees.upsert` in a single Prisma transaction.
- Add a regression test that verifies `createPendingWorktree` creates both parent and child rows with expected pending values.
- Address intermittent FK violations reported during worktree creation (`prisma.thread_worktrees.upsert` foreign key constraint failure).

## Diagnosis
The failure occurs when creating pending worktree metadata:
- parent row: `thread_sessions`
- child row: `thread_worktrees` (FK to `thread_sessions.thread_id`)

Previously these writes were separate statements, which leaves a timing window under concurrency. A single transaction removes that window.

User-provided screenshot of the failure:

## Validation
- `pnpm -C discord test src/db.test.ts`