### PR TITLE
feat: add Wayland screen sharing support

### DIFF
--- a/cli/src/commands/screenshare.test.ts
+++ b/cli/src/commands/screenshare.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from 'vitest'
-import { buildNoVncUrl, createScreenshareTunnelId } from './screenshare.js'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import {
+  buildNoVncUrl,
+  createScreenshareTunnelId,
+  detectDisplayServer,
+  detectWaylandCompositor,
+  spawnWaylandVncGnome,
+  spawnWaylandVncWlroots,
+} from './screenshare.js'
 
 describe('screenshare security defaults', () => {
   test('generates a 128-bit tunnel id', () => {
@@ -26,5 +33,105 @@ describe('screenshare security defaults', () => {
     )
     expect(url.searchParams.get('port')).toBe('443')
     expect(url.searchParams.get('encrypt')).toBe('1')
+  })
+})
+
+describe('display server detection', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    delete process.env['DISPLAY']
+    delete process.env['WAYLAND_DISPLAY']
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('detects X11 when DISPLAY is set', () => {
+    process.env['DISPLAY'] = ':0'
+    expect(detectDisplayServer()).toBe('x11')
+  })
+
+  test('detects Wayland when WAYLAND_DISPLAY is set', () => {
+    process.env['WAYLAND_DISPLAY'] = 'wayland-0'
+    expect(detectDisplayServer()).toBe('wayland')
+  })
+
+  test('prefers Wayland when both are set', () => {
+    process.env['DISPLAY'] = ':0'
+    process.env['WAYLAND_DISPLAY'] = 'wayland-0'
+    expect(detectDisplayServer()).toBe('wayland')
+  })
+
+  test('returns unknown when neither is set', () => {
+    expect(detectDisplayServer()).toBe('unknown')
+  })
+})
+
+describe('Wayland compositor detection', () => {
+  test('detects GNOME from ps output', async () => {
+    const { execAsync } = await import('../worktrees.js')
+    vi.mocked(execAsync).mockResolvedValue({
+      stdout: 'user 1234 0.0 0.1 gnome-shell --session',
+      stderr: '',
+    })
+    expect(await detectWaylandCompositor()).toBe('gnome')
+  })
+
+  test('detects Sway from ps output', async () => {
+    const { execAsync } = await import('../worktrees.js')
+    vi.mocked(execAsync).mockResolvedValue({
+      stdout: 'user 1234 0.0 0.1 sway --config /etc/sway/config',
+      stderr: '',
+    })
+    expect(await detectWaylandCompositor()).toBe('wlroots')
+  })
+
+  test('detects River from ps output', async () => {
+    const { execAsync } = await import('../worktrees.js')
+    vi.mocked(execAsync).mockResolvedValue({
+      stdout: 'user 1234 0.0 0.1 river',
+      stderr: '',
+    })
+    expect(await detectWaylandCompositor()).toBe('wlroots')
+  })
+
+  test('returns unknown for unrecognized compositor', async () => {
+    const { execAsync } = await import('../worktrees.js')
+    vi.mocked(execAsync).mockResolvedValue({
+      stdout: 'user 1234 0.0 0.1 some-other-compositor',
+      stderr: '',
+    })
+    expect(await detectWaylandCompositor()).toBe('unknown')
+  })
+
+  test('returns unknown when ps fails', async () => {
+    const { execAsync } = await import('../worktrees.js')
+    vi.mocked(execAsync).mockRejectedValue(new Error('command not found'))
+    expect(await detectWaylandCompositor()).toBe('unknown')
+  })
+})
+
+describe('Wayland VNC spawn functions', () => {
+  test('spawnWaylandVncGnome spawns w0vncserver with correct args', () => {
+    const proc = spawnWaylandVncGnome()
+    expect(proc.spawnfile).toBe('w0vncserver')
+    expect(proc.spawnargs).toContain('-SecurityTypes')
+    expect(proc.spawnargs).toContain('None')
+    expect(proc.spawnargs).toContain('-localhost')
+    expect(proc.spawnargs).toContain('-rfbport')
+    expect(proc.spawnargs).toContain('5900')
+    proc.kill()
+  })
+
+  test('spawnWaylandVncWlroots spawns wayvnc with correct args', () => {
+    const proc = spawnWaylandVncWlroots()
+    expect(proc.spawnfile).toBe('wayvnc')
+    expect(proc.spawnargs).toContain('localhost')
+    expect(proc.spawnargs).toContain('5900')
+    proc.kill()
   })
 })

--- a/cli/src/commands/screenshare.ts
+++ b/cli/src/commands/screenshare.ts
@@ -1,6 +1,7 @@
 // /screenshare command - Start screen sharing via VNC + WebSocket bridge + kimaki tunnel.
 // On macOS: uses built-in Screen Sharing (port 5900).
-// On Linux: spawns x11vnc against the current $DISPLAY.
+// On Linux X11: spawns x11vnc against the current $DISPLAY.
+// On Linux Wayland: spawns w0vncserver (TigerVNC) for GNOME, wayvnc for wlroots.
 // Exposes the VNC stream via an in-process websockify bridge and a traforo tunnel,
 // then sends the user a noVNC URL they can open in a browser.
 //
@@ -24,7 +25,7 @@ const SECURE_REPLY_FLAGS = MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS
 export type ScreenshareSession = {
   tunnelClient: TunnelClient
   wss: WebSocketServer
-  /** x11vnc child process, only on Linux */
+  /** VNC child process: x11vnc (X11), w0vncserver (GNOME Wayland), or wayvnc (wlroots Wayland) */
   vncProcess: ChildProcess | undefined
   url: string
   noVncUrl: string
@@ -114,21 +115,96 @@ export function spawnX11Vnc(): ChildProcess {
   return child
 }
 
+// --- Wayland support ---
+
+type DisplayServer = 'x11' | 'wayland'
+
+/** Detect whether the current session is X11 or Wayland */
+export function detectDisplayServer(): DisplayServer | 'unknown' {
+  if (process.env['WAYLAND_DISPLAY']) return 'wayland'
+  if (process.env['DISPLAY']) return 'x11'
+  return 'unknown'
+}
+
+type WaylandCompositor = 'gnome' | 'wlroots' | 'unknown'
+
+/** Detect the Wayland compositor by scanning running processes */
+export async function detectWaylandCompositor(): Promise<WaylandCompositor> {
+  try {
+    const { stdout } = await execAsync('ps aux', { timeout: 3000 })
+    if (stdout.includes('gnome-shell')) return 'gnome'
+    if (stdout.includes('sway') || stdout.includes('river') || stdout.includes('wayfire')) return 'wlroots'
+    return 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+/** Check that a binary exists on PATH, throw a helpful message if not */
+async function checkBinary(name: string, installHint: string): Promise<void> {
+  try {
+    await execAsync(`which ${name}`, { timeout: 3000 })
+  } catch {
+    throw new Error(`${name} is not installed. Install it with: ${installHint}`)
+  }
+}
+
+/** Spawn w0vncserver (TigerVNC) for GNOME/Wayland */
+export function spawnWaylandVncGnome(): ChildProcess {
+  const child = spawn('w0vncserver', [
+    '-SecurityTypes', 'None',
+    '-localhost',
+    '-rfbport', String(VNC_PORT),
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout?.on('data', (data: Buffer) => {
+    logger.log(`w0vncserver: ${data.toString().trim()}`)
+  })
+  child.stderr?.on('data', (data: Buffer) => {
+    logger.error(`w0vncserver: ${data.toString().trim()}`)
+  })
+
+  return child
+}
+
+/** Spawn wayvnc for wlroots compositors (Sway, River, Wayfire) */
+export function spawnWaylandVncWlroots(): ChildProcess {
+  const child = spawn('wayvnc', [
+    'localhost',
+    String(VNC_PORT),
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout?.on('data', (data: Buffer) => {
+    logger.log(`wayvnc: ${data.toString().trim()}`)
+  })
+  child.stderr?.on('data', (data: Buffer) => {
+    logger.error(`wayvnc: ${data.toString().trim()}`)
+  })
+
+  return child
+}
+
 function waitForPort({
   port,
   process: proc,
   timeoutMs,
+  processName = 'VNC server',
 }: {
   port: number
   process: ChildProcess
   timeoutMs: number
+  processName?: string
 }): Promise<void> {
   return new Promise((resolve, reject) => {
     const maxAttempts = Math.ceil(timeoutMs / 100)
     let attempts = 0
     const check = () => {
       if (proc.exitCode !== null) {
-        reject(new Error(`x11vnc exited with code ${proc.exitCode} before becoming ready`))
+        reject(new Error(`${processName} exited with code ${proc.exitCode} before becoming ready`))
         return
       }
       const sock = net.createConnection(port, 'localhost')
@@ -187,18 +263,46 @@ export async function startScreenshare({
   if (platform === 'darwin') {
     await ensureMacRemoteManagement()
   } else if (platform === 'linux') {
-    if (!process.env['DISPLAY']) {
-      throw new Error('No $DISPLAY found. Screen sharing requires a running X11 display.')
+    const displayType = detectDisplayServer()
+
+    if (displayType === 'unknown') {
+      throw new Error(
+        'No display server detected. Screen sharing requires X11 ($DISPLAY) or Wayland ($WAYLAND_DISPLAY).',
+      )
     }
-    try {
-      await execAsync('which x11vnc', { timeout: 3000 })
-    } catch {
-      throw new Error('x11vnc is not installed. Install it with: sudo apt install x11vnc')
+
+    if (displayType === 'x11') {
+      try {
+        await checkBinary('x11vnc', 'sudo apt install x11vnc')
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('x11vnc is not installed')) {
+          throw err
+        }
+        throw new Error('x11vnc is not installed. Install it with: sudo apt install x11vnc')
+      }
+      vncProcess = spawnX11Vnc()
+      await waitForPort({ port: VNC_PORT, process: vncProcess, timeoutMs: 5000, processName: 'x11vnc' })
+    } else {
+      // Wayland path
+      const compositor = await detectWaylandCompositor()
+
+      if (compositor === 'gnome') {
+        await checkBinary('w0vncserver', 'sudo apt install tigervnc-standalone-server')
+        vncProcess = spawnWaylandVncGnome()
+        await waitForPort({ port: VNC_PORT, process: vncProcess, timeoutMs: 5000, processName: 'w0vncserver' })
+      } else if (compositor === 'wlroots') {
+        await checkBinary('wayvnc', 'sudo apt install wayvnc')
+        vncProcess = spawnWaylandVncWlroots()
+        await waitForPort({ port: VNC_PORT, process: vncProcess, timeoutMs: 5000, processName: 'wayvnc' })
+      } else {
+        throw new Error(
+          'Wayland detected but compositor not recognized.\n' +
+          'Supported compositors: GNOME (w0vncserver), Sway/River/Wayfire (wayvnc).\n' +
+          'For GNOME: sudo apt install tigervnc-standalone-server\n' +
+          'For wlroots: sudo apt install wayvnc',
+        )
+      }
     }
-    vncProcess = spawnX11Vnc()
-    // Wait for x11vnc to actually be ready (port 5900 accepting connections)
-    // instead of a blind 1s sleep. Polls every 100ms, fails if process exits first.
-    await waitForPort({ port: VNC_PORT, process: vncProcess, timeoutMs: 3000 })
   } else {
     throw new Error(`Screen sharing is not supported on ${platform}. Only macOS and Linux are supported.`)
   }

--- a/docs/screen-sharing.md
+++ b/docs/screen-sharing.md
@@ -38,10 +38,32 @@ sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resourc
 
 ## Linux Setup
 
-Requires `x11vnc` and a running X11 display (`$DISPLAY`):
+Kimaki auto-detects your display server (X11 or Wayland) and uses the appropriate VNC backend.
+
+### X11
+
+Requires `x11vnc`:
 
 ```bash
 sudo apt install x11vnc
 ```
 
-Kimaki spawns `x11vnc` automatically when you start screen sharing.
+### Wayland (GNOME)
+
+Requires TigerVNC 1.16+ (`w0vncserver`):
+
+```bash
+sudo apt install tigervnc-standalone-server
+```
+
+**Note:** First use may show a permission dialog asking to allow screen capture. Click "Allow" once — the permission is remembered.
+
+### Wayland (Sway, River, Wayfire)
+
+Requires `wayvnc`:
+
+```bash
+sudo apt install wayvnc
+```
+
+Kimaki spawns the correct VNC server automatically when you start screen sharing.


### PR DESCRIPTION
## Summary

Add automatic display server detection and Wayland VNC support to `/screenshare`:

- **X11**: uses `x11vnc` (existing behavior, unchanged)
- **GNOME Wayland**: uses `w0vncserver` (TigerVNC 1.16+)
- **wlroots Wayland** (Sway, River, Wayfire): uses `wayvnc`

## Changes

- `detectDisplayServer()` — checks `$WAYLAND_DISPLAY` then `$DISPLAY`
- `detectWaylandCompositor()` — scans `ps aux` for gnome-shell/sway/river/wayfire
- `spawnWaylandVncGnome()` — spawns `w0vncserver` with no auth, localhost-only
- `spawnWaylandVncWlroots()` — spawns `wayvnc` on localhost:5900
- `checkBinary()` — validates VNC binary exists with helpful install hints
- `waitForPort()` — now accepts `processName` for generic error messages
- Updated `docs/screen-sharing.md` with Wayland setup instructions
- Added tests for display detection and compositor detection

## Install Requirements

| Compositor | Package | Command |
|-----------|---------|---------|
| X11 | x11vnc | `sudo apt install x11vnc` |
| GNOME Wayland | tigervnc-standalone-server | `sudo apt install tigervnc-standalone-server` |
| wlroots Wayland | wayvnc | `sudo apt install wayvnc` |

Closes #129