### PR TITLE
fix: pass OpenCode server auth credentials to SDK client

### DIFF
--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -913,10 +913,19 @@ function getOrCreateClient({
       timeout: false,
     })
 
+  const serverPassword = process.env.OPENCODE_SERVER_PASSWORD
+  const serverUsername = process.env.OPENCODE_SERVER_USERNAME || 'opencode'
+  const authHeaders: Record<string, string> = {}
+  if (serverPassword) {
+    const encoded = Buffer.from(`${serverUsername}:${serverPassword}`).toString('base64')
+    authHeaders['Authorization'] = `Basic ${encoded}`
+  }
+
   const client = createOpencodeClient({
     baseUrl,
     directory,
     fetch: fetchWithTimeout as typeof fetch,
+    headers: authHeaders,
   })
   clientCache.set(directory, client)
   return client


### PR DESCRIPTION
Fix: Pass OpenCode server auth credentials to SDK client

Problem：
When OPENCODE_SERVER_PASSWORD is set in the environment for kimaki, the opencode serve endpoint enables Basic authentication. Kimaki spawns opencode serve as a child process, which inherits these environment variables and requires auth. However, the SDK client was not sending authentication headers, causing all requests (session creation, event subscription, prompt submission) to fail, such as no data return when create session.
Users running kimaki from within an OpenCode session, or with OPENCODE_SERVER_PASSWORD set in their shell environment, would experience silent failures — sessions could not be created and conversations would hang indefinitely showing "is typing".

Fix: 
Read OPENCODE_SERVER_PASSWORD and OPENCODE_SERVER_USERNAME from the environment in getOrCreateClient() and attach a Basic Authorization header to the SDK client configuration. This ensures all SDK requests are properly authenticated.
- If OPENCODE_SERVER_PASSWORD is set → attach Authorization: Basic <base64> header
- If not set → no auth header, behavior unchanged (server runs unsecured)

Changes
- cli/src/opencode.ts: Add auth header construction in getOrCreateClient() (+9 lines)