### PR TITLE
Fix OpenCode 1.14 event stream handling

### DIFF
--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -86,6 +86,23 @@ async function requestHealthcheck({
   url: string
 }): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = <T>(
+      settle: (value: T) => void,
+      value: T,
+    ): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      settle(value)
+    }
+
+    const timeout = setTimeout(() => {
+      req.destroy(new Error('OpenCode healthcheck timed out'))
+    }, 2000)
+
     const req = http.request(
       url,
       {
@@ -100,14 +117,19 @@ async function requestHealthcheck({
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
         })
         res.on('end', () => {
-          resolve({
+          finish(resolve, {
             status: res.statusCode || 0,
             body: Buffer.concat(chunks).toString('utf-8'),
           })
         })
+        res.on('error', (error) => {
+          finish(reject, error)
+        })
       },
     )
-    req.on('error', reject)
+    req.on('error', (error) => {
+      finish(reject, error)
+    })
     req.end()
   })
 }

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -1394,10 +1394,7 @@ export class ThreadSessionRuntime {
         continue
       }
       const subscribeResult = await errore.tryAsync(() => {
-        return client.event.subscribe(
-          { directory: this.sdkDirectory },
-          { signal },
-        )
+        return client.global.event({ signal })
       })
 
       if (subscribeResult instanceof Error) {
@@ -1427,7 +1424,17 @@ export class ThreadSessionRuntime {
       await this.bootstrapSentPartIds()
 
       const iterResult = await errore.tryAsync(async () => {
-        for await (const event of events) {
+        for await (const rawEvent of events) {
+          const event = (
+            rawEvent &&
+            typeof rawEvent === 'object' &&
+            'payload' in rawEvent
+              ? rawEvent.payload
+              : rawEvent
+          ) as OpenCodeEvent
+          if (!event || typeof event !== 'object' || !('type' in event)) {
+            continue
+          }
           // Each event is dispatched through the serialized action queue
           // to prevent interleaving mutations from concurrent events.
           await this.dispatchAction(() => {


### PR DESCRIPTION
## Summary
- switch the Discord session listener from the directory-scoped event subscription to OpenCode's global event stream
- unwrap `{ payload }` events before dispatching them to the session runtime
- add a 2s timeout to the OpenCode readiness healthcheck so startup polling cannot hang forever

Closes #124.

## Verification
- Live local verification: after the same installed-runtime patch, a Discord thread prompt produced assistant event rows and `part_messages`, posted `Kimaki Discord replies are fixed.`, and renamed the thread to `Kimaki Discord replies fixed`.
- `git diff --check`
- `pnpm --filter kimaki exec tsc --noEmit`
- `pnpm --filter kimaki exec vitest run src/thread-message-queue.e2e.test.ts` passed 10/10 tests
- `pnpm --filter kimaki exec vitest run src/runtime-lifecycle.e2e.test.ts` passed 4/5 tests; `three sequential completions reuse same runtime and listener` timed out waiting for a Discord footer message containing `*project` after the user prompt was sent. This looks consistent with the existing Discord/footer timing issue observed during local verification rather than the event stream fix itself.
