### PR TITLE
feat(cli): add configurable permission timeout

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,12 +9,7 @@ import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { createLogger, formatErrorWithStack, initLogFile, LogPrefix } from './logger.js'
 import { initSentry } from './sentry.js'
-import {
-  setDataDir,
-  setProjectsDir,
-  getDataDir,
-  getProjectsDir,
-} from './config.js'
+import { setDataDir, setProjectsDir, getDataDir, getProjectsDir } from './config.js'
 import { getCurrentVersion } from './upgrade.js'
 import { store } from './store.js'
 import multioauthCommands from './commands/multioauth.js'
@@ -26,11 +21,7 @@ import sendCommands from './cli-commands/send.js'
 import sessionCommands from './cli-commands/session.js'
 import taskCommands from './cli-commands/task.js'
 import userCommands from './cli-commands/user.js'
-import {
-  EXIT_NO_RESTART,
-  printDiscordInstallUrlAndExit,
-  run,
-} from './cli-runner.js'
+import { EXIT_NO_RESTART, printDiscordInstallUrlAndExit, run } from './cli-runner.js'
 
 const cliLogger = createLogger(LogPrefix.CLI)
 const cli = goke('kimaki')
@@ -41,14 +32,8 @@ process.title = 'kimaki'
 cli
   .command('', 'Set up and run the Kimaki Discord bot')
   .option('--restart-onboarding', 'Prompt for new credentials even if saved')
-  .option(
-    '--add-channels',
-    'Select OpenCode projects to create Discord channels before starting',
-  )
-  .option(
-    '--data-dir <path>',
-    'Data directory for config and database (default: ~/.kimaki)',
-  )
+  .option('--add-channels', 'Select OpenCode projects to create Discord channels before starting')
+  .option('--data-dir <path>', 'Data directory for config and database (default: ~/.kimaki)')
   .option(
     '--projects-dir <path>',
     'Directory where new projects are created (default: <data-dir>/projects)',
@@ -58,34 +43,23 @@ cli
     '--use-worktrees',
     'Create git worktrees for all new sessions started from channel messages',
   )
-  .option(
-    '--enable-voice-channels',
-    'Create voice channels for projects (disabled by default)',
-  )
+  .option('--enable-voice-channels', 'Create voice channels for projects (disabled by default)')
   .option(
     '--verbosity <level>',
     'Default verbosity for all channels (tools_and_text, text_and_essential_tools, or text_only)',
   )
-  .option(
-    '--mention-mode',
-    'Bot only responds when @mentioned (default for all channels)',
-  )
-  .option(
-    '--no-critique',
-    'Disable automatic diff upload to critique.work in system prompts',
-  )
-  .option(
-    '--auto-restart',
-    'Automatically restart the bot on crash or OOM kill',
-  )
+  .option('--mention-mode', 'Bot only responds when @mentioned (default for all channels)')
+  .option('--no-critique', 'Disable automatic diff upload to critique.work in system prompts')
+  .option('--auto-restart', 'Automatically restart the bot on crash or OOM kill')
   .option(
     '--allow-all-users',
     'Allow all Discord users to start sessions without needing Kimaki role or admin permissions (no-kimaki role still blocks)',
   )
   .option(
-    '--disable-sync',
-    'Disable background sync of external OpenCode sessions into Discord',
+    '--permission-timeout-minutes <minutes>',
+    'Permission prompt timeout in minutes before auto-rejecting (default: 10)',
   )
+  .option('--disable-sync', 'Disable background sync of external OpenCode sessions into Discord')
   .option('--no-sentry', 'Disable Sentry error reporting')
   .option(
     '--gateway',
@@ -135,6 +109,7 @@ cli
       mentionMode?: boolean
       noCritique?: boolean
       allowAllUsers?: boolean
+      permissionTimeoutMinutes?: string
       disableSync?: boolean
       autoRestart?: boolean
       noSentry?: boolean
@@ -153,8 +128,8 @@ cli
       if (process.env.KIMAKI_OPENCODE_PROCESS && !usesDifferentLockPort) {
         cliLogger.error(
           'Cannot run `kimaki` inside an OpenCode session — it would kill the already-running bot process.\n' +
-          'Only one kimaki bot can run at a time (they share a lock port).\n' +
-          'Set KIMAKI_LOCK_PORT to a different port for an isolated dev process, or use `kimaki send`, `kimaki session`, and other subcommands instead.',
+            'Only one kimaki bot can run at a time (they share a lock port).\n' +
+            'Set KIMAKI_LOCK_PORT to a different port for an isolated dev process, or use `kimaki send`, `kimaki session`, and other subcommands instead.',
         )
         process.exit(EXIT_NO_RESTART)
       }
@@ -240,6 +215,21 @@ cli
           }
         }
 
+        // --permission-timeout-minutes validation
+        const permissionTimeoutMs = (() => {
+          if (!options.permissionTimeoutMinutes) {
+            return undefined
+          }
+          const parsed = Number.parseInt(options.permissionTimeoutMinutes, 10)
+          if (!Number.isFinite(parsed) || parsed <= 0) {
+            cliLogger.error(
+              `Invalid permission timeout: ${options.permissionTimeoutMinutes}. Must be a positive number of minutes.`,
+            )
+            process.exit(EXIT_NO_RESTART)
+          }
+          return parsed * 60 * 1000
+        })()
+
         store.setState({
           ...(defaultVerbosity && {
             defaultVerbosity,
@@ -247,6 +237,7 @@ cli
           ...(options.mentionMode && { defaultMentionMode: true }),
           ...(options.noCritique && { critiqueEnabled: false }),
           ...(options.allowAllUsers && { allowAllUsers: true }),
+          ...(permissionTimeoutMs !== undefined && { permissionTimeoutMs }),
           ...(options.disableSync && { syncEnabled: false }),
           ...(enabledSkills.length > 0 && { enabledSkills }),
           ...(disabledSkills.length > 0 && { disabledSkills }),
@@ -259,9 +250,7 @@ cli
           )
         }
         if (disabledSkills.length > 0) {
-          cliLogger.log(
-            `Skill blacklist enabled: [${disabledSkills.join(', ')}] will be hidden`,
-          )
+          cliLogger.log(`Skill blacklist enabled: [${disabledSkills.join(', ')}] will be hidden`)
         }
 
         if (options.allowAllUsers) {
@@ -270,18 +259,18 @@ cli
           )
         }
 
+        if (permissionTimeoutMs !== undefined) {
+          cliLogger.log(`Permission timeout set to ${options.permissionTimeoutMinutes} minutes`)
+        }
+
         if (options.verbosity) {
           cliLogger.log(`Default verbosity: ${options.verbosity}`)
         }
         if (options.mentionMode) {
-          cliLogger.log(
-            'Default mention mode: enabled (bot only responds when @mentioned)',
-          )
+          cliLogger.log('Default mention mode: enabled (bot only responds when @mentioned)')
         }
         if (options.noCritique) {
-          cliLogger.log(
-            'Critique disabled: diffs will not be auto-uploaded to critique.work',
-          )
+          cliLogger.log('Critique disabled: diffs will not be auto-uploaded to critique.work')
         }
         if (options.disableSync) {
           cliLogger.log(

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,7 +9,12 @@ import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { createLogger, formatErrorWithStack, initLogFile, LogPrefix } from './logger.js'
 import { initSentry } from './sentry.js'
-import { setDataDir, setProjectsDir, getDataDir, getProjectsDir } from './config.js'
+import {
+  setDataDir,
+  setProjectsDir,
+  getDataDir,
+  getProjectsDir,
+} from './config.js'
 import { getCurrentVersion } from './upgrade.js'
 import { store } from './store.js'
 import multioauthCommands from './commands/multioauth.js'
@@ -21,7 +26,11 @@ import sendCommands from './cli-commands/send.js'
 import sessionCommands from './cli-commands/session.js'
 import taskCommands from './cli-commands/task.js'
 import userCommands from './cli-commands/user.js'
-import { EXIT_NO_RESTART, printDiscordInstallUrlAndExit, run } from './cli-runner.js'
+import {
+  EXIT_NO_RESTART,
+  printDiscordInstallUrlAndExit,
+  run,
+} from './cli-runner.js'
 
 const cliLogger = createLogger(LogPrefix.CLI)
 const cli = goke('kimaki')
@@ -32,8 +41,14 @@ process.title = 'kimaki'
 cli
   .command('', 'Set up and run the Kimaki Discord bot')
   .option('--restart-onboarding', 'Prompt for new credentials even if saved')
-  .option('--add-channels', 'Select OpenCode projects to create Discord channels before starting')
-  .option('--data-dir <path>', 'Data directory for config and database (default: ~/.kimaki)')
+  .option(
+    '--add-channels',
+    'Select OpenCode projects to create Discord channels before starting',
+  )
+  .option(
+    '--data-dir <path>',
+    'Data directory for config and database (default: ~/.kimaki)',
+  )
   .option(
     '--projects-dir <path>',
     'Directory where new projects are created (default: <data-dir>/projects)',
@@ -43,14 +58,26 @@ cli
     '--use-worktrees',
     'Create git worktrees for all new sessions started from channel messages',
   )
-  .option('--enable-voice-channels', 'Create voice channels for projects (disabled by default)')
+  .option(
+    '--enable-voice-channels',
+    'Create voice channels for projects (disabled by default)',
+  )
   .option(
     '--verbosity <level>',
     'Default verbosity for all channels (tools_and_text, text_and_essential_tools, or text_only)',
   )
-  .option('--mention-mode', 'Bot only responds when @mentioned (default for all channels)')
-  .option('--no-critique', 'Disable automatic diff upload to critique.work in system prompts')
-  .option('--auto-restart', 'Automatically restart the bot on crash or OOM kill')
+  .option(
+    '--mention-mode',
+    'Bot only responds when @mentioned (default for all channels)',
+  )
+  .option(
+    '--no-critique',
+    'Disable automatic diff upload to critique.work in system prompts',
+  )
+  .option(
+    '--auto-restart',
+    'Automatically restart the bot on crash or OOM kill',
+  )
   .option(
     '--allow-all-users',
     'Allow all Discord users to start sessions without needing Kimaki role or admin permissions (no-kimaki role still blocks)',
@@ -59,7 +86,10 @@ cli
     '--permission-timeout-minutes <minutes>',
     'Permission prompt timeout in minutes before auto-rejecting (default: 10)',
   )
-  .option('--disable-sync', 'Disable background sync of external OpenCode sessions into Discord')
+  .option(
+    '--disable-sync',
+    'Disable background sync of external OpenCode sessions into Discord',
+  )
   .option('--no-sentry', 'Disable Sentry error reporting')
   .option(
     '--gateway',
@@ -128,8 +158,8 @@ cli
       if (process.env.KIMAKI_OPENCODE_PROCESS && !usesDifferentLockPort) {
         cliLogger.error(
           'Cannot run `kimaki` inside an OpenCode session — it would kill the already-running bot process.\n' +
-            'Only one kimaki bot can run at a time (they share a lock port).\n' +
-            'Set KIMAKI_LOCK_PORT to a different port for an isolated dev process, or use `kimaki send`, `kimaki session`, and other subcommands instead.',
+          'Only one kimaki bot can run at a time (they share a lock port).\n' +
+          'Set KIMAKI_LOCK_PORT to a different port for an isolated dev process, or use `kimaki send`, `kimaki session`, and other subcommands instead.',
         )
         process.exit(EXIT_NO_RESTART)
       }
@@ -215,6 +245,7 @@ cli
           }
         }
 
+
         // --permission-timeout-minutes validation
         const permissionTimeoutMs = (() => {
           if (!options.permissionTimeoutMinutes) {
@@ -229,7 +260,6 @@ cli
           }
           return parsed * 60 * 1000
         })()
-
         store.setState({
           ...(defaultVerbosity && {
             defaultVerbosity,
@@ -250,7 +280,9 @@ cli
           )
         }
         if (disabledSkills.length > 0) {
-          cliLogger.log(`Skill blacklist enabled: [${disabledSkills.join(', ')}] will be hidden`)
+          cliLogger.log(
+            `Skill blacklist enabled: [${disabledSkills.join(', ')}] will be hidden`,
+          )
         }
 
         if (options.allowAllUsers) {
@@ -260,17 +292,23 @@ cli
         }
 
         if (permissionTimeoutMs !== undefined) {
-          cliLogger.log(`Permission timeout set to ${options.permissionTimeoutMinutes} minutes`)
+          cliLogger.log(
+            `Permission timeout set to ${options.permissionTimeoutMinutes} minutes`,
+          )
         }
 
         if (options.verbosity) {
           cliLogger.log(`Default verbosity: ${options.verbosity}`)
         }
         if (options.mentionMode) {
-          cliLogger.log('Default mention mode: enabled (bot only responds when @mentioned)')
+          cliLogger.log(
+            'Default mention mode: enabled (bot only responds when @mentioned)',
+          )
         }
         if (options.noCritique) {
-          cliLogger.log('Critique disabled: diffs will not be auto-uploaded to critique.work')
+          cliLogger.log(
+            'Critique disabled: diffs will not be auto-uploaded to critique.work',
+          )
         }
         if (options.disableSync) {
           cliLogger.log(

--- a/cli/src/commands/permissions.ts
+++ b/cli/src/commands/permissions.ts
@@ -13,6 +13,7 @@ import {
 import crypto from 'node:crypto'
 import type { OpencodeClient, PermissionRequest } from '@opencode-ai/sdk/v2'
 import { getOpencodeClient } from '../opencode.js'
+import { getPermissionTimeoutMs } from '../config.js'
 import { NOTIFY_MESSAGE_FLAGS } from '../discord-utils.js'
 import { createLogger, LogPrefix } from '../logger.js'
 
@@ -53,13 +54,7 @@ async function resumeSessionIfIdleAfterPermission({
   return true
 }
 
-function wildcardMatch({
-  value,
-  pattern,
-}: {
-  value: string
-  pattern: string
-}): boolean {
+function wildcardMatch({ value, pattern }: { value: string; pattern: string }): boolean {
   let escapedPattern = pattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*/g, '.*')
@@ -110,11 +105,27 @@ type PendingPermissionContext = {
 
 // Store pending permission contexts by hash.
 // TTL prevents unbounded growth if user never clicks a permission button.
-const PERMISSION_CONTEXT_TTL_MS = 10 * 60 * 1000
-export const pendingPermissionContexts = new Map<
-  string,
-  PendingPermissionContext
->()
+// Configurable via --permission-timeout-minutes CLI flag or KIMAKI_PERMISSION_TIMEOUT_MINUTES env var.
+function getTtlMs(): number {
+  const envRaw = process.env['KIMAKI_PERMISSION_TIMEOUT_MINUTES']
+  if (envRaw) {
+    const parsed = Number.parseInt(envRaw, 10)
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed * 60 * 1000
+    }
+  }
+  return getPermissionTimeoutMs()
+}
+
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000)
+  if (minutes >= 1) {
+    return `${minutes} minute${minutes !== 1 ? 's' : ''}`
+  }
+  const seconds = Math.round(ms / 1_000)
+  return `${seconds} second${seconds !== 1 ? 's' : ''}`
+}
+export const pendingPermissionContexts = new Map<string, PendingPermissionContext>()
 
 // Atomic take: removes context from Map and returns it. Only the first caller
 // (TTL expiry or button click) wins, preventing duplicate permission replies.
@@ -156,6 +167,8 @@ export async function showPermissionButtons({
     contextHash,
   }
 
+  const ttlMs = getTtlMs()
+
   pendingPermissionContexts.set(contextHash, context)
   // Auto-reject on TTL expiry so the OpenCode session doesn't hang forever
   // waiting for a permission reply that will never come. Uses atomic take
@@ -167,9 +180,7 @@ export async function showPermissionButtons({
     }
     const client = getOpencodeClient(ctx.directory)
     if (client) {
-      const requestIds = ctx.requestIds.length > 0
-        ? ctx.requestIds
-        : [ctx.permission.id]
+      const requestIds = ctx.requestIds.length > 0 ? ctx.requestIds : [ctx.permission.id]
       await Promise.all(
         requestIds.map((requestId) => {
           return client.permission.reply({
@@ -181,12 +192,13 @@ export async function showPermissionButtons({
       ).catch((error) => {
         logger.error('Failed to auto-reject expired permission:', error)
       })
+      const durationStr = formatDuration(ttlMs)
       updatePermissionMessage({
         context: ctx,
-        status: '_Permission expired after 10 minutes and was rejected._',
+        status: `_Permission expired after ${durationStr} and was rejected._`,
       })
     }
-  }, PERMISSION_CONTEXT_TTL_MS).unref()
+  }, ttlMs).unref()
 
   const patternStr = compactPermissionPatterns(permission.patterns).join(', ')
 
@@ -292,9 +304,10 @@ export async function cancelPendingPermission(threadId: string): Promise<boolean
       continue
     }
 
-    const requestIds = pendingContext.requestIds.length > 0
-      ? pendingContext.requestIds
-      : [pendingContext.permission.id]
+    const requestIds =
+      pendingContext.requestIds.length > 0
+        ? pendingContext.requestIds
+        : [pendingContext.permission.id]
 
     const result = await Promise.all(
       requestIds.map((requestId) => {
@@ -304,13 +317,15 @@ export async function cancelPendingPermission(threadId: string): Promise<boolean
           reply: 'reject',
         })
       }),
-    ).then(() => {
-      return 'ok' as const
-    }).catch((error) => {
-      pendingPermissionContexts.set(pendingContext.contextHash, pendingContext)
-      logger.error('Failed to dismiss pending permission:', error)
-      return 'error' as const
-    })
+    )
+      .then(() => {
+        return 'ok' as const
+      })
+      .catch((error) => {
+        pendingPermissionContexts.set(pendingContext.contextHash, pendingContext)
+        logger.error('Failed to dismiss pending permission:', error)
+        return 'error' as const
+      })
 
     if (result === 'error') {
       continue
@@ -333,9 +348,7 @@ export async function cancelPendingPermission(threadId: string): Promise<boolean
 /**
  * Handle button click for permission.
  */
-export async function handlePermissionButton(
-  interaction: ButtonInteraction,
-): Promise<void> {
+export async function handlePermissionButton(interaction: ButtonInteraction): Promise<void> {
   const customId = interaction.customId
 
   // Extract action and hash from customId (e.g., "permission_once:abc123")
@@ -367,10 +380,7 @@ export async function handlePermissionButton(
     if (!permClient) {
       throw new Error('OpenCode server not found for directory')
     }
-    const requestIds =
-      context.requestIds.length > 0
-        ? context.requestIds
-        : [context.permission.id]
+    const requestIds = context.requestIds.length > 0 ? context.requestIds : [context.permission.id]
     await Promise.all(
       requestIds.map((requestId) => {
         return permClient.permission.reply({
@@ -414,9 +424,7 @@ export async function handlePermissionButton(
       status: resultText,
     })
 
-    logger.log(
-      `Permission ${context.permission.id} ${response} (${requestIds.length} request(s))`,
-    )
+    logger.log(`Permission ${context.permission.id} ${response} (${requestIds.length} request(s))`)
   } catch (error) {
     logger.error('Error handling permission:', error)
     await interaction.editReply({

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -73,6 +73,15 @@ export function setProjectsDir(dir: string): void {
   store.setState({ projectsDir: resolvedDir })
 }
 
+/**
+ * Get the permission button timeout in milliseconds.
+ * How long permission buttons remain active before auto-rejecting.
+ * Defaults to 10 minutes (600000ms).
+ */
+export function getPermissionTimeoutMs(): number {
+  return store.getState().permissionTimeoutMs
+}
+
 export type { RegisteredUserCommand } from './store.js'
 
 const DEFAULT_LOCK_PORT = 29988

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -94,6 +94,13 @@ export type KimakiState = {
   // Read by: discord-utils.ts hasKimakiBotPermission().
   allowAllUsers: boolean
 
+  // Permission button TTL in milliseconds. When a permission prompt is shown
+  // to the user, this is how long the buttons remain active before the
+  // permission is automatically rejected. Defaults to 10 minutes.
+  // Changes: set once at startup from --permission-timeout CLI flag.
+  // Read by: commands/permissions.ts showPermissionButtons().
+  permissionTimeoutMs: number
+
   // Whether background sync of external OpenCode sessions is enabled.
   // When true (default), sessions started from the OpenCode CLI or TUI
   // are mirrored into Discord threads so they can be browsed, searched,
@@ -155,6 +162,7 @@ export const store = createStore<KimakiState>(() => ({
   disabledSkills: [],
   allowedMentions: ['users'],
   allowAllUsers: false,
+  permissionTimeoutMs: 10 * 60 * 1000,
   syncEnabled: true,
   discordBaseUrl: 'https://discord.com',
   gatewayToken: null,


### PR DESCRIPTION
Adds support for configuring the permission prompt timeout via `--permission-timeout-minutes <minutes>` CLI flag or `KIMAKI_PERMISSION_TIMEOUT_MINUTES` environment variable (default: 10 minutes).