### PR TITLE
fix orphan opencode servers when parent kimaki is SIGKILL'd

### DIFF
--- a/cli/src/hrana-server.ts
+++ b/cli/src/hrana-server.ts
@@ -13,7 +13,6 @@ import fs from 'node:fs'
 import http from 'node:http'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { execFileSync } from 'node:child_process'
 import Database from 'libsql'
 import * as errore from 'errore'
 import {
@@ -23,9 +22,10 @@ import {
 } from 'libsqlproxy'
 import { createLogger, LogPrefix } from './logger.js'
 import { ServerStartError, FetchError } from './errors.js'
+import { execAsync } from './exec-async.js'
 import { getLockPort } from './config.js'
 import { store } from './store.js'
-import { getOpencodeServerPid, resolveOpencodeCommand } from './opencode.js'
+import { getOpencodeServerPid } from './opencode.js'
 
 const hranaLogger = createLogger(LogPrefix.DB)
 
@@ -132,7 +132,7 @@ export async function startHranaServer({
   process.env.KIMAKI_DB_AUTH_TOKEN = serviceAuthToken
 
   fs.mkdirSync(path.dirname(dbPath), { recursive: true })
-  sweepOrphanOpencodeServers()
+  await sweepOrphanOpencodeServers()
   await evictExistingInstance({ port })
 
   hranaLogger.log(
@@ -207,12 +207,13 @@ export async function startHranaServer({
   const started = await new Promise<ServerStartError | true>((resolve) => {
     const srv = http.createServer(handler)
 
-    srv.on('error', (err: NodeJS.ErrnoException) => {
+    srv.on('error', (err) => {
+      const errorCode = Object.getOwnPropertyDescriptor(err, 'code')?.value
       resolve(
         new ServerStartError({
           port,
           reason:
-            err.code === 'EADDRINUSE'
+            errorCode === 'EADDRINUSE'
               ? `Port ${port} still in use after eviction`
               : err.message,
         }),
@@ -310,18 +311,14 @@ export async function evictExistingInstance({ port }: { port: number }) {
   )
   if (probe instanceof Error) return
 
-  const body = await (
-    probe.json() as Promise<{ pid?: number; opencodePid?: number | null }>
-  ).catch((e) => new FetchError({ url, cause: e }))
-  if (body instanceof Error) return
+  const bodyText = await probe.text().catch((e) => new FetchError({ url, cause: e }))
+  if (bodyText instanceof Error) return
 
+  const body = parseHealthPayload({ body: bodyText })
   const targetPid = body.pid
   if (!targetPid || targetPid === process.pid) return
 
-  const opencodePid =
-    typeof body.opencodePid === 'number' && body.opencodePid > 0
-      ? body.opencodePid
-      : null
+  const opencodePid = body.opencodePid
 
   hranaLogger.log(
     `Evicting existing kimaki process (PID: ${targetPid}, opencode PID: ${
@@ -392,6 +389,30 @@ export async function evictExistingInstance({ port }: { port: number }) {
 
 type PsRow = { pid: number; ppid: number; command: string }
 
+type HealthPayload = {
+  pid: number | null
+  opencodePid: number | null
+}
+
+function parseHealthPayload({ body }: { body: string }): HealthPayload {
+  const parsed = errore.try({
+    try: () => JSON.parse(body),
+    catch: () => null,
+  })
+  if (!parsed || parsed instanceof Error || Array.isArray(parsed)) {
+    return { pid: null, opencodePid: null }
+  }
+
+  const record = parsed as { pid?: unknown; opencodePid?: unknown }
+  return {
+    pid: typeof record.pid === 'number' ? record.pid : null,
+    opencodePid:
+      typeof record.opencodePid === 'number' && record.opencodePid > 0
+        ? record.opencodePid
+        : null,
+  }
+}
+
 /**
  * Parse `ps -axo pid=,ppid=,command=` output into rows.
  * Format per line: leading whitespace, pid, space(s), ppid, space(s), command.
@@ -429,10 +450,6 @@ export function parsePsOutput(output: string): PsRow[] {
  * and then dies, the reparented orphan shows a different absolute path
  * ending in `.opencode`. Matching on the basename catches both shapes.
  *
- * `opencodeBinary` is accepted for symmetry and future use but intentionally
- * not required for the match — any path whose basename is `opencode` /
- * `.opencode` and that is running `serve` qualifies as one of ours.
- *
  * Self-exclusion is done by PID (never the current kimaki); at
  * startHranaServer() boot time there is no live opencode child yet.
  */
@@ -441,7 +458,6 @@ export function selectOrphanOpencodePids({
   selfPid,
 }: {
   rows: PsRow[]
-  opencodeBinary?: string
   selfPid: number
 }): number[] {
   const orphans: number[] = []
@@ -478,38 +494,20 @@ export function selectOrphanOpencodePids({
  * Safe to call on boot. Skips gracefully on non-POSIX platforms where `ps`
  * isn't available in this form (notably Windows).
  */
-export function sweepOrphanOpencodeServers(): void {
+export async function sweepOrphanOpencodeServers(): Promise<void> {
   if (process.platform === 'win32') return
 
-  const psResult = errore.try({
-    try: () =>
-      execFileSync('ps', ['-axo', 'pid=,ppid=,command='], {
-        encoding: 'utf8',
-        timeout: 3000,
-      }),
-    catch: (e) => new Error('ps enumeration failed', { cause: e }),
-  })
+  const psResult = await execAsync('ps -axo pid=,ppid=,command=', {
+    timeout: 3000,
+  }).catch((e) => new Error('ps enumeration failed', { cause: e }))
   if (psResult instanceof Error) {
     hranaLogger.log(`Orphan sweep skipped: ${psResult.message}`)
     return
   }
 
-  // resolveOpencodeCommand() isn't required for matching (we match on
-  // basename) but calling it validates the opencode install is present
-  // before we start killing processes that look like ours.
-  const binary = errore.try({
-    try: () => resolveOpencodeCommand(),
-    catch: () => new Error('opencode binary not resolvable'),
-  })
-  if (binary instanceof Error) {
-    hranaLogger.log(`Orphan sweep skipped: ${binary.message}`)
-    return
-  }
-
-  const rows = parsePsOutput(psResult)
+  const rows = parsePsOutput(psResult.stdout)
   const orphans = selectOrphanOpencodePids({
     rows,
-    opencodeBinary: binary,
     selfPid: process.pid,
   })
   if (orphans.length === 0) return

--- a/cli/src/hrana-server.ts
+++ b/cli/src/hrana-server.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs'
 import http from 'node:http'
 import path from 'node:path'
 import crypto from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 import Database from 'libsql'
 import * as errore from 'errore'
 import {
@@ -24,6 +25,7 @@ import { createLogger, LogPrefix } from './logger.js'
 import { ServerStartError, FetchError } from './errors.js'
 import { getLockPort } from './config.js'
 import { store } from './store.js'
+import { getOpencodeServerPid, resolveOpencodeCommand } from './opencode.js'
 
 const hranaLogger = createLogger(LogPrefix.DB)
 
@@ -130,6 +132,7 @@ export async function startHranaServer({
   process.env.KIMAKI_DB_AUTH_TOKEN = serviceAuthToken
 
   fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+  sweepOrphanOpencodeServers()
   await evictExistingInstance({ port })
 
   hranaLogger.log(
@@ -169,10 +172,22 @@ export async function startHranaServer({
       res.end(JSON.stringify({ ready: true }))
       return
     }
-    // Health check — no auth required
+    // Health check — no auth required.
+    //
+    // `opencodePid` is included so a second kimaki instance doing eviction
+    // can SIGTERM the opencode child alongside the parent. Without this, if
+    // the parent gets SIGKILL'd (our 1s grace timeout below, V8 heap OOM in
+    // bin.ts, Activity Monitor force-quit, etc.) the opencode child is
+    // reparented to PID 1 and leaks ~500 MB RSS indefinitely.
     if (pathname === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' })
-      res.end(JSON.stringify({ status: 'ok', pid: process.pid }))
+      res.end(
+        JSON.stringify({
+          status: 'ok',
+          pid: process.pid,
+          opencodePid: getOpencodeServerPid(),
+        }),
+      )
       return
     }
     // Hrana routes: /v2, /v2/pipeline — require auth
@@ -244,10 +259,48 @@ export async function stopHranaServer() {
 
 // ── Single-instance enforcement ──────────────────────────────────────
 
+function signalPid({
+  pid,
+  signal,
+  label,
+}: {
+  pid: number
+  signal: NodeJS.Signals
+  label: string
+}): void {
+  const killResult = errore.try({
+    try: () => {
+      process.kill(pid, signal)
+    },
+    catch: (e) =>
+      new Error(`Failed to send ${signal} to ${label}`, { cause: e }),
+  })
+  if (killResult instanceof Error) {
+    hranaLogger.log(`Failed to ${signal} ${label} (PID ${pid}): ${killResult.message}`)
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  const result = errore.try({
+    try: () => {
+      // Signal 0 = existence check, no signal delivered.
+      process.kill(pid, 0)
+      return true
+    },
+    catch: () => new Error('not alive'),
+  })
+  return result === true
+}
+
 /**
  * Evict a previous kimaki instance on the lock port.
  * Fetches /health to get the running process PID, then kills it directly.
  * No lsof/netstat/spawnSync needed — the PID comes from the health response.
+ *
+ * Also kills the opencode child (from body.opencodePid) on the same deadline.
+ * The old kimaki's SIGTERM handler normally does this, but SIGKILL skips
+ * cleanup handlers and would leak a ~500 MB opencode process. Killing the
+ * child externally via the advertised PID survives that case.
  */
 export async function evictExistingInstance({ port }: { port: number }) {
   const url = `http://127.0.0.1:${port}/health`
@@ -257,58 +310,214 @@ export async function evictExistingInstance({ port }: { port: number }) {
   )
   if (probe instanceof Error) return
 
-  const body = await (probe.json() as Promise<{ pid?: number }>).catch(
-    (e) => new FetchError({ url, cause: e }),
-  )
+  const body = await (
+    probe.json() as Promise<{ pid?: number; opencodePid?: number | null }>
+  ).catch((e) => new FetchError({ url, cause: e }))
   if (body instanceof Error) return
 
   const targetPid = body.pid
   if (!targetPid || targetPid === process.pid) return
 
+  const opencodePid =
+    typeof body.opencodePid === 'number' && body.opencodePid > 0
+      ? body.opencodePid
+      : null
+
   hranaLogger.log(
-    `Evicting existing kimaki process (PID: ${targetPid}) on port ${port}`,
+    `Evicting existing kimaki process (PID: ${targetPid}, opencode PID: ${
+      opencodePid ?? 'none'
+    }) on port ${port}`,
   )
-  const killResult = errore.try({
-    try: () => {
-      process.kill(targetPid, 'SIGTERM')
-    },
-    catch: (e) =>
-      new Error('Failed to send SIGTERM to existing kimaki process', {
-        cause: e,
-      }),
-  })
-  if (killResult instanceof Error) {
-    hranaLogger.log(`Failed to kill PID ${targetPid}: ${killResult.message}`)
-    return
-  }
+  signalPid({ pid: targetPid, signal: 'SIGTERM', label: 'existing kimaki process' })
 
   await new Promise((resolve) => {
     setTimeout(resolve, 1000)
   })
 
-  // Verify it's gone — if still alive, escalate to SIGKILL
+  // Verify kimaki is gone — if still alive, escalate to SIGKILL.
   const secondProbe = await fetch(url, {
     signal: AbortSignal.timeout(500),
   }).catch((e) => new FetchError({ url, cause: e }))
-  if (secondProbe instanceof Error) return
+  const kimakiStillAlive = !(secondProbe instanceof Error)
 
-  hranaLogger.log(`PID ${targetPid} still alive after SIGTERM, sending SIGKILL`)
-  const forceKillResult = errore.try({
-    try: () => {
-      process.kill(targetPid, 'SIGKILL')
-    },
-    catch: (e) =>
-      new Error('Failed to send SIGKILL to existing kimaki process', {
-        cause: e,
-      }),
-  })
-  if (forceKillResult instanceof Error) {
+  if (kimakiStillAlive) {
     hranaLogger.log(
-      `Failed to force-kill PID ${targetPid}: ${forceKillResult.message}`,
+      `PID ${targetPid} still alive after SIGTERM, sending SIGKILL`,
     )
+    signalPid({
+      pid: targetPid,
+      signal: 'SIGKILL',
+      label: 'existing kimaki process',
+    })
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+
+  // Clean up the opencode child regardless of how kimaki exited. If kimaki
+  // shut down gracefully its own handler already SIGTERM'd this PID, so
+  // isPidAlive will be false and we skip. If kimaki was SIGKILL'd (above,
+  // or by V8 OOM, Activity Monitor, etc.) the child is orphaned on PID 1
+  // with a closed socket and we kill it here.
+  if (opencodePid && opencodePid !== process.pid && isPidAlive(opencodePid)) {
+    hranaLogger.log(
+      `Cleaning up opencode child (PID: ${opencodePid}) orphaned by evicted kimaki`,
+    )
+    signalPid({
+      pid: opencodePid,
+      signal: 'SIGTERM',
+      label: 'orphaned opencode child',
+    })
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+    if (isPidAlive(opencodePid)) {
+      signalPid({
+        pid: opencodePid,
+        signal: 'SIGKILL',
+        label: 'orphaned opencode child',
+      })
+    }
+  }
+}
+
+// ── Orphan sweep ─────────────────────────────────────────────────────
+//
+// Catches opencode servers abandoned by a prior kimaki that died before
+// this instance started (so /health is unreachable and evictExistingInstance
+// has nothing to read). Runs at startHranaServer() boot time.
+//
+// Exported for testing. Pure parsing is split out so we can unit-test the
+// PID selection logic without touching real processes.
+
+type PsRow = { pid: number; ppid: number; command: string }
+
+/**
+ * Parse `ps -axo pid=,ppid=,command=` output into rows.
+ * Format per line: leading whitespace, pid, space(s), ppid, space(s), command.
+ * `command` can contain arbitrary spaces/args and is kept verbatim.
+ */
+export function parsePsOutput(output: string): PsRow[] {
+  const rows: PsRow[] = []
+  for (const rawLine of output.split('\n')) {
+    const line = rawLine.trimStart()
+    if (!line) continue
+    const match = line.match(/^(\d+)\s+(\d+)\s+(.*)$/)
+    if (!match) continue
+    const pid = Number.parseInt(match[1]!, 10)
+    const ppid = Number.parseInt(match[2]!, 10)
+    const command = match[3]!
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue
+    rows.push({ pid, ppid, command })
+  }
+  return rows
+}
+
+/**
+ * Pick orphan opencode server PIDs from `ps` output.
+ *
+ * An orphan is a process whose:
+ *  - parent is PID 1 (reparented after kimaki died without cleanup), and
+ *  - first token of the command is an opencode binary (basename `opencode`
+ *    or `.opencode`), and
+ *  - second token is `serve` (we never want to kill `opencode tui`, `run`,
+ *    or unrelated invocations).
+ *
+ * The binary path shape varies by install: kimaki's resolveOpencodeCommand()
+ * often returns `~/.nvm/.../bin/opencode` (a shell wrapper), but when that
+ * wrapper execs its sibling `.../lib/node_modules/opencode-ai/bin/.opencode`
+ * and then dies, the reparented orphan shows a different absolute path
+ * ending in `.opencode`. Matching on the basename catches both shapes.
+ *
+ * `opencodeBinary` is accepted for symmetry and future use but intentionally
+ * not required for the match — any path whose basename is `opencode` /
+ * `.opencode` and that is running `serve` qualifies as one of ours.
+ *
+ * Self-exclusion is done by PID (never the current kimaki); at
+ * startHranaServer() boot time there is no live opencode child yet.
+ */
+export function selectOrphanOpencodePids({
+  rows,
+  selfPid,
+}: {
+  rows: PsRow[]
+  opencodeBinary?: string
+  selfPid: number
+}): number[] {
+  const orphans: number[] = []
+  for (const row of rows) {
+    if (row.pid === selfPid) continue
+    if (row.ppid !== 1) continue
+
+    // Split on whitespace but preserve argv[0] intact even if it contains
+    // spaces-in-paths (unlikely but possible). First token = binary path.
+    const firstSpace = row.command.indexOf(' ')
+    if (firstSpace < 0) continue
+    const argv0 = row.command.slice(0, firstSpace)
+    const rest = row.command.slice(firstSpace + 1)
+
+    // Basename of argv[0].
+    const lastSlash = argv0.lastIndexOf('/')
+    const basename = lastSlash >= 0 ? argv0.slice(lastSlash + 1) : argv0
+    if (basename !== 'opencode' && basename !== '.opencode') continue
+
+    // Require `serve` as the subcommand (first positional arg).
+    const restTrimmed = rest.trimStart()
+    if (!restTrimmed.startsWith('serve')) continue
+    const afterServe = restTrimmed.slice('serve'.length)
+    if (afterServe.length > 0 && !/^\s/.test(afterServe)) continue
+
+    orphans.push(row.pid)
+  }
+  return orphans
+}
+
+/**
+ * Scan for orphan `opencode serve` processes and SIGTERM them.
+ *
+ * Safe to call on boot. Skips gracefully on non-POSIX platforms where `ps`
+ * isn't available in this form (notably Windows).
+ */
+export function sweepOrphanOpencodeServers(): void {
+  if (process.platform === 'win32') return
+
+  const psResult = errore.try({
+    try: () =>
+      execFileSync('ps', ['-axo', 'pid=,ppid=,command='], {
+        encoding: 'utf8',
+        timeout: 3000,
+      }),
+    catch: (e) => new Error('ps enumeration failed', { cause: e }),
+  })
+  if (psResult instanceof Error) {
+    hranaLogger.log(`Orphan sweep skipped: ${psResult.message}`)
     return
   }
-  await new Promise((resolve) => {
-    setTimeout(resolve, 1000)
+
+  // resolveOpencodeCommand() isn't required for matching (we match on
+  // basename) but calling it validates the opencode install is present
+  // before we start killing processes that look like ours.
+  const binary = errore.try({
+    try: () => resolveOpencodeCommand(),
+    catch: () => new Error('opencode binary not resolvable'),
   })
+  if (binary instanceof Error) {
+    hranaLogger.log(`Orphan sweep skipped: ${binary.message}`)
+    return
+  }
+
+  const rows = parsePsOutput(psResult)
+  const orphans = selectOrphanOpencodePids({
+    rows,
+    opencodeBinary: binary,
+    selfPid: process.pid,
+  })
+  if (orphans.length === 0) return
+
+  hranaLogger.log(
+    `Orphan sweep: found ${orphans.length} abandoned opencode serve process(es), sending SIGTERM`,
+  )
+  for (const pid of orphans) {
+    signalPid({ pid, signal: 'SIGTERM', label: `orphan opencode server` })
+  }
 }

--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -1178,6 +1178,18 @@ export function getOpencodeServerPort(_directory?: string): number | null {
   return singleServer?.port ?? null
 }
 
+/**
+ * PID of the currently running shared opencode server child process, if any.
+ *
+ * Exposed so hrana-server's /health endpoint can advertise it alongside the
+ * kimaki PID. A second kimaki doing eviction then knows how to clean up the
+ * opencode child even when the parent kimaki is SIGKILL'd (which skips
+ * in-process cleanup handlers registered in ensureProcessCleanupHandlersRegistered).
+ */
+export function getOpencodeServerPid(): number | null {
+  return singleServer?.process.pid ?? null
+}
+
 export function getOpencodeClient(directory: string): OpencodeClient | null {
   if (!singleServer) {
     return null

--- a/cli/src/orphan-opencode-sweep.test.ts
+++ b/cli/src/orphan-opencode-sweep.test.ts
@@ -26,23 +26,10 @@ describe('parsePsOutput', () => {
       { pid: 42000, ppid: 42000, command: 'grep opencode' },
     ])
   })
-
-  test('skips blank lines and unparseable rows', () => {
-    const output = ['', '   ', 'no numbers here', ' 777     1 /opt/thing run'].join('\n')
-
-    const rows = parsePsOutput(output)
-
-    expect(rows).toEqual([{ pid: 777, ppid: 1, command: '/opt/thing run' }])
-  })
-
-  test('preserves multi-space commands verbatim', () => {
-    const rows = parsePsOutput(' 1234     1 /a/b/opencode   serve   --port 99\n')
-    expect(rows[0]!.command).toBe('/a/b/opencode   serve   --port 99')
-  })
 })
 
 describe('selectOrphanOpencodePids', () => {
-  test('picks opencode serve with ppid=1 when argv[0] basename is `opencode`', () => {
+  test('picks orphaned opencode serve processes by basename', () => {
     const rows = [
       {
         pid: 100,
@@ -73,14 +60,6 @@ describe('selectOrphanOpencodePids', () => {
     expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([90368])
   })
 
-  test('matches the bare `opencode` command name (no absolute path)', () => {
-    const rows = [
-      { pid: 200, ppid: 1, command: 'opencode serve --port 3333' },
-      { pid: 201, ppid: 1, command: '.opencode serve --port 4444' },
-    ]
-    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([200, 201])
-  })
-
   test('skips processes whose parent is not PID 1 (still healthy under a kimaki)', () => {
     const rows = [{ pid: 300, ppid: 12345, command: '/bin/opencode serve --port 5555' }]
     expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
@@ -106,19 +85,6 @@ describe('selectOrphanOpencodePids', () => {
       // line if it were orphaned.
       { pid: 503, ppid: 1, command: 'node /path/to/opencode serve --port 9999' },
     ]
-    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
-  })
-
-  test('excludes the current kimaki PID even if it matches the shape', () => {
-    const rows = [
-      { pid: 99, ppid: 1, command: '/bin/opencode serve --port 6666' },
-      { pid: 600, ppid: 1, command: '/bin/opencode serve --port 7777' },
-    ]
-    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([600])
-  })
-
-  test('skips commands with no whitespace (no subcommand at all)', () => {
-    const rows = [{ pid: 700, ppid: 1, command: '/bin/opencode' }]
     expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
   })
 })

--- a/cli/src/orphan-opencode-sweep.test.ts
+++ b/cli/src/orphan-opencode-sweep.test.ts
@@ -1,0 +1,124 @@
+// Unit tests for the orphan opencode sweep PID selection.
+//
+// Tests the pure parsing/selection helpers exported from hrana-server.ts so
+// we can verify the logic without spawning real opencode servers or touching
+// the OS process table.
+
+import { describe, test, expect } from 'vitest'
+import { parsePsOutput, selectOrphanOpencodePids } from './hrana-server.js'
+
+describe('parsePsOutput', () => {
+  test('parses typical ps -axo pid=,ppid=,command= output', () => {
+    const output = [
+      '  1234     1 /abs/path/opencode serve --port 12345 --print-logs',
+      '  5678  1234 /abs/path/node cli.js',
+      '    99     1 /usr/sbin/somed',
+      '',
+      ' 42000 42000 grep opencode',
+    ].join('\n')
+
+    const rows = parsePsOutput(output)
+
+    expect(rows).toEqual([
+      { pid: 1234, ppid: 1, command: '/abs/path/opencode serve --port 12345 --print-logs' },
+      { pid: 5678, ppid: 1234, command: '/abs/path/node cli.js' },
+      { pid: 99, ppid: 1, command: '/usr/sbin/somed' },
+      { pid: 42000, ppid: 42000, command: 'grep opencode' },
+    ])
+  })
+
+  test('skips blank lines and unparseable rows', () => {
+    const output = ['', '   ', 'no numbers here', ' 777     1 /opt/thing run'].join('\n')
+
+    const rows = parsePsOutput(output)
+
+    expect(rows).toEqual([{ pid: 777, ppid: 1, command: '/opt/thing run' }])
+  })
+
+  test('preserves multi-space commands verbatim', () => {
+    const rows = parsePsOutput(' 1234     1 /a/b/opencode   serve   --port 99\n')
+    expect(rows[0]!.command).toBe('/a/b/opencode   serve   --port 99')
+  })
+})
+
+describe('selectOrphanOpencodePids', () => {
+  test('picks opencode serve with ppid=1 when argv[0] basename is `opencode`', () => {
+    const rows = [
+      {
+        pid: 100,
+        ppid: 1,
+        command: '/Users/t/.nvm/v24/bin/opencode serve --port 1111 --print-logs',
+      },
+      {
+        pid: 101,
+        ppid: 1,
+        command: '/Users/t/.nvm/v24/bin/opencode serve --port 2222 --print-logs',
+      },
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([100, 101])
+  })
+
+  test('matches the real-world orphan command shape (.opencode basename with long path)', () => {
+    // This is the command line we observed on orphaned children in the wild:
+    // a kimaki-spawned `opencode` wrapper dies, and the reparented orphan is
+    // the actual `.opencode` binary under node_modules. Regression guard.
+    const rows = [
+      {
+        pid: 90368,
+        ppid: 1,
+        command:
+          '/Users/chubes/.nvm/versions/node/v24.13.1/lib/node_modules/opencode-ai/bin/.opencode serve --port 53817 --print-logs --log-level WARN',
+      },
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([90368])
+  })
+
+  test('matches the bare `opencode` command name (no absolute path)', () => {
+    const rows = [
+      { pid: 200, ppid: 1, command: 'opencode serve --port 3333' },
+      { pid: 201, ppid: 1, command: '.opencode serve --port 4444' },
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([200, 201])
+  })
+
+  test('skips processes whose parent is not PID 1 (still healthy under a kimaki)', () => {
+    const rows = [{ pid: 300, ppid: 12345, command: '/bin/opencode serve --port 5555' }]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
+  })
+
+  test('skips unrelated opencode subcommands like tui or run', () => {
+    const rows = [
+      { pid: 400, ppid: 1, command: '/bin/opencode tui' },
+      { pid: 401, ppid: 1, command: '/bin/opencode run some-task' },
+      { pid: 402, ppid: 1, command: '/bin/opencode serverless --option' }, // starts with "serve" but isn't "serve"
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
+  })
+
+  test('skips non-opencode processes reparented to PID 1', () => {
+    const rows = [
+      { pid: 500, ppid: 1, command: '/usr/sbin/cupsd -l' },
+      { pid: 501, ppid: 1, command: '/bin/serve-something --flag' },
+      { pid: 502, ppid: 1, command: 'node serve.js' },
+      // Especially: a `node` process running the opencode wrapper script —
+      // argv[0] is `node`, not `opencode`, so we do NOT touch it. The real
+      // .opencode child underneath would be matched separately on its own
+      // line if it were orphaned.
+      { pid: 503, ppid: 1, command: 'node /path/to/opencode serve --port 9999' },
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
+  })
+
+  test('excludes the current kimaki PID even if it matches the shape', () => {
+    const rows = [
+      { pid: 99, ppid: 1, command: '/bin/opencode serve --port 6666' },
+      { pid: 600, ppid: 1, command: '/bin/opencode serve --port 7777' },
+    ]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([600])
+  })
+
+  test('skips commands with no whitespace (no subcommand at all)', () => {
+    const rows = [{ pid: 700, ppid: 1, command: '/bin/opencode' }]
+    expect(selectOrphanOpencodePids({ rows, selfPid: 99 })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #110 — orphaned `opencode serve` processes leak ~500 MB RSS each every time kimaki is SIGKILL'd.

`SIGKILL` is uncatchable, so the in-process cleanup handlers in `opencode.ts:360` don't run and the child is reparented to PID 1 with a closed listening socket. Over ~24 hours of active use on one laptop this accumulated **44 orphans / ~19 GB leaked RSS**, matching ~1:1 with `[kimaki] Process exited with signal SIGKILL, restarting in 2s...` lines in `kimaki.error.log`. Two independent triggers feed it: the 1-second grace timeout in `evictExistingInstance` (`hrana-server.ts:286`) and V8 heap-OOM snapshot exits wired up in `bin.ts:12-17`.

## Changes

Two complementary fixes, tiny surface area:

### 1. Advertise the opencode PID in `/health`, clean it up on eviction

- `opencode.ts`: new `getOpencodeServerPid()` returns the current shared server's PID.
- `hrana-server.ts`: `/health` now returns `{ status, pid, opencodePid }`.
- `evictExistingInstance` kills `opencodePid` on the same deadline as the parent. If the parent shut down gracefully its own handler already did this (`isPidAlive` returns false and we skip); if SIGKILL'd, we clean up externally.

### 2. Boot-time orphan sweep

- `sweepOrphanOpencodeServers()` enumerates `ps -axo pid=,ppid=,command=`, picks rows with `ppid=1` whose argv[0] basename is `opencode` / `.opencode` and whose first arg is `serve`, and SIGTERMs them.
- Called at the top of `startHranaServer`, before the eviction probe. Catches orphans from kimaki instances that died before this one started — the common case where `/health` is unreachable and eviction has nothing to read.

The basename match handles both wrapper shapes observed in the wild:

```
/Users/chubes/.nvm/versions/node/v24.13.1/bin/opencode serve ...                                         (wrapper)
/Users/chubes/.nvm/versions/node/v24.13.1/lib/node_modules/opencode-ai/bin/.opencode serve ...           (orphan after wrapper exits)
```

Conservative: requires `ppid === 1` AND `basename ∈ {opencode, .opencode}` AND subcommand is exactly `serve` (not `tui`/`run`/`serverless…`). Self-excludes by PID.

## Tests

New `cli/src/orphan-opencode-sweep.test.ts` covers the pure parsing + selection logic (11 tests, all passing):

- ps output parsing (typical, blank lines, multi-space commands)
- Matches both wrapper and real `.opencode` path shapes
- Includes a regression test using the exact command string observed on the reporter's laptop
- Rejects: non-orphan (ppid ≠ 1), wrong subcommand, non-opencode processes, `node /path/to/opencode serve` (argv[0] is `node`), self-PID, commands with no whitespace

```
✓ src/orphan-opencode-sweep.test.ts (11 tests) 2ms
```

Type-checked with `pnpm tsc`: zero new errors in touched files. The existing 47 errors on `main` are unrelated (`generated/client.js` not present, pre-existing implicit-any's in `cli.ts` / `database.ts` / etc).

## Manual verification

Ran the sweep logic standalone against my live process table — parsed 772 rows, matched zero orphans (system was clean after I killed them manually before starting this PR). Simulated one orphan row matching the real command shape and confirmed it was picked up.

## Notes for reviewer

- Introduces a new import edge `hrana-server.ts → opencode.ts` on top of the existing `opencode.ts → hrana-server.ts`. Both imports are used only inside function bodies, so ESM's cycle handling is fine.
- Adds one dependency: `execFileSync` from `node:child_process` (3s timeout, POSIX-only, no-ops on Windows).
- No changes to the public shape of `/health` beyond adding an optional field — old eviction code (older kimaki evicting a newer one with this change) simply ignores `opencodePid`.