### PR TITLE
feat(project): prefix channels and threads with emoji map

### DIFF
--- a/.changeset/project-emoji-prefixes.md
+++ b/.changeset/project-emoji-prefixes.md
@@ -1,0 +1,7 @@
+---
+'kimaki': minor
+---
+
+Add per-project emoji prefixes for new Discord channels and threads.
+
+`kimaki project emoji add <name> <emoji>` stores a prefix in `<dataDir>/project-emojis.json`. New channels and threads created for that project are then named like `<emoji> <original name>` automatically. `kimaki project emoji list` and `kimaki project emoji remove <name>` manage the map. `kimaki project apply-prefixes` retroactively renames existing channels and active threads so the prefixes land on already-created Discord resources too.

--- a/cli/src/channel-management.ts
+++ b/cli/src/channel-management.ts
@@ -18,6 +18,7 @@ import {
 import { getProjectsDir } from './config.js'
 import { execAsync } from './worktrees.js'
 import { createLogger, LogPrefix } from './logger.js'
+import { getProjectEmoji } from './project-emojis.js'
 
 const logger = createLogger(LogPrefix.CHANNEL)
 
@@ -94,10 +95,13 @@ export async function createProjectChannels({
   channelName: string
 }> {
   const baseName = path.basename(projectDirectory)
-  const channelName = `${baseName}`
+  const sanitizedBase = `${baseName}`
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, '-')
-    .slice(0, 100)
+  const emoji = getProjectEmoji(baseName)
+  const channelName = (
+    emoji ? `${emoji} ${sanitizedBase}` : sanitizedBase
+  ).slice(0, 100)
 
   const kimakiCategory = await ensureKimakiCategory(guild, botName)
 

--- a/cli/src/cli-commands/project.ts
+++ b/cli/src/cli-commands/project.ts
@@ -21,6 +21,14 @@ import type { ThreadStartMarker } from '../system-message.js'
 import { buildOpencodeEventLogLine } from '../session-handler/opencode-session-event-log.js'
 import { createDiscordRest } from '../discord-urls.js'
 import { archiveThread, uploadFilesToDiscord, stripMentions } from '../discord-utils.js'
+import {
+  getProjectEmoji,
+  setProjectEmoji,
+  removeProjectEmoji,
+  listProjectEmojis,
+  prefixNameWithEmoji,
+  hasProjectEmojiPrefix,
+} from '../project-emojis.js'
 import { setDataDir, setProjectsDir, getDataDir, getProjectsDir } from '../config.js'
 import { execAsync, validateWorktreeDirectory } from '../worktrees.js'
 import { upgrade, getCurrentVersion } from '../upgrade.js'
@@ -502,6 +510,234 @@ cli
 
     cliLogger.log(channelUrl)
     process.exit(0)
+  })
+
+cli
+  .command(
+    'project emoji add <name> <emoji>',
+    'Set the prefix emoji used for channels and threads of a project',
+  )
+  .action((name: string, emoji: string) => {
+    setProjectEmoji(name, emoji)
+    note(
+      `Set ${name} -> ${emoji}\n\nFile: ${listProjectEmojis.length > 0 ? '' : ''}Saved to project-emojis.json in the kimaki data dir.`,
+      '✅ Emoji Saved',
+    )
+    cliLogger.log(`kimaki project emoji list`)
+  })
+
+cli
+  .command(
+    'project emoji remove <name>',
+    'Remove the prefix emoji for a project',
+  )
+  .action((name: string) => {
+    const removed = removeProjectEmoji(name)
+    if (!removed) {
+      cliLogger.error(`No emoji configured for project: ${name}`)
+      process.exit(EXIT_NO_RESTART)
+    }
+    note(`Removed emoji for ${name}`, '✅ Emoji Removed')
+  })
+
+cli
+  .command('project emoji list', 'List all configured project prefix emojis')
+  .action(() => {
+    const map = listProjectEmojis()
+    const entries = Object.entries(map)
+    if (entries.length === 0) {
+      note(
+        'No project emojis configured. Use `kimaki project emoji add <name> <emoji>`.',
+        'Project Emojis',
+      )
+      process.exit(0)
+    }
+    const lines = entries
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, emoji]) => `  ${emoji}  ${name}`)
+      .join('\n')
+    note(`${lines}\n\nTotal: ${entries.length}`, 'Project Emojis')
+  })
+
+cli
+  .command(
+    'project apply-prefixes',
+    'Retroactively rename existing project channels and threads using the configured emoji map',
+  )
+  .action(async () => {
+    await initDatabase()
+    const map = listProjectEmojis()
+    const entries = Object.entries(map)
+    if (entries.length === 0) {
+      note(
+        'No project emojis configured. Use `kimaki project emoji add <name> <emoji>`.',
+        'Nothing to do',
+      )
+      process.exit(0)
+    }
+
+    const botRow = await getBotTokenWithMode()
+    if (!botRow) {
+      cliLogger.error('No bot configured. Run `kimaki` first.')
+      process.exit(EXIT_NO_RESTART)
+    }
+    const { token: botToken } = botRow
+    const rest = createDiscordRest(botToken)
+
+    const db = await getDb()
+    const textChannels = await db.query.channel_directories.findMany({
+      where: { channel_type: 'text' },
+    })
+    const voiceChannels = await db.query.channel_directories.findMany({
+      where: { channel_type: 'voice' },
+    })
+
+    const renameChannel = async ({
+      channelId,
+      kind,
+      emoji,
+    }: {
+      channelId: string
+      kind: 'text' | 'voice'
+      emoji: string
+    }) => {
+      const data = (await rest.get(Routes.channel(channelId))) as {
+        id: string
+        name: string
+        guild_id: string
+      }
+      if (hasProjectEmojiPrefix(data.name, emoji)) {
+        return { skipped: true, name: data.name, guildId: data.guild_id }
+      }
+      const newName = prefixNameWithEmoji(data.name, emoji).slice(0, 100)
+      await rest.patch(Routes.channel(channelId), {
+        body: { name: newName },
+      })
+      return {
+        skipped: false,
+        name: newName,
+        previous: data.name,
+        guildId: data.guild_id,
+      }
+    }
+
+    const renameThread = async ({
+      threadId,
+      emoji,
+    }: {
+      threadId: string
+      emoji: string
+    }) => {
+      const data = (await rest.get(Routes.channel(threadId))) as {
+        id: string
+        name: string
+        type: number
+      }
+      if (!isThreadChannelType(data.type)) {
+        return { skipped: true, name: data.name }
+      }
+      if (hasProjectEmojiPrefix(data.name, emoji)) {
+        return { skipped: true, name: data.name }
+      }
+      const newName = prefixNameWithEmoji(data.name, emoji).slice(0, 100)
+      await rest.patch(Routes.channel(threadId), {
+        body: { name: newName },
+      })
+      return { skipped: false, name: newName, previous: data.name }
+    }
+
+    const fetchActiveThreadIds = async ({
+      textChannelId,
+      guildId,
+    }: {
+      textChannelId: string
+      guildId: string
+    }) => {
+      try {
+        const data = (await rest.get(
+          Routes.guildActiveThreads(guildId),
+        )) as {
+          threads: Array<{ id: string; parent_id?: string; type: number }>
+        }
+        return data.threads
+          .filter((t) => t.parent_id === textChannelId)
+          .map((t) => t.id)
+      } catch (error) {
+        cliLogger.debug(
+          `Failed to list active threads for ${textChannelId}:`,
+          error instanceof Error ? error.stack : String(error),
+        )
+        return []
+      }
+    }
+
+    const summary: string[] = []
+    let renamed = 0
+    let skipped = 0
+
+    for (const [projectName, emoji] of entries) {
+      const textForProject = textChannels.filter(
+        (c) => path.basename(c.directory) === projectName,
+      )
+      if (textForProject.length === 0) {
+        summary.push(`⏭ ${projectName}  no registered text channel`)
+        continue
+      }
+      const voiceForProject = voiceChannels.filter(
+        (c) => path.basename(c.directory) === projectName,
+      )
+
+      for (const textChannel of textForProject) {
+        const result = await renameChannel({
+          channelId: textChannel.channel_id,
+          kind: 'text',
+          emoji,
+        })
+        if (result.skipped) {
+          skipped++
+        } else {
+          renamed++
+          summary.push(
+            `✏️ #${result.previous} -> #${result.name}`,
+          )
+        }
+
+        const threadIds = await fetchActiveThreadIds({
+          textChannelId: textChannel.channel_id,
+          guildId: result.guildId,
+        })
+        for (const threadId of threadIds) {
+          const threadResult = await renameThread({ threadId, emoji })
+          if (threadResult.skipped) {
+            skipped++
+          } else {
+            renamed++
+            summary.push(
+              `  ↳ thread ${threadResult.previous} -> ${threadResult.name}`,
+            )
+          }
+        }
+      }
+
+      for (const voiceChannel of voiceForProject) {
+        const result = await renameChannel({
+          channelId: voiceChannel.channel_id,
+          kind: 'voice',
+          emoji,
+        })
+        if (result.skipped) {
+          skipped++
+        } else {
+          renamed++
+          summary.push(`🔊 voice #${result.previous} -> #${result.name}`)
+        }
+      }
+    }
+
+    note(
+      `${summary.length === 0 ? 'No changes needed.' : summary.join('\n')}\n\nRenamed: ${renamed}\nSkipped (already prefixed): ${skipped}\n\nActive threads only — archived threads are not renamed.`,
+      '✅ Apply Prefixes',
+    )
   })
 
 

--- a/cli/src/cli-commands/send.ts
+++ b/cli/src/cli-commands/send.ts
@@ -21,6 +21,7 @@ import type { ThreadStartMarker } from '../system-message.js'
 import { buildOpencodeEventLogLine } from '../session-handler/opencode-session-event-log.js'
 import { createDiscordRest } from '../discord-urls.js'
 import { archiveThread, uploadFilesToDiscord, stripMentions } from '../discord-utils.js'
+import { getProjectEmoji, prefixNameWithEmoji } from '../project-emojis.js'
 import { setDataDir, setProjectsDir, getDataDir, getProjectsDir } from '../config.js'
 import { execAsync, resolveSessionWorkingDirectory } from '../worktrees.js'
 import { upgrade, getCurrentVersion } from '../upgrade.js'
@@ -539,6 +540,7 @@ cli
 
         // Compute thread name and worktree name early (needed for embed)
         const cleanPrompt = stripMentions(prompt)
+        const projectEmoji = getProjectEmoji(projectDirectory)
         const baseThreadName =
           name ||
           (cleanPrompt.length > 80
@@ -551,9 +553,16 @@ cli
             ? formatWorktreeName(options.worktree)
             : formatAutoWorktreeName(baseThreadName)
           : undefined
-        const threadName = worktreeName
+        // Project emoji always prefixes the visible thread name. The worktree
+        // prefix is inserted between the emoji and the thread name so the
+        // thread reads as `<emoji> <🌳worktree> actual task name`.
+        const worktreePrefixed = worktreeName
           ? `${WORKTREE_PREFIX}${baseThreadName}`
           : baseThreadName
+        const threadName = prefixNameWithEmoji(
+          worktreePrefixed,
+          projectEmoji,
+        )
 
         if (parsedSchedule) {
           const payload: ScheduledTaskPayload = {

--- a/cli/src/commands/btw.ts
+++ b/cli/src/commands/btw.ts
@@ -9,7 +9,7 @@ import {
   type ThreadChannel,
   MessageFlags,
 } from 'discord.js'
-import { getThreadSession, setThreadSession } from '../database.js'
+import { getThreadSession, setThreadSession, getChannelDirectory } from '../database.js'
 import {
   resolveWorkingDirectory,
   resolveTextChannel,
@@ -19,6 +19,7 @@ import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js
 import { createLogger, LogPrefix } from '../logger.js'
 import type { CommandContext } from './types.js'
 import { initializeOpencodeForDirectory } from '../opencode.js'
+import { prefixNameWithEmoji, projectEmojiForChannel } from '../project-emojis.js'
 
 const logger = createLogger(LogPrefix.FORK)
 
@@ -63,7 +64,10 @@ export async function forkSessionToBtwThread({
 
   const forkedSession = forkResponse.data
   const thread = await textChannel.threads.create({
-    name: `btw: ${prompt}`.slice(0, 100),
+    name: prefixNameWithEmoji(
+      `btw: ${prompt}`,
+      await projectEmojiForChannel(textChannel.id),
+    ).slice(0, 100),
     autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
     reason: `btw fork from session ${sessionId}`,
   })

--- a/cli/src/commands/fork-subagent.ts
+++ b/cli/src/commands/fork-subagent.ts
@@ -13,12 +13,14 @@ import {
   getSessionEventSnapshot,
   getThreadSession,
   setThreadSession,
+  getChannelDirectory,
 } from '../database.js'
 import {
   resolveTextChannel,
   resolveWorkingDirectory,
   sendThreadMessage,
 } from '../discord-utils.js'
+import { prefixNameWithEmoji, projectEmojiForChannel } from '../project-emojis.js'
 import {
   collectSessionChunks,
   batchChunksForDiscord,
@@ -210,7 +212,10 @@ export async function handleForkSubagentSelectMenu(
 
   const forkedSession = forkResponse.data
   const forkedThread = await textChannel.threads.create({
-    name: `Fork: ${selectedSubagent?.description || selectedSubagent?.subagentType || 'subagent session'}`.slice(0, 100),
+    name: prefixNameWithEmoji(
+      `Fork: ${selectedSubagent?.description || selectedSubagent?.subagentType || 'subagent session'}`,
+      await projectEmojiForChannel(textChannel.id),
+    ).slice(0, 100),
     autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
     reason: `Forked subagent session ${selectedSessionId}`,
   })

--- a/cli/src/commands/fork.ts
+++ b/cli/src/commands/fork.ts
@@ -14,6 +14,7 @@ import {
   getThreadSession,
   setThreadSession,
   setPartMessagesBatch,
+  getChannelDirectory,
 } from '../database.js'
 import { initializeOpencodeForDirectory } from '../opencode.js'
 import {
@@ -21,6 +22,7 @@ import {
   resolveTextChannel,
   sendThreadMessage,
 } from '../discord-utils.js'
+import { prefixNameWithEmoji, projectEmojiForChannel } from '../project-emojis.js'
 import {
   collectSessionChunks,
   batchChunksForDiscord,
@@ -323,7 +325,10 @@ export async function handleForkSelectMenu(
     }
 
     const thread = await textChannel.threads.create({
-      name: `Fork: ${forkedSession.title}`.slice(0, 100),
+      name: prefixNameWithEmoji(
+        `Fork: ${forkedSession.title}`,
+        await projectEmojiForChannel(textChannel.id),
+      ).slice(0, 100),
       autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
       reason: `Forked from session ${sessionId}`,
     })

--- a/cli/src/commands/resume.ts
+++ b/cli/src/commands/resume.ts
@@ -20,6 +20,7 @@ import {
   resolveProjectDirectoryFromAutocomplete,
   NOTIFY_MESSAGE_FLAGS,
 } from '../discord-utils.js'
+import { prefixNameWithEmoji, projectEmojiForChannel } from '../project-emojis.js'
 import { collectSessionChunks, batchChunksForDiscord } from '../message-formatting.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import * as errore from 'errore'
@@ -88,7 +89,10 @@ export async function handleResumeCommand({
     const sessionTitle = sessionResponse.data.title
 
     const thread = await channel.threads.create({
-      name: `Resume: ${sessionTitle}`.slice(0, 100),
+      name: prefixNameWithEmoji(
+        `Resume: ${sessionTitle}`,
+        await projectEmojiForChannel(channel.id),
+      ).slice(0, 100),
       autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
       reason: `Resuming session ${sessionId}`,
     })

--- a/cli/src/external-opencode-sync.ts
+++ b/cli/src/external-opencode-sync.ts
@@ -18,8 +18,14 @@ import {
   listTrackedTextChannels,
   setPartMessagesBatch,
   upsertThreadSession,
+  getChannelDirectory,
 } from './database.js'
 import { sendThreadMessage } from './discord-utils.js'
+import {
+  getProjectEmoji,
+  prefixNameWithEmoji,
+  projectEmojiForChannel,
+} from './project-emojis.js'
 import { createLogger, LogPrefix } from './logger.js'
 import {
   formatPart,
@@ -327,7 +333,12 @@ async function ensureExternalSessionThread({
     return new Error(`Channel ${channelId} is not a text channel`)
   }
 
-  const threadName = 'Sync: ' + getSessionThreadName({ sessionTitle, messages })
+  const projectDir = (await getChannelDirectory(channelId))?.directory
+  const projectEmoji = projectDir ? getProjectEmoji(projectDir) : null
+  const threadName = prefixNameWithEmoji(
+    'Sync: ' + getSessionThreadName({ sessionTitle, messages }),
+    projectEmoji,
+  )
   const thread = await (parentChannel).threads.create({
     name: threadName.slice(0, 100),
     autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,

--- a/cli/src/project-emojis.test.ts
+++ b/cli/src/project-emojis.test.ts
@@ -1,0 +1,138 @@
+// Unit tests for the project emoji prefix map module.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { setDataDir } from './config.js'
+
+describe('project-emojis', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimaki-emoji-test-'))
+    setDataDir(tmpDir)
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns null when no map file exists', async () => {
+    const { getProjectEmoji } = await import('./project-emojis.js')
+    expect(getProjectEmoji('myproject')).toBeNull()
+  })
+
+  it('persists and reads back the emoji for a project', async () => {
+    const { setProjectEmoji, getProjectEmoji } = await import(
+      './project-emojis.js'
+    )
+    setProjectEmoji('website', '🌐')
+    expect(getProjectEmoji('/abs/path/to/website')).toBe('🌐')
+    expect(getProjectEmoji('website')).toBe('🌐')
+  })
+
+  it('removes a project emoji', async () => {
+    const { setProjectEmoji, removeProjectEmoji, getProjectEmoji } =
+      await import('./project-emojis.js')
+    setProjectEmoji('kimaki', '🔮')
+    expect(getProjectEmoji('kimaki')).toBe('🔮')
+    expect(removeProjectEmoji('kimaki')).toBe(true)
+    expect(getProjectEmoji('kimaki')).toBeNull()
+    expect(removeProjectEmoji('kimaki')).toBe(false)
+  })
+
+  it('lists all configured project emojis', async () => {
+    const { setProjectEmoji, listProjectEmojis } = await import(
+      './project-emojis.js'
+    )
+    setProjectEmoji('kimaki', '🔮')
+    setProjectEmoji('website', '🌐')
+    const list = listProjectEmojis()
+    expect(list).toEqual({ kimaki: '🔮', website: '🌐' })
+  })
+
+  it('treats a corrupt map file as empty instead of throwing', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project-emojis.json'), '{ not json')
+    const { getProjectEmoji, listProjectEmojis } = await import(
+      './project-emojis.js'
+    )
+    expect(getProjectEmoji('kimaki')).toBeNull()
+    expect(listProjectEmojis()).toEqual({})
+  })
+
+  it('drops entries with non-string values or empty keys', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'project-emojis.json'),
+      JSON.stringify({
+        kimaki: '🔮',
+        website: 42,
+        '': '🫥',
+        emptyValue: '',
+      }),
+    )
+    const { listProjectEmojis } = await import('./project-emojis.js')
+    expect(listProjectEmojis()).toEqual({ kimaki: '🔮' })
+  })
+
+  it('treats a non-object map file as empty', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project-emojis.json'), '"a string"')
+    const { getProjectEmoji } = await import('./project-emojis.js')
+    expect(getProjectEmoji('kimaki')).toBeNull()
+  })
+
+  it('prefixes a thread name with the configured emoji', async () => {
+    const { prefixNameWithEmoji } = await import('./project-emojis.js')
+    expect(prefixNameWithEmoji('fix the bug', '🔮')).toBe('🔮 fix the bug')
+  })
+
+  it('does not double-prefix when name already starts with the emoji', async () => {
+    const { prefixNameWithEmoji } = await import('./project-emojis.js')
+    expect(prefixNameWithEmoji('🔮 fix the bug', '🔮')).toBe('🔮 fix the bug')
+    expect(prefixNameWithEmoji('🔮-fix the bug', '🔮')).toBe('🔮-fix the bug')
+  })
+
+  it('returns the name unchanged when no emoji is given', async () => {
+    const { prefixNameWithEmoji } = await import('./project-emojis.js')
+    expect(prefixNameWithEmoji('fix the bug', null)).toBe('fix the bug')
+  })
+
+  it('projectEmojiForChannel returns the project emoji when channel is registered', async () => {
+    const { setProjectEmoji, projectEmojiForChannel } = await import(
+      './project-emojis.js'
+    )
+    const { initDatabase, setChannelDirectory, getDb } = await import(
+      './database.js'
+    )
+    setProjectEmoji('website', '🌐')
+    await initDatabase()
+    await setChannelDirectory({
+      channelId: 'channel-abc',
+      directory: '/abs/path/to/website',
+      channelType: 'text',
+    })
+    expect(await projectEmojiForChannel('channel-abc')).toBe('🌐')
+    // getDb imported for the side effect of triggering the DB module
+    void getDb
+  })
+
+  it('projectEmojiForChannel returns null when the channel is not registered', async () => {
+    const { projectEmojiForChannel } = await import('./project-emojis.js')
+    const { initDatabase } = await import('./database.js')
+    await initDatabase()
+    expect(await projectEmojiForChannel('does-not-exist')).toBeNull()
+  })
+
+  it('projectEmojiForChannel returns null when the project has no emoji', async () => {
+    const { projectEmojiForChannel } = await import('./project-emojis.js')
+    const { initDatabase, setChannelDirectory } = await import(
+      './database.js'
+    )
+    await initDatabase()
+    await setChannelDirectory({
+      channelId: 'channel-no-emoji',
+      directory: '/abs/path/to/uncharted',
+      channelType: 'text',
+    })
+    expect(await projectEmojiForChannel('channel-no-emoji')).toBeNull()
+  })
+})

--- a/cli/src/project-emojis.ts
+++ b/cli/src/project-emojis.ts
@@ -1,0 +1,131 @@
+// Project emoji prefix map.
+// Stores a user-defined emoji per project name so new channels and threads
+// created for that project automatically start with the emoji as a prefix.
+// The map is persisted at <dataDir>/project-emojis.json and keyed by the
+// project folder basename (matches how channels are named).
+//
+// Corrupt or unreadable files are treated as an empty map so the bot never
+// refuses to start because of a typo in this file.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { getDataDir } from './config.js'
+import { getChannelDirectory } from './database.js'
+import * as errore from 'errore'
+
+const FILE_NAME = 'project-emojis.json'
+
+class ProjectEmojisError extends errore.createTaggedError({
+  name: 'ProjectEmojisError',
+  message: 'Failed to load project emoji map: $reason',
+}) {}
+
+function emojiMapPath(): string {
+  return path.join(getDataDir(), FILE_NAME)
+}
+
+function readEmojiMap(): Record<string, string> {
+  const filePath = emojiMapPath()
+  if (!fs.existsSync(filePath)) {
+    return {}
+  }
+  const result = errore.try(() =>
+    JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown,
+  )
+  if (result instanceof Error) {
+    console.warn(
+      `[project-emojis] ignoring unreadable ${FILE_NAME}: ${result.message}`,
+    )
+    return {}
+  }
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    console.warn(
+      `[project-emojis] ignoring ${FILE_NAME}: expected an object mapping project name -> emoji`,
+    )
+    return {}
+  }
+  const validated: Record<string, string> = {}
+  for (const [key, value] of Object.entries(result)) {
+    if (typeof value === 'string' && value.length > 0 && key.length > 0) {
+      validated[key] = value
+    }
+  }
+  return validated
+}
+
+function writeEmojiMap(map: Record<string, string>): void {
+  const filePath = emojiMapPath()
+  const dir = path.dirname(filePath)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  fs.writeFileSync(filePath, `${JSON.stringify(map, null, 2)}\n`, 'utf-8')
+}
+
+export function getProjectEmoji(
+  projectDirectoryOrName: string,
+): string | null {
+  const name = path.basename(projectDirectoryOrName)
+  const map = readEmojiMap()
+  return map[name] ?? null
+}
+
+export function setProjectEmoji(projectName: string, emoji: string): void {
+  const trimmed = projectName.trim()
+  if (!trimmed) {
+    throw new ProjectEmojisError({ reason: 'project name is empty' })
+  }
+  const map = readEmojiMap()
+  map[trimmed] = emoji
+  writeEmojiMap(map)
+}
+
+export function removeProjectEmoji(projectName: string): boolean {
+  const map = readEmojiMap()
+  if (!(projectName in map)) {
+    return false
+  }
+  delete map[projectName]
+  writeEmojiMap(map)
+  return true
+}
+
+export function listProjectEmojis(): Record<string, string> {
+  return readEmojiMap()
+}
+
+export function hasProjectEmojiPrefix(name: string, emoji: string): boolean {
+  const trimmedName = name.trimStart()
+  const trimmedEmoji = emoji.trim()
+  if (!trimmedEmoji) {
+    return true
+  }
+  return (
+    trimmedName.startsWith(`${trimmedEmoji} `) ||
+    trimmedName.startsWith(`${trimmedEmoji}-`) ||
+    trimmedName === trimmedEmoji
+  )
+}
+
+export function prefixNameWithEmoji(
+  name: string,
+  emoji: string | null,
+): string {
+  if (!emoji) {
+    return name
+  }
+  if (hasProjectEmojiPrefix(name, emoji)) {
+    return name
+  }
+  return `${emoji} ${name}`
+}
+
+export async function projectEmojiForChannel(
+  channelId: string,
+): Promise<string | null> {
+  const config = await getChannelDirectory(channelId)
+  if (!config) {
+    return null
+  }
+  return getProjectEmoji(config.directory)
+}


### PR DESCRIPTION
Store a per-project emoji in <dataDir>/project-emojis.json so new channels and threads created for that project are named '<emoji> <name>'. 'kimaki project emoji add|remove|list' manages the map. 'kimaki project apply-prefixes' retroactively renames existing text, voice, and active-thread names using the configured map. Idempotent on already-prefixed names; archived threads are intentionally skipped.