### PR TITLE
fix(opencode): filter false-positive duplicate skill name warnings from stderr

### DIFF
--- a/.changeset/filter-opencode-duplicate-skill-warnings.md
+++ b/.changeset/filter-opencode-duplicate-skill-warnings.md
@@ -2,13 +2,7 @@
 'kimaki': patch
 ---
 
-Filter false-positive "duplicate skill name" warnings from OpenCode stderr.
-
-When OpenCode discovers skills through multiple scan paths, it may log a
-"duplicate skill name" warning where `existing` and `duplicate` point to the
-same file. These warnings were logged at `error` level in Kimaki, creating
-noise in kimaki.log. The stderr handler now detects and suppresses these
-false-positive warnings; genuinely different files with the same name are
-still reported as warnings.
+Downgrade OpenCode "duplicate skill name" stderr warnings from error to warn
+level to reduce noise in kimaki.log.
 
 Fixes #121

--- a/.changeset/filter-opencode-duplicate-skill-warnings.md
+++ b/.changeset/filter-opencode-duplicate-skill-warnings.md
@@ -1,0 +1,14 @@
+---
+'kimaki': patch
+---
+
+Filter false-positive "duplicate skill name" warnings from OpenCode stderr.
+
+When OpenCode discovers skills through multiple scan paths, it may log a
+"duplicate skill name" warning where `existing` and `duplicate` point to the
+same file. These warnings were logged at `error` level in Kimaki, creating
+noise in kimaki.log. The stderr handler now detects and suppresses these
+false-positive warnings; genuinely different files with the same name are
+still reported as warnings.
+
+Fixes #121

--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -136,6 +136,80 @@ function sanitizeOutputLine(line: string): string {
   return stripAnsiCodes(line).trim()
 }
 
+// ── OpenCode stderr warning filter ───────────────────────────────
+// OpenCode may emit multi-line "duplicate skill name" warnings to stderr
+// when the same skill file is discovered through multiple scan paths.
+// These are false positives when existing === duplicate (the same file).
+// Track the 3-line pattern and suppress it when paths match.
+const DUPLICATE_SKILL_PENDING_NONE = 0
+const DUPLICATE_SKILL_PENDING_NAME = 1
+const DUPLICATE_SKILL_PENDING_EXISTING = 2
+let duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+let duplicateSkillPendingName = ''
+let duplicateSkillExistingPath = ''
+
+function duplicateSkillFilter({
+  line,
+  logger,
+}: {
+  line: string
+  logger: typeof opencodeLogger
+}): boolean {
+  // Returns true when line was consumed by the filter (handled or suppressed)
+
+  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_NONE) {
+    const nameMatch = line.match(/duplicate skill name "([^"]+)"/)
+    if (nameMatch) {
+      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NAME
+      duplicateSkillPendingName = nameMatch[1]!
+      duplicateSkillExistingPath = ''
+      return true // consumed
+    }
+    return false // not a duplicate skill warning
+  }
+
+  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_NAME) {
+    const existingMatch = line.match(/existing:\s*(.+)/)
+    if (existingMatch) {
+      duplicateSkillExistingPath = existingMatch[1]!.trim()
+      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_EXISTING
+      return true // consumed
+    }
+    // Unexpected line after name — flush the pending name line
+    logger.warn(`duplicate skill name "${duplicateSkillPendingName}"`)
+    duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+    return false // let this line be handled normally
+  }
+
+  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_EXISTING) {
+    const duplicateMatch = line.match(/duplicate:\s*(.+)/)
+    if (duplicateMatch) {
+      const duplicatePath = duplicateMatch[1]!.trim()
+      if (duplicateSkillExistingPath === duplicatePath) {
+        // Same file — false positive, suppress entirely
+        duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+        return true // consumed + suppressed
+      }
+      // Different files — genuine duplicate, log as warning
+      logger.warn(
+        `duplicate skill name "${duplicateSkillPendingName}" (existing: ${duplicateSkillExistingPath}, duplicate: ${duplicatePath})`,
+      )
+      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+      return true // consumed (re-logged as warn)
+    }
+    // Unexpected line — flush what we have
+    logger.warn(`duplicate skill name "${duplicateSkillPendingName}" (existing: ${duplicateSkillExistingPath})`)
+    duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+    return false
+  }
+
+  // Safety: unknown state, reset
+  duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
+  return false
+}
+
+
+
 function sanitizeForCodeFence(line: string): string {
   return line.replaceAll('```', '`\u200b``')
 }
@@ -760,6 +834,12 @@ async function startSingleServer({
       if (!serverReady) {
         logBuffer.push(`[stderr] ${line}`)
         pushStartupStderrTail({ stderrTail: startupStderrTail, line })
+        return
+      }
+      // Filter false-positive "duplicate skill name" warnings where
+      // existing === duplicate (same file found via multiple scan paths).
+      // These are harmless and should not clutter error-level logs.
+      if (duplicateSkillFilter({ line, logger: opencodeLogger })) {
         return
       }
       opencodeLogger.error(line)

--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -136,76 +136,11 @@ function sanitizeOutputLine(line: string): string {
   return stripAnsiCodes(line).trim()
 }
 
-// ── OpenCode stderr warning filter ───────────────────────────────
-// OpenCode may emit multi-line "duplicate skill name" warnings to stderr
-// when the same skill file is discovered through multiple scan paths.
-// These are false positives when existing === duplicate (the same file).
-// Track the 3-line pattern and suppress it when paths match.
-const DUPLICATE_SKILL_PENDING_NONE = 0
-const DUPLICATE_SKILL_PENDING_NAME = 1
-const DUPLICATE_SKILL_PENDING_EXISTING = 2
-let duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-let duplicateSkillPendingName = ''
-let duplicateSkillExistingPath = ''
-
-function duplicateSkillFilter({
-  line,
-  logger,
-}: {
-  line: string
-  logger: typeof opencodeLogger
-}): boolean {
-  // Returns true when line was consumed by the filter (handled or suppressed)
-
-  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_NONE) {
-    const nameMatch = line.match(/duplicate skill name "([^"]+)"/)
-    if (nameMatch) {
-      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NAME
-      duplicateSkillPendingName = nameMatch[1]!
-      duplicateSkillExistingPath = ''
-      return true // consumed
-    }
-    return false // not a duplicate skill warning
-  }
-
-  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_NAME) {
-    const existingMatch = line.match(/existing:\s*(.+)/)
-    if (existingMatch) {
-      duplicateSkillExistingPath = existingMatch[1]!.trim()
-      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_EXISTING
-      return true // consumed
-    }
-    // Unexpected line after name — flush the pending name line
-    logger.warn(`duplicate skill name "${duplicateSkillPendingName}"`)
-    duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-    return false // let this line be handled normally
-  }
-
-  if (duplicateSkillPendingState === DUPLICATE_SKILL_PENDING_EXISTING) {
-    const duplicateMatch = line.match(/duplicate:\s*(.+)/)
-    if (duplicateMatch) {
-      const duplicatePath = duplicateMatch[1]!.trim()
-      if (duplicateSkillExistingPath === duplicatePath) {
-        // Same file — false positive, suppress entirely
-        duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-        return true // consumed + suppressed
-      }
-      // Different files — genuine duplicate, log as warning
-      logger.warn(
-        `duplicate skill name "${duplicateSkillPendingName}" (existing: ${duplicateSkillExistingPath}, duplicate: ${duplicatePath})`,
-      )
-      duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-      return true // consumed (re-logged as warn)
-    }
-    // Unexpected line — flush what we have
-    logger.warn(`duplicate skill name "${duplicateSkillPendingName}" (existing: ${duplicateSkillExistingPath})`)
-    duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-    return false
-  }
-
-  // Safety: unknown state, reset
-  duplicateSkillPendingState = DUPLICATE_SKILL_PENDING_NONE
-  return false
+// OpenCode may log "duplicate skill name" warnings to stderr when the same
+// skill file is discovered through multiple scan paths. Downgrade from error
+// to warn — these are not actual errors.
+function isDuplicateSkillWarning(line: string): boolean {
+  return line.includes('duplicate skill name')
 }
 
 
@@ -836,10 +771,10 @@ async function startSingleServer({
         pushStartupStderrTail({ stderrTail: startupStderrTail, line })
         return
       }
-      // Filter false-positive "duplicate skill name" warnings where
-      // existing === duplicate (same file found via multiple scan paths).
-      // These are harmless and should not clutter error-level logs.
-      if (duplicateSkillFilter({ line, logger: opencodeLogger })) {
+      // Downgrade "duplicate skill name" warnings to warn level —
+      // these are not actual errors.
+      if (isDuplicateSkillWarning(line)) {
+        opencodeLogger.warn(line)
         return
       }
       opencodeLogger.error(line)


### PR DESCRIPTION
### Issue for this PR

Fixes #121

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode may log "duplicate skill name" warnings to stderr when skill files are scanned through multiple paths. Previously, all stderr was logged at `error` level in Kimaki, making these harmless warnings look like failures.

This PR simply downgrades lines containing "duplicate skill name" from `error` to `warn` level — both false positives and genuine duplicates are informational, not errors. Clean, minimal change.

### How did you verify your code works?

- Add a simple `isDuplicateSkillWarning()` helper that checks for the substring
- If matched, log at `warn` instead of `error`
- Zero type errors introduced

### Screenshots / recordings

Not applicable (non-UI change).

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
