### PR TITLE
Respect explicit OpenCode permission config for external directories

### DIFF
--- a/discord/package.json
+++ b/discord/package.json
@@ -81,6 +81,7 @@
     "pretty-ms": "^9.3.0",
     "proper-lockfile": "^4.1.2",
     "string-dedent": "^3.0.2",
+    "tiny-jsonc": "^1.0.2",
     "traforo": "workspace:^",
     "undici": "^7.16.0",
     "ws": "^8.19.0",

--- a/discord/src/opencode.ts
+++ b/discord/src/opencode.ts
@@ -7,9 +7,9 @@
 //
 // Per-directory permissions (external_directory rules for worktrees, tmpdir,
 // etc.) are passed via session.create({ permission }) at session creation time,
-// NOT via the server config. The server config has permissive defaults
-// (edit: allow, bash: allow, external_directory: ask) and session-level rules
-// override them via opencode's findLast() evaluation (last matching rule wins).
+// NOT via the server config. The server config only installs Kimaki's base
+// non-directory defaults (edit/bash/webfetch allow). The session-level
+// external_directory rules decide whether unknown external paths ask or allow.
 //
 // Uses errore for type-safe error handling.
 
@@ -27,6 +27,7 @@ import {
   type Config as SdkConfig,
   type PermissionRuleset,
 } from '@opencode-ai/sdk/v2'
+import JSONC from 'tiny-jsonc'
 
 import {
   getDataDir,
@@ -38,14 +39,22 @@ import { getHranaUrl } from './hrana-server.js'
 // SDK Config type is simplified; opencode accepts nested permission objects with path patterns
 type PermissionAction = 'ask' | 'allow' | 'deny'
 type PermissionRule = PermissionAction | Record<string, PermissionAction>
+type JsonConfig = Record<string, unknown>
+const KIMAKI_BASE_PERMISSION = {
+  edit: 'allow',
+  bash: 'allow',
+  webfetch: 'allow',
+} as const
+
 type Config = Omit<SdkConfig, 'permission'> & {
-  permission?: {
-    edit?: PermissionRule
-    bash?: PermissionRule
-    external_directory?: PermissionRule
-    webfetch?: PermissionRule
-    [key: string]: PermissionRule | undefined
-  }
+  permission?:
+    | PermissionAction
+    | {
+        edit?: PermissionRule
+        bash?: PermissionRule
+        webfetch?: PermissionRule
+        [key: string]: PermissionRule | undefined
+      }
 }
 import * as errore from 'errore'
 import { createLogger, LogPrefix } from './logger.js'
@@ -476,31 +485,9 @@ async function startSingleServer(): Promise<ServerStartError | SingleServer> {
     baseArgs: serveArgs,
   })
 
-  // Server config uses permissive defaults. Per-directory external_directory
-  // permissions are set at session creation time via session.create({ permission }).
-  // Common directories (tmpdir, ~/.config/opencode, ~/.kimaki) are pre-allowed
-  // at the server level so they never trigger permission prompts regardless of
-  // whether session-level rules compose correctly.
-  const tmpdir = os.tmpdir().replaceAll('\\', '/')
-  const opencodeConfigDir = path
-    .join(os.homedir(), '.config', 'opencode')
-    .replaceAll('\\', '/')
-  const kimakiDataDir = path
-    .join(os.homedir(), '.kimaki')
-    .replaceAll('\\', '/')
-  const externalDirectoryPermissions: Record<string, 'ask' | 'allow' | 'deny'> = {
-    '*': 'ask',
-    '/tmp': 'allow',
-    '/tmp/*': 'allow',
-    '/private/tmp': 'allow',
-    '/private/tmp/*': 'allow',
-    [tmpdir]: 'allow',
-    [`${tmpdir}/*`]: 'allow',
-    [opencodeConfigDir]: 'allow',
-    [`${opencodeConfigDir}/*`]: 'allow',
-    [kimakiDataDir]: 'allow',
-    [`${kimakiDataDir}/*`]: 'allow',
-  }
+  // Server config keeps Kimaki's non-external-directory defaults. Directory
+  // access is handled per session so explicit user/project permission config can
+  // still disable Kimaki's secure-by-default external_directory ask rule.
   const kimakiShimDirectory = ensureKimakiCommandShim({
     dataDir: getDataDir(),
     execPath: process.execPath,
@@ -544,10 +531,7 @@ async function startSingleServer(): Promise<ServerStartError | SingleServer> {
     formatter: false,
     plugin: [new URL('../src/kimaki-opencode-plugin.ts', import.meta.url).href],
     permission: {
-      edit: 'allow',
-      bash: 'allow',
-      external_directory: externalDirectoryPermissions,
-      webfetch: 'allow',
+      ...KIMAKI_BASE_PERMISSION,
     },
     agent: {
       explore: {
@@ -565,7 +549,6 @@ async function startSingleServer(): Promise<ServerStartError | SingleServer> {
           webfetch: 'allow',
           websearch: 'allow',
           codesearch: 'allow',
-          external_directory: externalDirectoryPermissions,
         },
       },
     },
@@ -850,9 +833,11 @@ export async function initializeOpencodeForDirectory(
 export function buildSessionPermissions({
   directory,
   originalRepoDirectory,
+  includeExternalDirectoryAsk = true,
 }: {
   directory: string
   originalRepoDirectory?: string
+  includeExternalDirectoryAsk?: boolean
 }): PermissionRuleset {
   // Normalize path separators for cross-platform compatibility (Windows uses backslashes)
   const tmpdir = os.tmpdir().replaceAll('\\', '/')
@@ -860,8 +845,9 @@ export function buildSessionPermissions({
   const originalRepo = originalRepoDirectory?.replaceAll('\\', '/')
 
   const rules: PermissionRuleset = [
-    // Base rule: ask for unknown external directories
-    { permission: 'external_directory', pattern: '*', action: 'ask' },
+    ...(includeExternalDirectoryAsk
+      ? [{ permission: 'external_directory', pattern: '*', action: 'ask' as const }]
+      : []),
     // Allow tmpdir access
     { permission: 'external_directory', pattern: '/tmp', action: 'allow' },
     { permission: 'external_directory', pattern: '/tmp/*', action: 'allow' },
@@ -885,11 +871,10 @@ export function buildSessionPermissions({
     { permission: 'external_directory', pattern: `${opencodeConfigDir}/*`, action: 'allow' },
   )
 
-  // Allow ~/.kimaki so the agent can access kimaki data dir (logs, db, etc.)
-  // without permission prompts.
-  const kimakiDataDir = path
-    .join(os.homedir(), '.kimaki')
-    .replaceAll('\\', '/')
+  // Allow the active Kimaki data dir so the agent can access logs, sqlite, and
+  // related bot state without permission prompts even when the data dir is not
+  // the legacy ~/.kimaki path.
+  const kimakiDataDir = getDataDir().replaceAll('\\', '/')
   rules.push(
     { permission: 'external_directory', pattern: kimakiDataDir, action: 'allow' },
     { permission: 'external_directory', pattern: `${kimakiDataDir}/*`, action: 'allow' },
@@ -922,6 +907,62 @@ export function buildSessionPermissions({
   }
 
   return rules
+}
+
+export function shouldIncludeExternalDirectoryAsk({
+  projectDirectory,
+}: {
+  projectDirectory: string
+}): boolean {
+  return !hasExplicitPermissionConfig({ projectDirectory })
+}
+
+function hasExplicitPermissionConfig({
+  projectDirectory,
+}: {
+  projectDirectory: string
+}): boolean {
+  const globalConfigDirectory = getOpencodeGlobalConfigDirectory()
+  const candidatePaths = [
+    path.join(projectDirectory, 'opencode.json'),
+    path.join(projectDirectory, 'opencode.jsonc'),
+    path.join(globalConfigDirectory, 'opencode.json'),
+    path.join(globalConfigDirectory, 'opencode.jsonc'),
+  ]
+
+  return candidatePaths.some((filePath) => {
+    const config = readConfigFileIfExists({ filePath })
+    return config ? Object.hasOwn(config, 'permission') : false
+  })
+}
+
+function getOpencodeGlobalConfigDirectory(): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
+  return path.join(xdgConfigHome, 'opencode')
+}
+
+function readConfigFileIfExists({
+  filePath,
+}: {
+  filePath: string
+}): JsonConfig | null {
+  if (!fs.existsSync(filePath)) {
+    return null
+  }
+
+  const parsed = errore.try({
+    try: () => {
+      return JSONC.parse(fs.readFileSync(filePath, 'utf-8')) as unknown
+    },
+    catch: () => {
+      return null
+    },
+  })
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+
+  return parsed as JsonConfig
 }
 
 /**

--- a/discord/src/parse-permission-rules.test.ts
+++ b/discord/src/parse-permission-rules.test.ts
@@ -1,6 +1,19 @@
 // Tests for parsePermissionRules() from opencode.ts
+import path from 'node:path'
 import { describe, test, expect } from 'vitest'
-import { parsePermissionRules } from './opencode.js'
+import {
+  buildSessionPermissions,
+  parsePermissionRules,
+  shouldIncludeExternalDirectoryAsk,
+} from './opencode.js'
+import { setDataDir } from './config.js'
+import fs from 'node:fs'
+
+function createProjectDirectory({ name }: { name: string }) {
+  const projectDirectory = path.resolve(process.cwd(), 'tmp', name)
+  fs.mkdirSync(projectDirectory, { recursive: true })
+  return projectDirectory
+}
 
 describe('parsePermissionRules', () => {
   test('simple tool:action format', () => {
@@ -123,5 +136,109 @@ describe('parsePermissionRules', () => {
         },
       ]
     `)
+  })
+})
+
+describe('buildSessionPermissions', () => {
+  test('injects catch-all external_directory ask by default', () => {
+    expect(
+      buildSessionPermissions({
+        directory: '/repo',
+      }),
+    ).toContainEqual({
+      permission: 'external_directory',
+      pattern: '*',
+      action: 'ask',
+    })
+  })
+
+  test('omits catch-all external_directory ask when permission is explicitly configured', () => {
+    const projectDirectory = createProjectDirectory({ name: 'permission-project-allow' })
+    fs.writeFileSync(
+      path.join(projectDirectory, 'opencode.json'),
+      JSON.stringify({ permission: 'allow' }, null, 2),
+    )
+
+    expect(
+      buildSessionPermissions({
+        directory: '/repo',
+        includeExternalDirectoryAsk: shouldIncludeExternalDirectoryAsk({
+          projectDirectory,
+        }),
+      }),
+    ).not.toContainEqual({
+      permission: 'external_directory',
+      pattern: '*',
+      action: 'ask',
+    })
+  })
+
+  test('keeps catch-all external_directory ask without explicit config', () => {
+    const projectDirectory = createProjectDirectory({ name: 'permission-project-default' })
+    const xdgConfigHome = path.resolve(process.cwd(), 'tmp', 'permission-project-default-config-home')
+    fs.mkdirSync(xdgConfigHome, { recursive: true })
+
+    const previousXdgConfigHome = process.env['XDG_CONFIG_HOME']
+    process.env['XDG_CONFIG_HOME'] = xdgConfigHome
+    try {
+      expect(shouldIncludeExternalDirectoryAsk({ projectDirectory })).toBe(true)
+    } finally {
+      if (previousXdgConfigHome) {
+        process.env['XDG_CONFIG_HOME'] = previousXdgConfigHome
+      } else {
+        delete process.env['XDG_CONFIG_HOME']
+      }
+    }
+  })
+
+  test('omits catch-all external_directory ask for explicit global config', () => {
+    const dataDir = path.resolve(process.cwd(), 'tmp', 'permission-global-data')
+    const projectDirectory = createProjectDirectory({ name: 'permission-global-project' })
+    const xdgConfigHome = path.join(dataDir, '.config-home')
+    setDataDir(dataDir)
+    fs.mkdirSync(path.join(xdgConfigHome, 'opencode'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(xdgConfigHome, 'opencode', 'opencode.json'),
+      JSON.stringify({ permission: 'allow' }, null, 2),
+    )
+
+    const previousXdgConfigHome = process.env['XDG_CONFIG_HOME']
+    process.env['XDG_CONFIG_HOME'] = xdgConfigHome
+    try {
+      expect(shouldIncludeExternalDirectoryAsk({ projectDirectory })).toBe(false)
+    } finally {
+      if (previousXdgConfigHome) {
+        process.env['XDG_CONFIG_HOME'] = previousXdgConfigHome
+      } else {
+        delete process.env['XDG_CONFIG_HOME']
+      }
+    }
+  })
+
+  test('supports explicit permission in project jsonc config', () => {
+    const projectDirectory = createProjectDirectory({ name: 'permission-project-jsonc' })
+    fs.writeFileSync(
+      path.join(projectDirectory, 'opencode.jsonc'),
+      '{\n  // user override\n  "permission": "allow"\n}\n',
+    )
+
+    expect(shouldIncludeExternalDirectoryAsk({ projectDirectory })).toBe(false)
+  })
+
+  test('allows the active kimaki data dir', () => {
+    const dataDir = path.resolve(process.cwd(), 'tmp', 'kimaki-data-test')
+    setDataDir(dataDir)
+
+    expect(
+      buildSessionPermissions({
+        directory: '/repo',
+      }),
+    ).toContainEqual({
+      permission: 'external_directory',
+      pattern: dataDir,
+      action: 'allow',
+    })
   })
 })

--- a/discord/src/session-handler/thread-session-runtime.ts
+++ b/discord/src/session-handler/thread-session-runtime.ts
@@ -25,6 +25,7 @@ import {
   initializeOpencodeForDirectory,
   buildSessionPermissions,
   parsePermissionRules,
+  shouldIncludeExternalDirectoryAsk,
   subscribeOpencodeServerLifecycle,
   writeInjectionGuardConfig,
 } from '../opencode.js'
@@ -3731,14 +3732,18 @@ export class ThreadSessionRuntime {
     if (!session) {
       // Pass per-session external_directory permissions so this session can
       // access its own project directory (and worktree origin if applicable)
-      // without prompts. These override the server-level 'ask' default via
-      // opencode's findLast() rule evaluation.
+      // without prompts. Keep Kimaki's secure-by-default catch-all ask rule
+      // unless the project or global OpenCode config explicitly defines
+      // `permission`.
       // CLI --permission rules are appended after base rules so they win
       // via opencode's findLast() evaluation.
       const sessionPermissions = [
         ...buildSessionPermissions({
           directory: this.sdkDirectory,
           originalRepoDirectory,
+          includeExternalDirectoryAsk: shouldIncludeExternalDirectoryAsk({
+            projectDirectory: this.sdkDirectory,
+          }),
         }),
         ...parsePermissionRules(permissions ?? []),
       ]


### PR DESCRIPTION
Fixes a remaining permissions issue related to #90.

Kimaki was still adding its own catch-all `external_directory:* -> ask` rule even when OpenCode config already defined a top-level `permission`, so global or project permission config could still end up not being respected.

I tried to keep this as close as possible to the current behavior while fixing the bug:
- keep the current defaults when no explicit OpenCode permission is configured
- stop adding the extra catch-all ask rule once project or global OpenCode config explicitly defines `permission`

> [!NOTE]
> This dynamic injection of configs still feels a bit counterintuitive from a user perspective, and longer term it may be nicer to rely more on OpenCode’s default behavior where possible.