### PR TITLE
add one-shot add-directory preapproval

### DIFF
--- a/discord/src/add-directory.e2e.test.ts
+++ b/discord/src/add-directory.e2e.test.ts
@@ -1,0 +1,124 @@
+// E2e tests for thread-scoped external directory preapproval via /add-directory.
+
+import { describe, expect, test } from 'vitest'
+import {
+  setupQueueAdvancedSuite,
+  TEST_USER_ID,
+} from './queue-advanced-e2e-setup.js'
+import {
+  waitForBotMessageContaining,
+  waitForFooterMessage,
+} from './test-utils.js'
+
+const TEXT_CHANNEL_ID = '200000000000001014'
+
+describe('/add-directory', () => {
+  const ctx = setupQueueAdvancedSuite({
+    channelId: TEXT_CHANNEL_ID,
+    channelName: 'add-directory-e2e',
+    dirName: 'add-directory-e2e',
+    username: 'add-directory-tester',
+  })
+
+  test(
+    'preapproves external directory access for the current thread',
+    async () => {
+      await ctx.discord.channel(TEXT_CHANNEL_ID).user(TEST_USER_ID).sendMessage({
+        content: 'Reply with exactly: add-directory-setup',
+      })
+
+      const thread = await ctx.discord.channel(TEXT_CHANNEL_ID).waitForThread({
+        timeout: 4_000,
+        predicate: (candidate) => {
+          return candidate.name === 'Reply with exactly: add-directory-setup'
+        },
+      })
+      const th = ctx.discord.thread(thread.id)
+
+      await th.waitForBotReply({ timeout: 4_000 })
+      await waitForFooterMessage({
+        discord: ctx.discord,
+        threadId: thread.id,
+        timeout: 4_000,
+      })
+
+      const slashCommand = await th.user(TEST_USER_ID).runSlashCommand({
+        name: 'add-directory',
+        options: [{ name: 'path', type: 3, value: '/Users/morse' }],
+      })
+      await th.waitForInteractionAck({
+        interactionId: slashCommand.id,
+        timeout: 4_000,
+      })
+
+      await th.user(TEST_USER_ID).sendMessage({
+        content: 'PERMISSION_TYPING_MARKER add-directory-flow first',
+      })
+
+      await waitForBotMessageContaining({
+        discord: ctx.discord,
+        threadId: thread.id,
+        userId: TEST_USER_ID,
+        text: 'permission-flow-done',
+        timeout: 8_000,
+      })
+      await waitForFooterMessage({
+        discord: ctx.discord,
+        threadId: thread.id,
+        timeout: 12_000,
+        afterMessageIncludes: 'permission-flow-done',
+        afterAuthorId: ctx.discord.botUserId,
+      })
+
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const messages = await th.getMessages()
+        const hasPermissionPrompt = messages.some((message) => {
+          return message.content.includes('Permission Required')
+        })
+        expect(hasPermissionPrompt).toBe(false)
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 20)
+        })
+      }
+
+      await th.user(TEST_USER_ID).sendMessage({
+        content: 'PERMISSION_TYPING_MARKER add-directory-flow second',
+      })
+
+      await waitForBotMessageContaining({
+        discord: ctx.discord,
+        threadId: thread.id,
+        userId: TEST_USER_ID,
+        text: 'Permission Required',
+        timeout: 8_000,
+      })
+
+      const timeline = await th.text()
+      expect(timeline).toMatchInlineSnapshot(`
+        "--- from: user (add-directory-tester)
+        Reply with exactly: add-directory-setup
+        --- from: assistant (TestBot)
+        ⬥ ok
+        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*
+        Directory preapproved for the next message in this thread.
+        \`/Users/morse\`
+        Kimaki will auto-accept matching external directory requests for \`/Users/morse/*\` during the next run only.
+        --- from: user (add-directory-tester)
+        PERMISSION_TYPING_MARKER add-directory-flow first
+        --- from: assistant (TestBot)
+        ⬥ requesting external read permission
+        ⬥ permission-flow-done
+        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*
+        --- from: user (add-directory-tester)
+        PERMISSION_TYPING_MARKER add-directory-flow second
+        --- from: assistant (TestBot)
+        ⚠️ **Permission Required**
+        **Type:** \`external_directory\`
+        Agent is accessing files outside the project. [Learn more](https://opencode.ai/docs/permissions/#external-directories)
+        **Pattern:** \`/Users/morse/*\`
+        ⬥ requesting external read permission"
+      `)
+    },
+    20_000,
+  )
+})

--- a/discord/src/commands/add-directory.ts
+++ b/discord/src/commands/add-directory.ts
@@ -1,0 +1,93 @@
+// /add-directory command - Preapprove an external directory for this thread.
+
+import {
+  ChannelType,
+  MessageFlags,
+  type TextChannel,
+  type ThreadChannel,
+} from 'discord.js'
+import type { CommandContext } from './types.js'
+import { getThreadSession } from '../database.js'
+import { normalizeAllowedDirectoryPath } from '../directory-permissions.js'
+import {
+  resolveWorkingDirectory,
+  SILENT_MESSAGE_FLAGS,
+} from '../discord-utils.js'
+import { createLogger } from '../logger.js'
+import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js'
+
+const logger = createLogger('ADD_DIR')
+
+export async function handleAddDirectoryCommand({
+  command,
+  appId,
+}: CommandContext): Promise<void> {
+  const inputPath = command.options.getString('path', true)
+  const channel = command.channel
+
+  if (!channel) {
+    await command.reply({
+      content: 'This command can only be used in a channel',
+      flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS,
+    })
+    return
+  }
+
+  const isThread = [
+    ChannelType.PublicThread,
+    ChannelType.PrivateThread,
+    ChannelType.AnnouncementThread,
+  ].includes(channel.type)
+
+  if (!isThread) {
+    await command.reply({
+      content: 'This command can only be used in a thread with an active session',
+      flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS,
+    })
+    return
+  }
+
+  await command.deferReply({
+    flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS,
+  })
+
+  const sessionId = await getThreadSession(channel.id)
+  if (!sessionId) {
+    await command.editReply('No active session in this thread')
+    return
+  }
+
+  const resolved = await resolveWorkingDirectory({
+    channel: channel as TextChannel | ThreadChannel,
+  })
+  if (!resolved) {
+    await command.editReply('Could not determine project directory for this channel')
+    return
+  }
+
+  const normalizedPath = normalizeAllowedDirectoryPath({
+    input: inputPath,
+    workingDirectory: resolved.workingDirectory,
+  })
+  if (normalizedPath instanceof Error) {
+    await command.editReply(normalizedPath.message)
+    return
+  }
+
+  const runtime = getOrCreateRuntime({
+    threadId: channel.id,
+    thread: channel as ThreadChannel,
+    projectDirectory: resolved.projectDirectory,
+    sdkDirectory: resolved.workingDirectory,
+    channelId: (channel as ThreadChannel).parentId || channel.id,
+    appId,
+  })
+  runtime.primeNextExternalDirectoryAccess({
+    directory: normalizedPath,
+  })
+
+  await command.editReply(
+    `Directory preapproved for the next message in this thread.\n\`${normalizedPath}\`\nKimaki will auto-accept matching external directory requests for \`${normalizedPath}/*\` during the next run only.`,
+  )
+  logger.log(`Thread ${channel.id} primed one-shot directory ${normalizedPath}`)
+}

--- a/discord/src/directory-permissions.test.ts
+++ b/discord/src/directory-permissions.test.ts
@@ -1,0 +1,47 @@
+// Tests for one-shot directory permission path normalization helpers.
+
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import {
+  buildAllowedDirectoryPatterns,
+  normalizeAllowedDirectoryPath,
+} from './directory-permissions.js'
+
+describe('normalizeAllowedDirectoryPath', () => {
+  test('resolves relative paths from the working directory', () => {
+    const result = normalizeAllowedDirectoryPath({
+      input: '../shared/',
+      workingDirectory: '/repo/worktree/app',
+    })
+    expect(result).toBe('/repo/worktree/shared')
+  })
+
+  test('expands home directories and strips implicit trailing glob', () => {
+    const result = normalizeAllowedDirectoryPath({
+      input: '~/projects/*',
+      workingDirectory: '/repo/worktree/app',
+    })
+    expect(result).toBe(`${os.homedir().replaceAll('\\', '/')}/projects`)
+  })
+
+  test('rejects glob patterns in the middle of the path', () => {
+    const result = normalizeAllowedDirectoryPath({
+      input: 'src/*/nested',
+      workingDirectory: '/repo/worktree/app',
+    })
+    expect(result instanceof Error ? result.message : result).toBe(
+      'Path must be a directory, not a glob pattern',
+    )
+  })
+})
+
+describe('buildAllowedDirectoryPatterns', () => {
+  test('adds exact and child wildcard patterns for a directory', () => {
+    const directory = path.join('/repo', 'shared').replaceAll('\\', '/')
+    expect(buildAllowedDirectoryPatterns({ directory })).toEqual([
+      '/repo/shared',
+      '/repo/shared/*',
+    ])
+  })
+})

--- a/discord/src/directory-permissions.ts
+++ b/discord/src/directory-permissions.ts
@@ -1,0 +1,55 @@
+// Directory permission helpers for one-shot external directory preapproval.
+
+import os from 'node:os'
+import path from 'node:path'
+
+export function normalizeAllowedDirectoryPath({
+  input,
+  workingDirectory,
+}: {
+  input: string
+  workingDirectory: string
+}): Error | string {
+  const trimmedInput = input.trim()
+  if (!trimmedInput) {
+    return new Error('Path cannot be empty')
+  }
+
+  const withoutTrailingGlob = trimmedInput.replace(/[\\/]\*+$/u, '')
+  if (!withoutTrailingGlob) {
+    return new Error('Path cannot be empty')
+  }
+  if (withoutTrailingGlob.includes('*') || withoutTrailingGlob.includes('?')) {
+    return new Error('Path must be a directory, not a glob pattern')
+  }
+
+  const expandedHomeDirectory = (() => {
+    if (withoutTrailingGlob === '~') {
+      return os.homedir()
+    }
+    if (withoutTrailingGlob.startsWith('~/')) {
+      return path.join(os.homedir(), withoutTrailingGlob.slice(2))
+    }
+    return withoutTrailingGlob
+  })()
+
+  const absolutePath = path.isAbsolute(expandedHomeDirectory)
+    ? expandedHomeDirectory
+    : path.resolve(workingDirectory, expandedHomeDirectory)
+  const normalizedPath = path.normalize(absolutePath)
+  const root = path.parse(normalizedPath).root
+  const withoutTrailingSlash = normalizedPath.length > root.length
+    ? normalizedPath.replace(/[\\/]+$/u, '')
+    : normalizedPath
+
+  return withoutTrailingSlash.replaceAll('\\', '/')
+}
+
+export function buildAllowedDirectoryPatterns({
+  directory,
+}: {
+  directory: string
+}): string[] {
+  const childPattern = directory.endsWith('/') ? `${directory}*` : `${directory}/*`
+  return [directory, childPattern]
+}

--- a/discord/src/discord-command-registration.ts
+++ b/discord/src/discord-command-registration.ts
@@ -303,6 +303,19 @@ export async function registerCommands({
       .setDMPermission(false)
       .toJSON(),
     new SlashCommandBuilder()
+      .setName('add-directory')
+      .setDescription(truncateCommandDescription('Preapprove an external directory for the next message in this thread'))
+      .addStringOption((option) => {
+        option
+          .setName('path')
+          .setDescription(truncateCommandDescription('Directory path to allow for the next message'))
+          .setRequired(true)
+
+        return option
+      })
+      .setDMPermission(false)
+      .toJSON(),
+    new SlashCommandBuilder()
       .setName('compact')
       .setDescription(
         truncateCommandDescription('Compact the session context by summarizing conversation history'),

--- a/discord/src/interaction-handler.ts
+++ b/discord/src/interaction-handler.ts
@@ -39,6 +39,7 @@ import {
 import { handleCreateNewProjectCommand } from './commands/create-new-project.js'
 import { handlePermissionButton } from './commands/permissions.js'
 import { handleAbortCommand } from './commands/abort.js'
+import { handleAddDirectoryCommand } from './commands/add-directory.js'
 import { handleCompactCommand } from './commands/compact.js'
 import { handleShareCommand } from './commands/share.js'
 import { handleDiffCommand } from './commands/diff.js'
@@ -241,6 +242,10 @@ export function registerInteractionHandler({
 
             case 'abort':
               await handleAbortCommand({ command: interaction, appId })
+              return
+
+            case 'add-directory':
+              await handleAddDirectoryCommand({ command: interaction, appId })
               return
 
             case 'compact':

--- a/discord/src/session-handler/thread-session-runtime.ts
+++ b/discord/src/session-handler/thread-session-runtime.ts
@@ -49,6 +49,7 @@ import {
   appendSessionEventsSinceLastTimestamp,
   getSessionEventSnapshot,
 } from '../database.js'
+import { buildAllowedDirectoryPatterns } from '../directory-permissions.js'
 import {
   showPermissionButtons,
   cleanupPermissionContext,
@@ -533,6 +534,8 @@ export class ThreadSessionRuntime {
   // resolved input is then routed through the normal enqueue paths which
   // use dispatchAction internally.
   private preprocessChain: Promise<void> = Promise.resolve()
+  private primedExternalDirectoryPatterns: string[] | null = null
+  private activeExternalDirectoryPatterns: string[] | null = null
 
   constructor(opts: RuntimeOptions) {
     this.threadId = opts.threadId
@@ -575,6 +578,35 @@ export class ThreadSessionRuntime {
 
   getDerivedPhase(): 'idle' | 'running' {
     return this.isMainSessionBusy() ? 'running' : 'idle'
+  }
+
+  primeNextExternalDirectoryAccess({ directory }: { directory: string }): void {
+    this.primedExternalDirectoryPatterns = buildAllowedDirectoryPatterns({
+      directory,
+    })
+  }
+
+  private consumePrimedExternalDirectoryPatterns({
+    prompt,
+    images,
+    command,
+  }: {
+    prompt: string
+    images?: DiscordFileAttachment[]
+    command?: { name: string; arguments: string }
+  }): string[] | undefined {
+    const hasPromptText = prompt.trim().length > 0
+    const hasImages = (images?.length || 0) > 0
+    if (!hasPromptText && !hasImages && !command) {
+      return undefined
+    }
+    const primedPatterns = this.primedExternalDirectoryPatterns
+    this.primedExternalDirectoryPatterns = null
+    return primedPatterns || undefined
+  }
+
+  private activateExternalDirectoryPatterns(patterns?: string[]): void {
+    this.activeExternalDirectoryPatterns = patterns?.length ? [...patterns] : null
   }
 
   /** Whether the listener has been disposed. */
@@ -2184,6 +2216,7 @@ export class ThreadSessionRuntime {
     // The event is also pushed into the event buffer by handleEvent(),
     // so waitForEvent() consumers (abort settlement) will see it too.
     if (idleSessionId === sessionId) {
+      this.activeExternalDirectoryPatterns = null
       const shouldDrainQueuedMessages = doesLatestUserTurnHaveNaturalCompletion({
         events: this.eventBuffer,
         sessionId: idleSessionId,
@@ -2278,6 +2311,7 @@ export class ThreadSessionRuntime {
     }
 
     const errorMessage = formatSessionErrorFromProps(properties.error)
+    this.activeExternalDirectoryPatterns = null
     logger.error(`Sending error to thread: ${errorMessage}`)
     await sendThreadMessage(
       this.thread,
@@ -2310,6 +2344,39 @@ export class ThreadSessionRuntime {
     }
 
     const subtaskLabel = subtaskInfo?.label
+
+    if (permission.permission === 'external_directory') {
+      const allowedPatterns = this.activeExternalDirectoryPatterns || []
+      const isCovered = arePatternsCoveredBy({
+        patterns: permission.patterns,
+        coveringPatterns: allowedPatterns,
+      })
+      if (isCovered) {
+        const client = getOpencodeClient(this.projectDirectory)
+        if (!client) {
+          logger.warn(
+            `[PERMISSION] Could not auto-accept preapproved directory request ${permission.id}: no client`,
+          )
+        } else {
+          const autoReplyResult = await errore.tryAsync(() => {
+            return client.permission.reply({
+              requestID: permission.id,
+              directory: this.sdkDirectory,
+              reply: 'once',
+            })
+          })
+          if (!(autoReplyResult instanceof Error)) {
+            logger.log(
+              `[PERMISSION] Auto-accepted preapproved external directory request ${permission.id} patterns=${permission.patterns.join(', ')}`,
+            )
+            return
+          }
+          logger.warn(
+            `[PERMISSION] Failed to auto-accept preapproved directory request ${permission.id}: ${autoReplyResult.message}`,
+          )
+        }
+      }
+    }
 
     const dedupeKey = buildPermissionDedupeKey({
       permission,
@@ -2683,6 +2750,14 @@ export class ThreadSessionRuntime {
         modelOverride: input.model,
         force: createdNewSession,
       })
+
+      this.activateExternalDirectoryPatterns(
+        this.consumePrimedExternalDirectoryPatterns({
+          prompt: input.prompt,
+          images: input.images,
+          command: input.command,
+        }),
+      )
 
       const agentResult = await errore.tryAsync(() => {
         return resolveValidatedAgentPreference({
@@ -3915,6 +3990,7 @@ export class ThreadSessionRuntime {
     this.modelContextLimitKey = undefined
     this.lastDisplayedContextPercentage = 0
     this.lastRateLimitDisplayTime = 0
+    this.activeExternalDirectoryPatterns = null
   }
 
   // ── Retry Last User Prompt (for model-change flow) ──────────


### PR DESCRIPTION
`/add-directory` now primes external directory access for the next message only instead of storing a thread-scoped allowlist in sqlite.
The runtime auto-accepts the next matching `external_directory` request with a one-shot reply, then falls back to the normal permission prompt on later turns.
Includes unit coverage for path normalization and an e2e that proves the first matching turn is auto-approved while the second prompts again.