### PR TITLE
fix: disable external opencode sync by default

### DIFF
--- a/.changeset/disable-external-opencode-sync-by-default.md
+++ b/.changeset/disable-external-opencode-sync-by-default.md
@@ -1,0 +1,7 @@
+---
+"kimaki": patch
+---
+
+Disable external OpenCode session sync by default so the Discord bot does not continuously initialize OpenCode for every tracked project. Users who want to mirror sessions started outside Discord can opt in with `KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC=1`.
+
+Also sanitize model/provider select menu options so missing model names fall back to model IDs instead of producing invalid Discord select options.

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -35,6 +35,28 @@ import { buildPaginatedOptions, parsePaginationValue } from './paginated-select.
 
 const modelLogger = createLogger(LogPrefix.MODEL)
 
+
+function buildSafeSelectOption({
+  label,
+  value,
+  description,
+}: {
+  label: string | undefined
+  value: string | undefined
+  description?: string
+}) {
+  const safeLabel = (label || value || 'Unknown').trim().slice(0, 100)
+  const safeValue = (value || label || '').trim()
+  if (!safeLabel || !safeValue) {
+    return undefined
+  }
+  return {
+    label: safeLabel,
+    value: safeValue,
+    description: description?.slice(0, 100),
+  }
+}
+
 // Store context by hash to avoid customId length limits (Discord max: 100 chars).
 // Entries are TTL'd to prevent unbounded growth when users open /model and never
 // interact with the select menu.
@@ -492,16 +514,13 @@ export async function handleModelCommand({
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((provider) => {
         const modelCount = Object.keys(provider.models || {}).length
-        return {
-          label: provider.name.slice(0, 100),
+        return buildSafeSelectOption({
+          label: provider.name,
           value: provider.id,
-          description:
-            `${modelCount} model${modelCount !== 1 ? 's' : ''} available`.slice(
-              0,
-              100,
-            ),
-        }
+          description: `${modelCount} model${modelCount !== 1 ? 's' : ''} available`,
+        })
       })
+      .filter((option): option is NonNullable<typeof option> => !!option)
 
     const { options } = buildPaginatedOptions({
       allOptions: allProviderOptions,
@@ -586,12 +605,13 @@ export async function handleProviderSelectMenu(
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((p) => {
         const modelCount = Object.keys(p.models || {}).length
-        return {
-          label: p.name.slice(0, 100),
+        return buildSafeSelectOption({
+          label: p.name,
           value: p.id,
-          description: `${modelCount} model${modelCount !== 1 ? 's' : ''} available`.slice(0, 100),
-        }
+          description: `${modelCount} model${modelCount !== 1 ? 's' : ''} available`,
+        })
       })
+      .filter((option): option is NonNullable<typeof option> => !!option)
     const { options } = buildPaginatedOptions({ allOptions: allProviderOptions, page: providerNavPage })
     const selectMenu = new StringSelectMenuBuilder()
       .setCustomId(`model_provider:${contextHash}`)
@@ -642,9 +662,10 @@ export async function handleProviderSelectMenu(
     const models = Object.entries(provider.models || {})
       .map(([modelId, model]) => ({
         id: modelId,
-        name: model.name,
+        name: model.name || modelId,
         releaseDate: model.release_date,
       }))
+      .filter((model) => model.id && model.name)
       .sort((a, b) => a.name.localeCompare(b.name))
 
     if (models.length === 0) {
@@ -661,16 +682,18 @@ export async function handleProviderSelectMenu(
     context.modelPage = 0
     setModelContext(contextHash, context)
 
-    const allModelOptions = models.map((model) => {
-      const dateStr = model.releaseDate
-        ? new Date(model.releaseDate).toLocaleDateString()
-        : 'Unknown date'
-      return {
-        label: model.name.slice(0, 100),
-        value: model.id,
-        description: dateStr.slice(0, 100),
-      }
-    })
+    const allModelOptions = models
+      .map((model) => {
+        const dateStr = model.releaseDate
+          ? new Date(model.releaseDate).toLocaleDateString()
+          : 'Unknown date'
+        return buildSafeSelectOption({
+          label: model.name,
+          value: model.id,
+          description: dateStr,
+        })
+      })
+      .filter((option): option is NonNullable<typeof option> => !!option)
 
     const { options } = buildPaginatedOptions({
       allOptions: allModelOptions,
@@ -752,14 +775,16 @@ export async function handleModelSelectMenu(
       return
     }
     const allModelOptions = Object.entries(provider.models || {})
-      .map(([modelId, model]) => ({
-        label: model.name.slice(0, 100),
-        value: modelId,
-        description: (model.release_date
-          ? new Date(model.release_date).toLocaleDateString()
-          : 'Unknown date'
-        ).slice(0, 100),
-      }))
+      .map(([modelId, model]) =>
+        buildSafeSelectOption({
+          label: model.name || modelId,
+          value: modelId,
+          description: model.release_date
+            ? new Date(model.release_date).toLocaleDateString()
+            : 'Unknown date',
+        }),
+      )
+      .filter((option): option is NonNullable<typeof option> => !!option)
       .sort((a, b) => a.label.localeCompare(b.label))
     const { options } = buildPaginatedOptions({ allOptions: allModelOptions, page: modelNavPage })
     const selectMenu = new StringSelectMenuBuilder()

--- a/cli/src/external-opencode-sync.test.ts
+++ b/cli/src/external-opencode-sync.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { stopExternalOpencodeSessionSync, externalOpencodeSyncInternals } from './external-opencode-sync.js'
+
+afterEach(() => {
+  delete process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC
+  stopExternalOpencodeSessionSync()
+})
+
+describe('external OpenCode session sync feature flag', () => {
+  test('is disabled by default in production', () => {
+    delete process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC
+
+    expect(externalOpencodeSyncInternals.isExternalOpencodeSessionSyncEnabled()).toBe(false)
+  })
+
+  test('only enables when explicitly set to 1', () => {
+    process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC = '0'
+    expect(externalOpencodeSyncInternals.isExternalOpencodeSessionSyncEnabled()).toBe(false)
+
+    process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC = '1'
+    expect(externalOpencodeSyncInternals.isExternalOpencodeSessionSyncEnabled()).toBe(true)
+  })
+})

--- a/cli/src/external-opencode-sync.ts
+++ b/cli/src/external-opencode-sync.ts
@@ -38,6 +38,7 @@ import { extractNonXmlContent } from './xml.js'
 const logger = createLogger(LogPrefix.OPENCODE)
 
 const EXTERNAL_SYNC_INTERVAL_MS = 5_000
+const EXTERNAL_SYNC_ENABLED_VALUE = '1'
 // Don't sync sessions from before the CLI started. 5 min grace window
 // covers sessions that were just created before the bot connected.
 const CLI_START_MS = Date.now() - 5 * 60 * 1000
@@ -629,15 +630,17 @@ async function pollExternalSessions({
   }
 }
 
+function isExternalOpencodeSessionSyncEnabled(): boolean {
+  return process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC === EXTERNAL_SYNC_ENABLED_VALUE
+}
+
 export function startExternalOpencodeSessionSync({
   discordClient,
 }: {
   discordClient: Client
 }): void {
-  if (
-    process.env.KIMAKI_VITEST &&
-    process.env.KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC !== '1'
-  ) {
+  if (!isExternalOpencodeSessionSyncEnabled()) {
+    logger.log('[EXTERNAL_SYNC] Disabled; set KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC=1 to mirror sessions started outside Discord')
     return
   }
   if (externalSyncInterval) {
@@ -682,4 +685,5 @@ export const externalOpencodeSyncInternals = {
   parseDiscordOriginMetadata,
   getDiscordOriginMetadataFromMessage,
   isLatestUserTurnFromDiscord,
+  isExternalOpencodeSessionSyncEnabled,
 }


### PR DESCRIPTION
## Summary
- Disable external OpenCode session sync by default; operators can opt back in with `KIMAKI_ENABLE_EXTERNAL_OPENCODE_SYNC=1`.
- Keep the feature available but prevent the Discord bot from continuously initializing OpenCode across every tracked project during normal startup.
- Sanitize model/provider select options so missing model names fall back to IDs instead of producing invalid Discord menu options.

## Why
In a real long-running bot, external sync was repeatedly initializing OpenCode for multiple tracked local project directories. When some directory initializations timed out, the shared OpenCode server could become "ready" at the process level but unresponsive over HTTP/SSE, which then surfaced as Discord interaction timeouts and `SSE read timed out` errors.

The sync feature is useful, but it is expensive and should be explicit opt-in rather than a default background dependency for every bot instance.

## Test plan
- `./node_modules/.bin/vitest run cli/src/external-opencode-sync.test.ts`
- `./node_modules/.bin/tsc --noEmit --strict true --skipLibCheck true --target ESNext --module nodenext --moduleResolution nodenext --verbatimModuleSyntax true --allowJs true --typeRoots ./node_modules/.pnpm/@types+node@24.11.0/node_modules/@types cli/src/external-opencode-sync.ts cli/src/external-opencode-sync.test.ts cli/src/commands/model.ts`