### PR TITLE
voice: Gemini fallback chain + retry-transcription button

### DIFF
--- a/cli/src/commands/retry-transcription.test.ts
+++ b/cli/src/commands/retry-transcription.test.ts
@@ -1,0 +1,33 @@
+// Unit tests for the retry-transcription button.
+// We only test the pure customId-encoding helper here. The handler itself
+// requires a live Discord ButtonInteraction so it's covered by e2e tests.
+
+import { describe, expect, test } from 'vitest'
+import { buildRetryTranscriptionRow } from './retry-transcription.js'
+
+describe('buildRetryTranscriptionRow', () => {
+  test('encodes channelId and messageId into the customId with the expected prefix', () => {
+    const row = buildRetryTranscriptionRow({
+      id: '1508877325930987611',
+      channelId: '1508804737179324469',
+    })
+    const button = row.components[0]
+    expect(button).toBeDefined()
+    expect(button!.data).toMatchObject({
+      custom_id: 'retry_transcription:1508804737179324469:1508877325930987611',
+      label: 'Retry transcription',
+      style: 2, // ButtonStyle.Secondary
+    })
+  })
+
+  test('produced customId fits comfortably under Discord 100-char limit', () => {
+    // Discord snowflakes are at most 19 digits; even with very long IDs the
+    // customId stays well under the 100-char hard limit.
+    const row = buildRetryTranscriptionRow({
+      id: '9999999999999999999',
+      channelId: '9999999999999999999',
+    })
+    const customId = row.components[0]!.data.custom_id as string
+    expect(customId.length).toBeLessThanOrEqual(100)
+  })
+})

--- a/cli/src/commands/retry-transcription.ts
+++ b/cli/src/commands/retry-transcription.ts
@@ -1,0 +1,162 @@
+// Retry-transcription button: attached to every "⚠️ Transcription failed" message
+// so users can re-run transcription without manually re-uploading the voice message.
+//
+// Flow:
+//   1. Voice transcription fails → voice-handler.ts posts the failure message with
+//      a 🔄 Retry button built by `buildRetryTranscriptionRow`. The customId encodes
+//      `retry_transcription:<channelId>:<messageId>` so the handler can re-fetch the
+//      original voice attachment from Discord.
+//   2. User clicks → `handleRetryTranscriptionButton` defers, refetches the message,
+//      and delegates back to `processVoiceAttachment` — which already knows how to
+//      post a transcript on success or a fresh failure-with-retry-button on retry.
+//
+// We deliberately re-use the full voice pipeline (vs. ad-hoc transcribe-only logic)
+// so the retry path stays consistent with first-attempt transcription: same project
+// context, same agent enum, same session-context awareness, same thread renaming.
+
+import * as errore from 'errore'
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+  type ButtonInteraction,
+  type Message,
+} from 'discord.js'
+import { getChannelDirectory } from '../database.js'
+import { processVoiceAttachment } from '../voice-handler.js'
+import { createLogger, LogPrefix } from '../logger.js'
+
+const logger = createLogger(LogPrefix.VOICE)
+
+const CUSTOM_ID_PREFIX = 'retry_transcription:'
+
+/**
+ * Build the action row containing a "🔄 Retry transcription" button. Caller is
+ * responsible for attaching it to a Discord message (typically the failure notice
+ * posted by `processVoiceAttachment`).
+ *
+ * The customId encodes the source channel + message IDs so the handler can locate
+ * the original voice attachment when the user clicks. Discord's customId hard limit
+ * is 100 chars — two snowflake IDs (~19 chars each) + prefix fit comfortably.
+ */
+export function buildRetryTranscriptionRow(
+  voiceMessage: Pick<Message, 'id' | 'channelId'>,
+): ActionRowBuilder<ButtonBuilder> {
+  const button = new ButtonBuilder()
+    .setCustomId(`${CUSTOM_ID_PREFIX}${voiceMessage.channelId}:${voiceMessage.id}`)
+    .setLabel('Retry transcription')
+    .setEmoji('🔄')
+    .setStyle(ButtonStyle.Secondary)
+
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(button)
+}
+
+/**
+ * Discord button-click handler for the retry-transcription button.
+ * Re-fetches the original voice message and delegates to `processVoiceAttachment`,
+ * which posts the transcript (or another failure-with-retry-button) into the thread.
+ *
+ * Replies to the interaction itself are ephemeral — the user-visible transcription
+ * goes to the thread, not the ephemeral reply, so other thread members can see it.
+ */
+export async function handleRetryTranscriptionButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  if (!interaction.customId.startsWith(CUSTOM_ID_PREFIX)) return
+
+  const payload = interaction.customId.slice(CUSTOM_ID_PREFIX.length)
+  const [channelId, messageId] = payload.split(':')
+  if (!channelId || !messageId) {
+    await interaction.reply({
+      content: '⚠️ Malformed retry button — missing message reference.',
+      flags: MessageFlags.Ephemeral,
+    })
+    return
+  }
+
+  // Transcription can take 10+ seconds — defer before doing real work so Discord
+  // doesn't time us out at the 3s mark.
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral })
+
+  const thread = interaction.channel
+  if (!thread || !thread.isThread()) {
+    await interaction.editReply({
+      content: '⚠️ Retry must be triggered from inside the thread that hosted the original transcription.',
+    })
+    return
+  }
+
+  // Fetch the original voice message via the source channel (not the thread).
+  // Voice messages live on the parent channel; the thread was spawned alongside.
+  const sourceChannel = await errore.tryAsync({
+    try: () => interaction.client.channels.fetch(channelId),
+    catch: (e) => new Error('channel fetch failed', { cause: e }),
+  })
+  if (sourceChannel instanceof Error || !sourceChannel) {
+    await interaction.editReply({
+      content: `⚠️ Could not access the source channel: ${sourceChannel instanceof Error ? sourceChannel.message : 'channel not found'}`,
+    })
+    return
+  }
+  if (!sourceChannel.isTextBased()) {
+    await interaction.editReply({
+      content: '⚠️ Source channel does not support messages.',
+    })
+    return
+  }
+
+  const sourceMessage = await errore.tryAsync({
+    try: () => sourceChannel.messages.fetch(messageId),
+    catch: (e) => new Error('message fetch failed', { cause: e }),
+  })
+  if (sourceMessage instanceof Error) {
+    await interaction.editReply({
+      content: `⚠️ Could not fetch the original voice message (it may have been deleted): ${sourceMessage.message}`,
+    })
+    return
+  }
+
+  // Best-effort project directory lookup so the retry path keeps the same project
+  // context (file tree, agents) the first attempt had. Falls back to no context
+  // if the channel is not registered.
+  const parentChannelId = thread.parentId
+  const projectConfig = parentChannelId
+    ? await getChannelDirectory(parentChannelId)
+    : undefined
+  const projectDirectory = projectConfig?.directory
+
+  const appId = interaction.client.application?.id
+
+  logger.log(
+    `Retry button clicked for message ${messageId} in channel ${channelId} (thread ${thread.id})`,
+  )
+
+  await interaction.editReply({
+    content: '🔄 Retrying transcription… result will appear in the thread.',
+  })
+
+  // Hand off to the canonical voice pipeline. It will:
+  //   - post its own "🎤 Transcribing voice message…" status into the thread
+  //   - either succeed (post the transcript) or fail again (post a fresh
+  //     failure message with another retry button attached)
+  const result = await processVoiceAttachment({
+    message: sourceMessage,
+    thread,
+    ...(projectDirectory ? { projectDirectory } : {}),
+    ...(appId ? { appId } : {}),
+  })
+
+  if (result === null) {
+    // The voice pipeline already posted a detailed error in the thread, so the
+    // ephemeral reply just acknowledges it.
+    await interaction.editReply({
+      content: '⚠️ Retry failed. See the thread message for details — you can click Retry again to try once more.',
+    })
+    return
+  }
+
+  await interaction.editReply({
+    content: '✅ Transcription succeeded — posted in the thread.',
+  })
+}

--- a/cli/src/interaction-handler.ts
+++ b/cli/src/interaction-handler.ts
@@ -75,6 +75,7 @@ import {
   handleTranscriptionApiKeyCommand,
   handleTranscriptionApiKeyModalSubmit,
 } from './commands/gemini-apikey.js'
+import { handleRetryTranscriptionButton } from './commands/retry-transcription.js'
 import {
   handleAgentCommand,
   handleAgentSelectMenu,
@@ -447,6 +448,13 @@ export function registerInteractionHandler({
               return
             }
             await handleTranscriptionApiKeyButton(interaction)
+            return
+          }
+
+          if (customId.startsWith('retry_transcription:')) {
+            // Permission check already gated by hasKimakiBotPermission above.
+            // Any thread member with the Kimaki role can retry a failed transcription.
+            await handleRetryTranscriptionButton(interaction)
             return
           }
 

--- a/cli/src/voice-handler.ts
+++ b/cli/src/voice-handler.ts
@@ -38,6 +38,7 @@ import {
   hasKimakiBotPermission,
 } from './discord-utils.js'
 import { showApiKeyRequiredButton } from './commands/gemini-apikey.js'
+import { buildRetryTranscriptionRow } from './commands/retry-transcription.js'
 import { transcribeAudio, type TranscriptionResult } from './voice.js'
 import { FetchError } from './errors.js'
 import { store } from './store.js'
@@ -567,11 +568,13 @@ export async function processVoiceAttachment({
       `Failed to download audio attachment:`,
       audioResponse.message,
     )
-    await sendThreadMessage(
-      thread,
-      `⚠️ Failed to download audio: ${audioResponse.message}`,
-      { flags: NOTIFY_MESSAGE_FLAGS },
-    )
+    // Discord CDN URLs are signed and can expire — clicking Retry will re-fetch
+    // the message which regenerates a fresh URL, so the retry button is useful here.
+    await thread.send({
+      content: `⚠️ Failed to download audio: ${audioResponse.message}`,
+      components: [buildRetryTranscriptionRow(message)],
+      flags: NOTIFY_MESSAGE_FLAGS,
+    })
     return null
   }
   const audioBuffer = Buffer.from(await audioResponse.arrayBuffer())
@@ -654,7 +657,13 @@ export async function processVoiceAttachment({
       Error: (e) => e.message,
     })
     voiceLogger.error(`Transcription failed:`, transcription)
-    await sendThreadMessage(thread, `⚠️ Transcription failed: ${errMsg}`, {
+    // Attach a 🔄 Retry button so users can re-run transcription after the model
+    // recovers from overload, after quota resets, or after a fresh API key is set.
+    // The handler in commands/retry-transcription.ts re-fetches the original voice
+    // attachment via the encoded channelId:messageId and re-runs the full pipeline.
+    await thread.send({
+      content: `⚠️ Transcription failed: ${errMsg}`,
+      components: [buildRetryTranscriptionRow(message)],
       flags: NOTIFY_MESSAGE_FLAGS,
     })
     return null

--- a/cli/src/voice.test.ts
+++ b/cli/src/voice.test.ts
@@ -10,6 +10,8 @@ import {
   extractTranscription,
   normalizeAudioMediaType,
   getOpenAIAudioConversionStrategy,
+  classifyGeminiError,
+  GEMINI_TRANSCRIPTION_MODELS,
 } from './voice.js'
 import {
   getVoiceAttachmentMatchReason,
@@ -169,6 +171,86 @@ describe('extractTranscription', () => {
     expect((result as Error).message).toMatchInlineSnapshot(
       `"Transcription failed: Model did not produce a transcription"`,
     )
+  })
+})
+
+describe('classifyGeminiError', () => {
+  test('classifies "high demand" overload as retry-then-next', () => {
+    const cls = classifyGeminiError(
+      new Error(
+        'API call failed: AI_APICallError: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.',
+      ),
+    )
+    expect(cls).toMatchInlineSnapshot(`
+      {
+        "delayMs": 3000,
+        "kind": "retry-then-next",
+      }
+    `)
+  })
+
+  test('classifies "exceeded your current quota" as next-model (no retry)', () => {
+    const cls = classifyGeminiError(
+      new Error(
+        'API call failed: AI_APICallError: You exceeded your current quota, please check your plan and billing details.',
+      ),
+    )
+    expect(cls).toMatchInlineSnapshot(`
+      {
+        "kind": "next-model",
+      }
+    `)
+  })
+
+  test('classifies "not found for API version" (deprecated model) as next-model', () => {
+    const cls = classifyGeminiError(
+      new Error(
+        'API call failed: AI_APICallError: models/gemini-1.5-flash is not found for API version v1beta, or is not supported for generateContent.',
+      ),
+    )
+    expect(cls).toMatchInlineSnapshot(`
+      {
+        "kind": "next-model",
+      }
+    `)
+  })
+
+  test('classifies "API key not valid" as bail', () => {
+    const cls = classifyGeminiError(
+      new Error('API call failed: AI_APICallError: API key not valid. Please pass a valid API key.'),
+    )
+    expect(cls).toMatchInlineSnapshot(`
+      {
+        "kind": "bail",
+      }
+    `)
+  })
+
+  test('classifies unknown errors as next-model (degrade gracefully)', () => {
+    const cls = classifyGeminiError(new Error('something weird happened'))
+    expect(cls).toMatchInlineSnapshot(`
+      {
+        "kind": "next-model",
+      }
+    `)
+  })
+})
+
+describe('GEMINI_TRANSCRIPTION_MODELS chain', () => {
+  test('starts with the high-quota free-tier model', () => {
+    expect(GEMINI_TRANSCRIPTION_MODELS[0]).toMatchInlineSnapshot(`"gemini-3.1-flash-lite"`)
+  })
+
+  test('chain is non-empty and only contains audio-capable chat models', () => {
+    expect(GEMINI_TRANSCRIPTION_MODELS.length).toBeGreaterThan(0)
+    for (const model of GEMINI_TRANSCRIPTION_MODELS) {
+      // No paid-only models (`limit: 0` on free tier) and no deprecated v1beta models.
+      expect(model).not.toBe('gemini-2.5-pro')
+      expect(model).not.toBe('gemini-2.0-flash')
+      expect(model).not.toBe('gemini-1.5-flash')
+      // All entries are flash variants that accept audio file parts.
+      expect(model).toMatch(/^gemini-/)
+    }
   })
 })
 

--- a/cli/src/voice.ts
+++ b/cli/src/voice.ts
@@ -4,7 +4,10 @@
 //   - OpenAI: gpt-4o-audio-preview via .chat() (Chat Completions API). MUST use .chat()
 //     because the default Responses API doesn't support audio file parts. The Chat
 //     Completions handler converts audio/mpeg file parts to input_audio format.
-//   - Gemini: gemini-2.5-flash natively accepts audio file parts in chat.
+//   - Gemini: walks GEMINI_TRANSCRIPTION_MODELS in order. The default chain starts
+//     with `gemini-3.1-flash-lite` (500 RPD on free tier) then rotates through higher
+//     quality models. Errors are classified (overload vs quota vs deprecated) so we
+//     retry transient overloads but skip exhausted/deprecated models permanently.
 // Calls model.doGenerate() directly without the `ai` npm package.
 // Uses errore for type-safe error handling.
 
@@ -34,6 +37,74 @@ import {
 } from './errors.js'
 
 const voiceLogger = createLogger(LogPrefix.VOICE)
+
+// Gemini fallback chain for transcription. Ordered by free-tier friendliness first
+// (so the most common case — users without billing enabled — still works) but every
+// model in this list accepts audio file parts in chat. Override per-call via the
+// `transcriptionModels` parameter to `transcribeAudio`.
+//
+// Free-tier daily request quotas (as of 2026-05):
+//   - gemini-3.1-flash-lite: 500 RPD  ← primary, proven on real audio
+//   - gemini-3.5-flash:       20 RPD  ← higher quality, lower quota
+//   - gemini-2.5-flash:       20 RPD  ← legacy default, retained for paid users
+//
+// Excluded on purpose: `gemini-2.5-pro` and `gemini-2.0-flash` have `limit: 0` on the
+// free tier (paid-only), and `gemini-1.5-flash` is deprecated on the v1beta endpoint.
+export const GEMINI_TRANSCRIPTION_MODELS: readonly string[] = [
+  'gemini-3.1-flash-lite',
+  'gemini-3.5-flash',
+  'gemini-2.5-flash',
+] as const
+
+/**
+ * Classification of a Gemini API error after a transcription attempt failed.
+ * Drives the per-model retry loop inside `transcribeWithGeminiFallback`.
+ */
+export type GeminiErrorClass =
+  | { kind: 'retry-then-next'; delayMs: number }
+  | { kind: 'next-model' }
+  | { kind: 'bail' }
+
+/**
+ * Inspect an AI SDK error from `model.doGenerate()` and decide what to do next.
+ * The AI SDK swallows the structured Google error code, so we pattern-match on the
+ * message string — these patterns mirror the real-world responses observed when
+ * running against the free tier with quota exhausted, paid-only models, and
+ * deprecated v1beta model IDs.
+ */
+export function classifyGeminiError(err: Error): GeminiErrorClass {
+  const msg = err.message.toLowerCase()
+
+  // Bad API key — no model in the chain will help.
+  if (msg.includes('api key not valid') || msg.includes('invalid api key')) {
+    return { kind: 'bail' }
+  }
+
+  // Model ID not recognised by the v1beta endpoint (deprecated or typo). Skip it
+  // for the rest of this transcription run.
+  if (msg.includes('is not found for api version') || msg.includes('not supported for generatecontent')) {
+    return { kind: 'next-model' }
+  }
+
+  // Quota exhausted — daily cap hit OR model is paid-only (`limit: 0`). Either way
+  // retrying this model right now won't help; move to the next.
+  if (
+    msg.includes('exceeded your current quota') ||
+    msg.includes('resource_exhausted') ||
+    msg.includes('quota exceeded')
+  ) {
+    return { kind: 'next-model' }
+  }
+
+  // Transient model overload — gemini occasionally returns this even when quota is
+  // healthy. Worth one retry with a small backoff before moving on.
+  if (msg.includes('experiencing high demand') || msg.includes('overloaded') || msg.includes('unavailable')) {
+    return { kind: 'retry-then-next', delayMs: 3000 }
+  }
+
+  // Anything else is treated as fatal for this model but not for the chain.
+  return { kind: 'next-model' }
+}
 
 // OpenAI input_audio only supports wav and mp3. Other formats (OGG Opus, etc)
 // must be converted before sending.
@@ -439,24 +510,127 @@ export type TranscriptionProvider = 'openai' | 'gemini'
  * OpenAI: must use .chat() to get the Chat Completions API model, because the
  * default callable (Responses API) doesn't support audio file parts.
  * Gemini: language models natively accept audio in chat.
+ *
+ * For Gemini, the model defaults to the first entry in `GEMINI_TRANSCRIPTION_MODELS`.
+ * The higher-level `transcribeAudio` walks the full chain — call this helper directly
+ * only when you want a single-shot model without fallback.
  */
 export function createTranscriptionModel({
   apiKey,
   provider,
+  modelId,
 }: {
   apiKey: string
   provider?: TranscriptionProvider
+  /** Override the model ID. Defaults to gpt-4o-audio-preview (OpenAI) or the head of GEMINI_TRANSCRIPTION_MODELS (Gemini). */
+  modelId?: string
 }): LanguageModelV3 {
   const resolvedProvider: TranscriptionProvider =
     provider || (apiKey.startsWith('sk-') ? 'openai' : 'gemini')
 
   if (resolvedProvider === 'openai') {
     const openai = createOpenAI({ apiKey })
-    return openai.chat('gpt-4o-audio-preview')
+    return openai.chat(modelId || 'gpt-4o-audio-preview')
   }
 
   const google = createGoogleGenerativeAI({ apiKey })
-  return google('gemini-2.5-flash')
+  return google(modelId || GEMINI_TRANSCRIPTION_MODELS[0]!)
+}
+
+/**
+ * Walk the Gemini fallback chain, running `runTranscriptionOnce` against each model
+ * in order. Per-model behaviour is driven by `classifyGeminiError`:
+ *
+ *   - `retry-then-next`  → one retry after `delayMs`, then move to the next model
+ *   - `next-model`       → skip to the next model immediately (no retry)
+ *   - `bail`             → return the error, stop walking the chain
+ *
+ * Returns the first successful transcription or the last error seen.
+ */
+async function transcribeWithGeminiFallback({
+  apiKey,
+  models,
+  prompt,
+  audioBase64,
+  mediaType,
+  temperature,
+  agentNames,
+}: {
+  apiKey: string
+  models: readonly string[]
+  prompt: string
+  audioBase64: string
+  mediaType: string
+  temperature: number
+  agentNames?: string[]
+}): Promise<TranscriptionLoopError | TranscriptionResult> {
+  if (models.length === 0) {
+    return new TranscriptionError({ reason: 'No Gemini models configured in fallback chain' })
+  }
+
+  const google = createGoogleGenerativeAI({ apiKey })
+  let lastError: TranscriptionLoopError | null = null
+
+  for (const modelId of models) {
+    voiceLogger.log(`Trying Gemini model: ${modelId}`)
+    const model = google(modelId)
+
+    // Up to 2 attempts per model — second attempt only fires for transient overloads.
+    let movedOn = false
+    for (let attempt = 1; attempt <= 2 && !movedOn; attempt++) {
+      const result = await runTranscriptionOnce({
+        model,
+        provider: 'gemini',
+        prompt,
+        audioBase64,
+        mediaType,
+        temperature,
+        agentNames,
+      })
+
+      if (!(result instanceof Error)) {
+        if (lastError) {
+          voiceLogger.log(`Gemini fallback recovered on ${modelId} after earlier failures`)
+        }
+        return result
+      }
+
+      lastError = result
+      const classification = classifyGeminiError(result)
+
+      if (classification.kind === 'bail') {
+        voiceLogger.error(`Gemini fallback bailing: ${result.message}`)
+        return result
+      }
+
+      if (classification.kind === 'next-model') {
+        voiceLogger.log(
+          `  ${modelId} failed (${result.message.split('\n')[0]!.slice(0, 120)}) — next model`,
+        )
+        movedOn = true
+        break
+      }
+
+      // retry-then-next
+      if (attempt < 2) {
+        voiceLogger.log(
+          `  ${modelId} overloaded, retrying in ${classification.delayMs}ms`,
+        )
+        await new Promise<void>((r) => {
+          setTimeout(r, classification.delayMs)
+        })
+        continue
+      }
+      voiceLogger.log(`  ${modelId} still overloaded after retry — next model`)
+    }
+  }
+
+  return (
+    lastError ||
+    new TranscriptionError({
+      reason: 'No Gemini models in fallback chain succeeded',
+    })
+  )
 }
 
 export async function transcribeAudio({
@@ -471,6 +645,7 @@ export async function transcribeAudio({
   currentSessionContext,
   lastSessionContext,
   agents,
+  transcriptionModels,
 }: {
   audio: Buffer | Uint8Array | ArrayBuffer | string
   prompt?: string
@@ -485,6 +660,11 @@ export async function transcribeAudio({
   lastSessionContext?: string
   /** Available agents for agent selection via voice. Names used as enum values in the tool schema. */
   agents?: Array<{ name: string; description?: string }>
+  /**
+   * Override the Gemini fallback chain. Defaults to `GEMINI_TRANSCRIPTION_MODELS`.
+   * Ignored when an explicit `model` is passed or when the provider is OpenAI.
+   */
+  transcriptionModels?: readonly string[]
 }): Promise<TranscribeAudioErrors | TranscriptionResult> {
   const apiKey =
     apiKeyParam || process.env.OPENAI_API_KEY || process.env.GEMINI_API_KEY
@@ -503,8 +683,11 @@ export async function transcribeAudio({
     return 'gemini'
   })()
 
-  const languageModel: LanguageModelV3 =
-    model || createTranscriptionModel({ apiKey: apiKey!, provider: resolvedProvider })
+  // When the caller provides their own `model`, honour it as a single-shot (no
+  // fallback chain). Otherwise we lazily construct the model — for Gemini that
+  // means walking GEMINI_TRANSCRIPTION_MODELS, so we defer model creation until
+  // after audio conversion below.
+  const explicitModel: LanguageModelV3 | null = model || null
 
   // Convert audio to Buffer for potential format conversion
   const audioBuffer: Buffer = (() => {
@@ -631,13 +814,36 @@ Note: "critique" is a CLI tool for showing diffs in the browser.`
     ?.map((a) => { return a.name })
     .filter((name) => { return name.length > 0 })
 
+  const finalAgentNames = agentNames && agentNames.length > 0 ? agentNames : undefined
+  const finalTemperature = temperature ?? 0.3
+
+  // Gemini + no explicit model = walk the fallback chain. Every other case is a
+  // single-shot call against whatever model the caller resolved.
+  if (resolvedProvider === 'gemini' && !explicitModel) {
+    return transcribeWithGeminiFallback({
+      apiKey: apiKey!,
+      models: transcriptionModels && transcriptionModels.length > 0
+        ? transcriptionModels
+        : GEMINI_TRANSCRIPTION_MODELS,
+      prompt: transcriptionPrompt,
+      audioBase64: finalAudioBase64,
+      mediaType,
+      temperature: finalTemperature,
+      agentNames: finalAgentNames,
+    })
+  }
+
+  const languageModel: LanguageModelV3 =
+    explicitModel ||
+    createTranscriptionModel({ apiKey: apiKey!, provider: resolvedProvider })
+
   return runTranscriptionOnce({
     model: languageModel,
     prompt: transcriptionPrompt,
     audioBase64: finalAudioBase64,
     mediaType,
-    temperature: temperature ?? 0.3,
-    agentNames: agentNames && agentNames.length > 0 ? agentNames : undefined,
+    temperature: finalTemperature,
+    agentNames: finalAgentNames,
     provider: resolvedProvider,
   })
 }


### PR DESCRIPTION
## Why

Two intertwined failures of the voice transcription path, exposed by a real-world incident:

1. **No fallback chain** — `voice.ts` hardcodes `gemini-2.5-flash`. On Gemini free tier that's a single 20-RPD bucket; once exhausted, voice messages fail with no recovery.
2. **No retry UX** — when transcription fails, the user has no way to re-run it short of asking an agent to manually re-fetch the Discord attachment and replay the transcription pipeline.

During the incident, the agent tried 5 different Gemini models in 4 retry scripts before stumbling onto `gemini-3.1-flash-lite` via a user-provided AI Studio dashboard screenshot. Every model except 3.1-flash-lite was a dead end:

| Model | Why it failed |
|---|---|
| `gemini-2.5-pro` | `limit: 0` on free tier — paid only |
| `gemini-2.5-flash` | Daily 20-RPD quota exhausted |
| `gemini-2.0-flash` | `limit: 0` on free tier — paid only |
| `gemini-1.5-flash` | Deprecated on `v1beta` endpoint |
| `gemini-3.5-flash` | Transient "high demand" overload |
| **`gemini-3.1-flash-lite`** | Worked — 500 RPD free quota |

The exact quota metric blocking the calls (`GenerateRequestsPerDayPerProjectPerModel-FreeTier`) was only visible via the raw REST endpoint — the AI SDK swallows it. Text generation still worked because it lives in a different rate-limit bucket than audio/multimodal.

## What changed

### Commit 1: `voice: add Gemini fallback chain + error classification`

```
voice.ts
├── GEMINI_TRANSCRIPTION_MODELS         ← new ordered fallback chain
├── classifyGeminiError                 ← new helper, pattern-matches error msg
├── createTranscriptionModel({modelId}) ← new optional override
├── transcribeWithGeminiFallback        ← new internal walker
└── transcribeAudio({transcriptionModels?}) ← routes to walker when no model passed
```

Default chain:

```ts
export const GEMINI_TRANSCRIPTION_MODELS = [
  'gemini-3.1-flash-lite',   // 500 RPD free, proven on real audio
  'gemini-3.5-flash',        //  20 RPD free, higher quality
  'gemini-2.5-flash',        //  20 RPD free, legacy default
] as const
```

Excluded on purpose: `gemini-2.5-pro`, `gemini-2.0-flash` (`limit: 0` on free tier), `gemini-1.5-flash` (deprecated on v1beta).

Error classifier:

```ts
type GeminiErrorClass =
  | { kind: 'retry-then-next', delayMs: number }   // transient overload → 1 retry
  | { kind: 'next-model' }                          // quota exhausted / deprecated
  | { kind: 'bail' }                                // bad API key
```

### Commit 2: `voice: add retry-transcription button to failure messages`

Every "Transcription failed" message now includes a Retry button. The button's customId encodes `retry_transcription:<channelId>:<messageId>` so the handler can re-fetch the original Discord voice attachment and replay the full pipeline.

```
commands/retry-transcription.ts
├── buildRetryTranscriptionRow(message)        ← builds the button row
└── handleRetryTranscriptionButton(interaction) ← button click handler

voice-handler.ts
├── failure path (audio download)  ← now attaches retry row
└── failure path (transcription)   ← now attaches retry row

interaction-handler.ts
└── retry_transcription:* → handleRetryTranscriptionButton
```

The handler delegates back to `processVoiceAttachment` so the retry path is identical to the first attempt: same project context, same agent enum, same session-context awareness, same thread renaming. On repeated failure the new failure message gets another retry button — users can keep clicking until it succeeds or until they fix the underlying issue (API key, quota top-up, etc.).

Discord CDN URLs are signed and expire, so retry handles that case too by re-fetching the message via the Discord API, which regenerates a fresh URL.

### Behaviour matrix

| Caller pattern | Behaviour |
|---|---|
| `transcribeAudio({ apiKey })` (Gemini, no model) | **Walks the chain** (new) |
| `transcribeAudio({ apiKey, transcriptionModels })` (Gemini override) | Walks the custom chain |
| `transcribeAudio({ apiKey, model: google('x') })` | Single-shot (unchanged) |
| `transcribeAudio({ apiKey, provider: 'openai' })` | Single-shot (unchanged) |
| `createTranscriptionModel({ apiKey })` | Default model ID changed from `2.5-flash` → `3.1-flash-lite` |
| `createTranscriptionModel({ apiKey, modelId })` | Returns requested model (new) |
| Voice transcription fails | Failure message now has Retry button (new) |

## Tests

```
✓ src/voice.test.ts (22 tests) 8758ms
   ✓ transcribeAudio with real API > transcribes with Gemini  8654ms
✓ src/commands/retry-transcription.test.ts (2 tests)

Test Files  2 passed (2)
     Tests  24 passed (24)
```

- 5 unit tests for each `classifyGeminiError` branch (overload, quota, deprecated, bad key, unknown)
- 2 tests pinning the chain shape (head model, no paid-only/deprecated entries)
- 2 tests for the retry button customId encoding + Discord 100-char budget
- Existing real-API integration test now exercises the fallback path end-to-end against the live Gemini API

## Diff previews

- Chain commit: https://critique.work/v/2a0d15d0e9128b743582398cad11cac4
- Retry button commit: https://critique.work/v/c83045eea4017ba07213823bf39b976a

## Reference

Original incident: voice message → transcription failed with "high demand" → agent walked through 5 dead-end models before finding `gemini-3.1-flash-lite` via an AI Studio dashboard screenshot, then had to manually save the audio file because there was no retry button to surface the same flow next time.