### PR TITLE
fix: autocomplete handlers return empty results with gateway-proxy

### DIFF
--- a/discord/src/commands/merge-worktree.ts
+++ b/discord/src/commands/merge-worktree.ts
@@ -15,7 +15,7 @@ import { mergeWorktree, listBranchesByLastCommit, validateBranchRef } from '../w
 import {
   sendThreadMessage,
   resolveWorkingDirectory,
-  resolveTextChannel,
+  resolveProjectDirectoryFromAutocomplete,
 } from '../discord-utils.js'
 import {
   getOrCreateRuntime,
@@ -189,26 +189,10 @@ export async function handleMergeWorktreeAutocomplete({
   try {
     const focusedValue = interaction.options.getFocused()
 
-    let projectDirectory: string | undefined
-
-    // Try to get directory from worktree info (we're in a thread)
-    if (interaction.channel?.isThread()) {
-      const worktreeInfo = await getThreadWorktree(interaction.channel.id)
-      if (worktreeInfo?.project_directory) {
-        projectDirectory = worktreeInfo.project_directory
-      }
-    }
-
-    // Fallback: resolve from parent channel
-    if (!projectDirectory && interaction.channel) {
-      const textChannel = await resolveTextChannel(
-        interaction.channel as TextChannel | ThreadChannel | null,
-      )
-      if (textChannel) {
-        const channelConfig = await getChannelDirectory(textChannel.id)
-        projectDirectory = channelConfig?.directory
-      }
-    }
+    // interaction.channel can be null when the channel isn't cached
+    // (common with gateway-proxy). Use channelId which is always available
+    // from the raw interaction payload.
+    const projectDirectory = await resolveProjectDirectoryFromAutocomplete(interaction)
 
     if (!projectDirectory) {
       await interaction.respond([])

--- a/discord/src/commands/new-worktree.ts
+++ b/discord/src/commands/new-worktree.ts
@@ -21,7 +21,7 @@ import {
 import {
   SILENT_MESSAGE_FLAGS,
   reactToThread,
-  resolveTextChannel,
+  resolveProjectDirectoryFromAutocomplete,
 } from '../discord-utils.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import { notifyError } from '../sentry.js'
@@ -452,16 +452,10 @@ export async function handleNewWorktreeAutocomplete({
   try {
     const focusedValue = interaction.options.getFocused()
 
-    let projectDirectory: string | undefined
-    if (interaction.channel) {
-      const textChannel = await resolveTextChannel(
-        interaction.channel as TextChannel | ThreadChannel | null,
-      )
-      if (textChannel) {
-        const channelConfig = await getChannelDirectory(textChannel.id)
-        projectDirectory = channelConfig?.directory
-      }
-    }
+    // interaction.channel can be null when the channel isn't cached
+    // (common with gateway-proxy). Use channelId which is always available
+    // from the raw interaction payload.
+    const projectDirectory = await resolveProjectDirectoryFromAutocomplete(interaction)
 
     if (!projectDirectory) {
       await interaction.respond([])

--- a/discord/src/commands/resume.ts
+++ b/discord/src/commands/resume.ts
@@ -15,7 +15,7 @@ import {
   getAllThreadSessionIds,
 } from '../database.js'
 import { initializeOpencodeForDirectory } from '../opencode.js'
-import { sendThreadMessage, resolveTextChannel } from '../discord-utils.js'
+import { sendThreadMessage, resolveProjectDirectoryFromAutocomplete } from '../discord-utils.js'
 import { collectLastAssistantParts } from '../message-formatting.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import * as errore from 'errore'
@@ -168,17 +168,10 @@ export async function handleResumeAutocomplete({
 }: AutocompleteContext): Promise<void> {
   const focusedValue = interaction.options.getFocused()
 
-  let projectDirectory: string | undefined
-
-  if (interaction.channel) {
-    const textChannel = await resolveTextChannel(
-      interaction.channel as TextChannel | ThreadChannel | null,
-    )
-    if (textChannel) {
-      const channelConfig = await getChannelDirectory(textChannel.id)
-      projectDirectory = channelConfig?.directory
-    }
-  }
+  // interaction.channel can be null when the channel isn't cached
+  // (common with gateway-proxy). Use channelId which is always available
+  // from the raw interaction payload.
+  const projectDirectory = await resolveProjectDirectoryFromAutocomplete(interaction)
 
   if (!projectDirectory) {
     await interaction.respond([])

--- a/discord/src/commands/session.ts
+++ b/discord/src/commands/session.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import type { CommandContext, AutocompleteContext } from './types.js'
 import { getChannelDirectory } from '../database.js'
 import { initializeOpencodeForDirectory } from '../opencode.js'
-import { SILENT_MESSAGE_FLAGS } from '../discord-utils.js'
+import { SILENT_MESSAGE_FLAGS, resolveProjectDirectoryFromAutocomplete } from '../discord-utils.js'
 import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import * as errore from 'errore'
@@ -110,17 +110,10 @@ async function handleAgentAutocomplete({
 }): Promise<void> {
   const focusedValue = interaction.options.getFocused()
 
-  let projectDirectory: string | undefined
-
-  if (
-    interaction.channel &&
-    interaction.channel.type === ChannelType.GuildText
-  ) {
-    const channelConfig = await getChannelDirectory(interaction.channel.id)
-    if (channelConfig) {
-      projectDirectory = channelConfig.directory
-    }
-  }
+  // interaction.channel can be null when the channel isn't cached
+  // (common with gateway-proxy). Use channelId which is always available
+  // from the raw interaction payload.
+  const projectDirectory = await resolveProjectDirectoryFromAutocomplete(interaction)
 
   if (!projectDirectory) {
     await interaction.respond([])
@@ -186,17 +179,7 @@ export async function handleSessionAutocomplete({
     .filter((f) => f)
   const currentQuery = (parts[parts.length - 1] || '').trim()
 
-  let projectDirectory: string | undefined
-
-  if (
-    interaction.channel &&
-    interaction.channel.type === ChannelType.GuildText
-  ) {
-    const channelConfig = await getChannelDirectory(interaction.channel.id)
-    if (channelConfig) {
-      projectDirectory = channelConfig.directory
-    }
-  }
+  const projectDirectory = await resolveProjectDirectoryFromAutocomplete(interaction)
 
   if (!projectDirectory) {
     await interaction.respond([])

--- a/discord/src/discord-utils.ts
+++ b/discord/src/discord-utils.ts
@@ -4,6 +4,7 @@
 
 import {
   type APIInteractionGuildMember,
+  type AutocompleteInteraction,
   ChannelType,
   GuildMember,
   MessageFlags,
@@ -643,6 +644,58 @@ export async function getKimakiMetadata(
   return {
     projectDirectory: channelConfig.directory,
   }
+}
+
+/**
+ * Resolve project directory from an autocomplete interaction.
+ * Uses interaction.channelId (always available from raw payload) instead of
+ * interaction.channel (cache-based getter, often null with gateway-proxy).
+ * Checks the channel ID directly in DB, then tries thread worktree lookup,
+ * then falls back to fetching the channel to resolve thread parent.
+ */
+export async function resolveProjectDirectoryFromAutocomplete(
+  interaction: Pick<AutocompleteInteraction, 'channelId' | 'channel' | 'client'>,
+): Promise<string | undefined> {
+  const channelId = interaction.channelId
+
+  // Direct channel lookup — works when the command is run from a project text channel
+  const channelConfig = await getChannelDirectory(channelId)
+  if (channelConfig) {
+    return channelConfig.directory
+  }
+
+  // If we're in a thread, try worktree info first (has project_directory)
+  const worktreeInfo = await getThreadWorktree(channelId)
+  if (worktreeInfo?.project_directory) {
+    return worktreeInfo.project_directory
+  }
+
+  // Thread fallback: resolve parent channel ID and look up its directory.
+  // Try cached channel first, then fetch if cache misses (gateway-proxy scenario).
+  const cachedParentId = interaction.channel?.isThread() ? interaction.channel.parentId : null
+  if (cachedParentId) {
+    const parentConfig = await getChannelDirectory(cachedParentId)
+    if (parentConfig) {
+      return parentConfig.directory
+    }
+  }
+
+  // Last resort: fetch the channel from Discord API to get parentId for threads
+  // when the channel isn't cached at all (common with gateway-proxy).
+  if (!cachedParentId) {
+    const fetched = await errore.tryAsync({
+      try: () => { return interaction.client.channels.fetch(channelId) },
+      catch: (e) => { return e as Error },
+    })
+    if (!(fetched instanceof Error) && fetched?.isThread() && fetched.parentId) {
+      const parentConfig = await getChannelDirectory(fetched.parentId)
+      if (parentConfig) {
+        return parentConfig.directory
+      }
+    }
+  }
+
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`interaction.channel` is null with gateway-proxy** because discord.js resolves it from cache, and the proxy doesn't warm all channels. All autocomplete handlers that used `interaction.channel` to resolve the project directory silently returned `[]`.
- **Created `resolveProjectDirectoryFromAutocomplete()`** shared helper that uses `interaction.channelId` (always available from raw payload). Falls back through: direct DB lookup → thread worktree info → cached parent → API fetch for parent.
- **Fixed 4 autocomplete handlers:** `/new-worktree` base-branch, `/merge-worktree` target-branch, `/new-session` agent + files, `/resume` session.

Net -67/+74 lines — less boilerplate since all handlers now call the same helper.