### PR TITLE
fix: use remote default branch as worktree base instead of HEAD

### DIFF
--- a/cli/src/commands/new-worktree.ts
+++ b/cli/src/commands/new-worktree.ts
@@ -281,7 +281,8 @@ export async function createWorktreeInBackground({
       editStatus(
         `🌳 **Worktree: ${worktreeName}**\n` +
           `📁 \`${worktreeResult.directory}\`\n` +
-          `🌿 Branch: \`${worktreeResult.branch}\``,
+          `🌿 Branch: \`${worktreeResult.branch}\`\n` +
+          `🔀 Base: \`${worktreeResult.baseBranch}\``,
       )
       await editChain
 

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -522,6 +522,7 @@ async function validateSubmodulePointers(
 type WorktreeResult = {
   directory: string
   branch: string
+  baseBranch: string
 }
 
 async function resolveDefaultWorktreeTarget(
@@ -658,7 +659,7 @@ export async function createWorktreeWithSubmodules({
     })
   }
 
-  return { directory: worktreeDir, branch: name }
+  return { directory: worktreeDir, branch: name, baseBranch: targetRef }
 }
 
 // ─── Worktree merge ──────────────────────────────────────────────────────────

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -528,7 +528,11 @@ type WorktreeResult = {
 async function resolveDefaultWorktreeTarget(
   directory: string,
 ): Promise<string> {
-  return getDefaultBranch(directory)
+  const branch = await getDefaultBranch(directory)
+  await git(directory, `fetch origin ${branch}`, { timeout: 30_000 }).catch(
+    () => {},
+  )
+  return `origin/${branch}`
 }
 
 /**

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -527,7 +527,7 @@ type WorktreeResult = {
 async function resolveDefaultWorktreeTarget(
   directory: string,
 ): Promise<string> {
-  return 'HEAD'
+  return getDefaultBranch(directory)
 }
 
 /**


### PR DESCRIPTION
When creating worktrees without an explicit `--base-branch`, `resolveDefaultWorktreeTarget` returned `HEAD` — meaning the worktree was based on whatever commit the main checkout happened to be on.

This caused auto-worktrees (e.g., via `/toggle-worktrees` or `--use-worktrees`) to potentially branch from an outdated or unrelated commit, rather than from the repository's default branch.

The fix changes `resolveDefaultWorktreeTarget` to call `getDefaultBranch(directory)`, which:
1. Reads `refs/remotes/origin/HEAD` to detect the remote's default branch
2. Falls back to `"main"` if that ref is unavailable

This only affects auto-created worktrees (no explicit `baseBranch`). The `/new-worktree` command's `--base-branch` option continues to work as before.
