### PR TITLE
feat: auto-recover missing worktree directories

### DIFF
--- a/cli/src/discord-utils.ts
+++ b/cli/src/discord-utils.ts
@@ -22,6 +22,7 @@ import { discordApiUrl } from './discord-urls.js'
 import { Lexer } from 'marked'
 import { splitTablesFromMarkdown } from './format-tables.js'
 import { getChannelDirectory, getThreadWorktree } from './database.js'
+import { recoverWorktreeDirectory } from './worktrees.js'
 import { DiscordOperationError } from './errors.js'
 import { limitHeadingDepth } from './limit-heading-depth.js'
 import { unnestCodeBlocksFromLists } from './unnest-code-blocks.js'
@@ -96,9 +97,7 @@ export function hasKimakiAdminPermission(
   return isOwner || isAdmin || canManageServer || hasKimakiRole
 }
 
-export async function resolveGuildMessageMember(
-  message: Message,
-): Promise<GuildMemberType | null> {
+export async function resolveGuildMessageMember(message: Message): Promise<GuildMemberType | null> {
   if (!message.guild) return null
   if (message.member) return message.member
 
@@ -106,9 +105,7 @@ export async function resolveGuildMessageMember(
     .fetch(message.author.id)
     .catch((e) => new Error('Failed to fetch guild member', { cause: e }))
   if (fetchedMember instanceof Error) {
-    discordLogger.warn(
-      `[PERMISSION] Denying message ${message.id}: ${fetchedMember.message}`,
-    )
+    discordLogger.warn(`[PERMISSION] Denying message ${message.id}: ${fetchedMember.message}`)
     return null
   }
 
@@ -148,9 +145,7 @@ export function hasNoKimakiRole(member: GuildMemberType | null): boolean {
   if (!member?.roles?.cache) {
     return false
   }
-  return member.roles.cache.some(
-    (role) => role.name.toLowerCase() === 'no-kimaki',
-  )
+  return member.roles.cache.some((role) => role.name.toLowerCase() === 'no-kimaki')
 }
 
 /**
@@ -175,40 +170,30 @@ export async function reactToThread({
       return channelId
     }
     // Fetch the thread to get its parent channel ID
-    const threadResult = await (rest.get(Routes.channel(threadId)) as Promise<{
+    const threadResult = await (
+      rest.get(Routes.channel(threadId)) as Promise<{
         parent_id?: string
-      }>).catch((e) => new DiscordOperationError({ operation: 'fetchThreadStarter', cause: e }))
+      }>
+    ).catch((e) => new DiscordOperationError({ operation: 'fetchThreadStarter', cause: e }))
     if (threadResult instanceof Error) {
-      discordLogger.warn(
-        `Failed to fetch thread ${threadId}:`,
-        threadResult.message,
-      )
+      discordLogger.warn(`Failed to fetch thread ${threadId}:`, threadResult.message)
       return null
     }
     return threadResult.parent_id || null
   })()
 
   if (!parentChannelId) {
-    discordLogger.warn(
-      `Could not resolve parent channel for thread ${threadId}`,
-    )
+    discordLogger.warn(`Could not resolve parent channel for thread ${threadId}`)
     return
   }
 
   // React to the thread starter message in the parent channel.
   // Thread ID equals the starter message ID for threads created from messages.
-  const result = await rest.put(
-    Routes.channelMessageOwnReaction(
-      parentChannelId,
-      threadId,
-      encodeURIComponent(emoji),
-    ),
-  ).catch((e) => new DiscordOperationError({ operation: 'addReaction', cause: e }))
+  const result = await rest
+    .put(Routes.channelMessageOwnReaction(parentChannelId, threadId, encodeURIComponent(emoji)))
+    .catch((e) => new DiscordOperationError({ operation: 'addReaction', cause: e }))
   if (result instanceof Error) {
-    discordLogger.warn(
-      `Failed to react to thread ${threadId} with ${emoji}:`,
-      result.message,
-    )
+    discordLogger.warn(`Failed to react to thread ${threadId} with ${emoji}:`, result.message)
   }
 }
 
@@ -236,26 +221,25 @@ export async function archiveThread({
 
   if (client && sessionId) {
     const updateResult = await (async () => {
-        const sessionResponse = await client.session.get({
-          sessionID: sessionId,
-        })
-        if (!sessionResponse.data) {
-          return
-        }
-        const currentTitle = sessionResponse.data.title || ''
-        const newTitle = currentTitle.startsWith('📁')
-          ? currentTitle
-          : `📁 ${currentTitle}`.trim()
-        await client.session.update({
-          sessionID: sessionId,
-          title: newTitle,
-        })
+      const sessionResponse = await client.session.get({
+        sessionID: sessionId,
+      })
+      if (!sessionResponse.data) {
+        return
+      }
+      const currentTitle = sessionResponse.data.title || ''
+      const newTitle = currentTitle.startsWith('📁') ? currentTitle : `📁 ${currentTitle}`.trim()
+      await client.session.update({
+        sessionID: sessionId,
+        title: newTitle,
+      })
     })().catch((e) => new Error('Failed to update session title', { cause: e }))
     if (updateResult instanceof Error) {
       discordLogger.warn(`[archive-thread] ${updateResult.message}`)
     }
 
-    const abortResult = await client.session.abort({ sessionID: sessionId })
+    const abortResult = await client.session
+      .abort({ sessionID: sessionId })
       .catch((e) => new Error('Failed to abort session', { cause: e }))
     if (abortResult instanceof Error) {
       discordLogger.warn(`[archive-thread] ${abortResult.message}`)
@@ -397,11 +381,7 @@ export function splitMarkdownForDiscord({
   let currentLang: string | null = null
 
   // helper to split a long line into smaller pieces at word boundaries or hard breaks
-  const splitLongLine = (
-    text: string,
-    available: number,
-    inCode: boolean,
-  ): string[] => {
+  const splitLongLine = (text: string, available: number, inCode: boolean): string[] => {
     const pieces: string[] = []
     let remaining = text
 
@@ -433,16 +413,11 @@ export function splitMarkdownForDiscord({
         : 0
     // When opening fence starts a fresh chunk, its size is in openingFenceSize.
     // Otherwise count it normally so the overflow check doesn't miss the fence text.
-    const lineLength =
-      line.isOpeningFence && currentChunk.length === 0 ? 0 : line.text.length
+    const lineLength = line.isOpeningFence && currentChunk.length === 0 ? 0 : line.text.length
     const activeFenceOverhead =
       currentLang !== null || openingFenceSize > 0 ? closingFence.length : 0
     const wouldExceed =
-      currentChunk.length +
-        openingFenceSize +
-        lineLength +
-        activeFenceOverhead >
-      maxLength
+      currentChunk.length + openingFenceSize + lineLength + activeFenceOverhead > maxLength
 
     if (wouldExceed) {
       // handle case where single line is longer than maxLength
@@ -461,16 +436,9 @@ export function splitMarkdownForDiscord({
           ? ('```' + line.lang + '\n').length + '```\n'.length
           : 0
         // ensure at least 10 chars available, even if maxLength is very small
-        const availablePerChunk = Math.max(
-          10,
-          maxLength - codeBlockOverhead - 50,
-        )
+        const availablePerChunk = Math.max(10, maxLength - codeBlockOverhead - 50)
 
-        const pieces = splitLongLine(
-          line.text,
-          availablePerChunk,
-          line.inCodeBlock,
-        )
+        const pieces = splitLongLine(line.text, availablePerChunk, line.inCodeBlock)
 
         for (let i = 0; i < pieces.length; i++) {
           const piece = pieces[i]!
@@ -512,25 +480,13 @@ export function splitMarkdownForDiscord({
       } else {
         // currentChunk is empty but line still exceeds - shouldn't happen after above check
         const openingFence = line.inCodeBlock || line.isOpeningFence
-        const openingFenceSize = openingFence
-          ? ('```' + line.lang + '\n').length
-          : 0
-        if (
-          line.text.length + openingFenceSize + activeFenceOverhead >
-          maxLength
-        ) {
+        const openingFenceSize = openingFence ? ('```' + line.lang + '\n').length : 0
+        if (line.text.length + openingFenceSize + activeFenceOverhead > maxLength) {
           const fencedOverhead = openingFence
             ? ('```' + line.lang + '\n').length + closingFence.length
             : 0
-          const availablePerChunk = Math.max(
-            10,
-            maxLength - fencedOverhead - 50,
-          )
-          const pieces = splitLongLine(
-            line.text,
-            availablePerChunk,
-            line.inCodeBlock,
-          )
+          const availablePerChunk = Math.max(10, maxLength - fencedOverhead - 50)
+          const pieces = splitLongLine(line.text, availablePerChunk, line.inCodeBlock)
           for (const piece of pieces) {
             if (openingFence) {
               chunks.push('```' + line.lang + '\n' + piece + closingFence)
@@ -615,9 +571,7 @@ export async function sendThreadMessage(
     })
 
     if (chunks.length > 1) {
-      discordLogger.log(
-        `MESSAGE: Splitting ${text.length} chars into ${chunks.length} messages`,
-      )
+      discordLogger.log(`MESSAGE: Splitting ${text.length} chars into ${chunks.length} messages`)
     }
 
     for (let chunk of chunks) {
@@ -670,9 +624,7 @@ export function escapeDiscordFormatting(text: string): string {
   return text.replace(/```/g, '\\`\\`\\`').replace(/````/g, '\\`\\`\\`\\`')
 }
 
-export async function getKimakiMetadata(
-  textChannel: TextChannel | null,
-): Promise<{
+export async function getKimakiMetadata(textChannel: TextChannel | null): Promise<{
   projectDirectory?: string
 }> {
   if (!textChannel) {
@@ -727,7 +679,8 @@ export async function resolveProjectDirectoryFromAutocomplete(
   // Last resort: fetch the channel from Discord API to get parentId for threads
   // when the channel isn't cached at all (common with gateway-proxy).
   if (!cachedParentId) {
-    const fetched = await interaction.client.channels.fetch(channelId)
+    const fetched = await interaction.client.channels
+      .fetch(channelId)
       .catch((e) => new DiscordOperationError({ operation: 'fetchChannel', cause: e }))
     if (!(fetched instanceof Error) && fetched?.isThread() && fetched.parentId) {
       const parentConfig = await getChannelDirectory(fetched.parentId)
@@ -777,7 +730,14 @@ export async function resolveWorkingDirectory({
   if (isThread) {
     const worktreeInfo = await getThreadWorktree(channel.id)
     if (worktreeInfo?.status === 'ready' && worktreeInfo.worktree_directory) {
-      workingDirectory = worktreeInfo.worktree_directory
+      // Auto-recover missing worktree directory
+      const recovery = await recoverWorktreeDirectory({ threadId: channel.id })
+      if (recovery.recovered) {
+        workingDirectory = recovery.worktreeDirectory
+      } else {
+        // Use the stored directory - will fail if missing, but that's the existing behavior
+        workingDirectory = worktreeInfo.worktree_directory
+      }
     }
   }
 
@@ -817,23 +777,16 @@ export async function uploadFilesToDiscord({
   files.forEach((file, index) => {
     const buffer = fs.readFileSync(file)
     const mimeType = mime.getType(file) || 'application/octet-stream'
-    formData.append(
-      `files[${index}]`,
-      new Blob([buffer], { type: mimeType }),
-      path.basename(file),
-    )
+    formData.append(`files[${index}]`, new Blob([buffer], { type: mimeType }), path.basename(file))
   })
 
-  const response = await fetch(
-    discordApiUrl(`/channels/${threadId}/messages`),
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bot ${botToken}`,
-      },
-      body: formData,
+  const response = await fetch(discordApiUrl(`/channels/${threadId}/messages`), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bot ${botToken}`,
     },
-  )
+    body: formData,
+  })
 
   if (!response.ok) {
     const error = await response.text()

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -31,16 +31,9 @@ import {
   extractSdkErrorMessage,
 } from '../opencode.js'
 import { isAbortError } from '../utils.js'
-import {
-  registerEventListener,
-  unregisterEventListener,
-} from './global-event-listener.js'
+import { registerEventListener, unregisterEventListener } from './global-event-listener.js'
 import { createLogger, LogPrefix } from '../logger.js'
-import {
-  sendThreadMessage,
-  SILENT_MESSAGE_FLAGS,
-  NOTIFY_MESSAGE_FLAGS,
-} from '../discord-utils.js'
+import { sendThreadMessage, SILENT_MESSAGE_FLAGS, NOTIFY_MESSAGE_FLAGS } from '../discord-utils.js'
 import type { DiscordFileAttachment } from '../message-formatting.js'
 import { formatPart } from '../message-formatting.js'
 import {
@@ -77,14 +70,8 @@ import {
   pendingActionButtonContexts,
   cancelPendingActionButtons,
 } from '../commands/action-buttons.js'
-import {
-  pendingFileUploadContexts,
-  cancelPendingFileUpload,
-} from '../commands/file-upload.js'
-import {
-  getCurrentModelInfo,
-  ensureSessionPreferencesSnapshot,
-} from '../commands/model.js'
+import { pendingFileUploadContexts, cancelPendingFileUpload } from '../commands/file-upload.js'
+import { getCurrentModelInfo, ensureSessionPreferencesSnapshot } from '../commands/model.js'
 import {
   getOpencodePromptContext,
   getOpencodeSystemMessage,
@@ -132,16 +119,9 @@ export const pendingPermissions = new Map<
     }
   > // permissionId -> data
 >()
-import {
-  getThinkingValuesForModel,
-  matchThinkingValue,
-} from '../thinking-utils.js'
+import { getThinkingValuesForModel, matchThinkingValue } from '../thinking-utils.js'
 import { execAsync } from '../worktrees.js'
-import {
-  DiscordOperationError,
-  OpenCodeSdkError,
-  FilesystemOperationError,
-} from '../errors.js'
+import { DiscordOperationError, OpenCodeSdkError, FilesystemOperationError } from '../errors.js'
 
 import { notifyError } from '../sentry.js'
 import { createDebouncedProcessFlush } from '../debounced-process-flush.js'
@@ -164,8 +144,7 @@ function stripToastSessionId({ message }: { message: string }): string {
 }
 
 const shouldLogSessionEvents =
-  process.env['KIMAKI_LOG_SESSION_EVENTS'] === '1' ||
-  process.env['KIMAKI_VITEST'] === '1'
+  process.env['KIMAKI_LOG_SESSION_EVENTS'] === '1' || process.env['KIMAKI_VITEST'] === '1'
 
 // ── Registry ─────────────────────────────────────────────────────
 // Runtime instances are kept in a plain Map (not Zustand — the Map
@@ -173,9 +152,7 @@ const shouldLogSessionEvents =
 
 const runtimes = new Map<string, ThreadSessionRuntime>()
 
-export function getRuntime(
-  threadId: string,
-): ThreadSessionRuntime | undefined {
+export function getRuntime(threadId: string): ThreadSessionRuntime | undefined {
   return runtimes.get(threadId)
 }
 
@@ -188,9 +165,7 @@ export type RuntimeOptions = {
   appId?: string
 }
 
-export function getOrCreateRuntime(
-  opts: RuntimeOptions,
-): ThreadSessionRuntime {
+export function getOrCreateRuntime(opts: RuntimeOptions): ThreadSessionRuntime {
   const existing = runtimes.get(opts.threadId)
   if (existing) {
     if (existing.sdkDirectory !== opts.sdkDirectory) {
@@ -289,9 +264,8 @@ function cleanupPendingUiForThread(threadId: string): void {
       if (ctx) {
         const client = getOpencodeClient(ctx.directory)
         if (client) {
-          const requestIds: string[] = ctx.requestIds.length > 0
-            ? ctx.requestIds
-            : [ctx.permission.id]
+          const requestIds: string[] =
+            ctx.requestIds.length > 0 ? ctx.requestIds : [ctx.permission.id]
           void Promise.all(
             requestIds.map((requestId) => {
               return client.permission.reply({
@@ -356,13 +330,7 @@ type TokenUsage = {
 }
 
 function getTokenTotal(tokens: TokenUsage): number {
-  return (
-    tokens.input +
-    tokens.output +
-    tokens.reasoning +
-    tokens.cache.read +
-    tokens.cache.write
-  )
+  return tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
 }
 
 /** Check if a tool part is "essential" (shown in text-and-essential-tools mode). */
@@ -407,11 +375,7 @@ const WORKTREE_THREAD_PREFIX = '⬦ '
 
 // Prefixes that should survive OpenCode session title renames.
 // When a thread starts with one of these, the rename preserves it.
-const PRESERVED_THREAD_PREFIXES: string[] = [
-  WORKTREE_THREAD_PREFIX,
-  'btw: ',
-  'Fork: ',
-]
+const PRESERVED_THREAD_PREFIXES: string[] = [WORKTREE_THREAD_PREFIX, 'btw: ', 'Fork: ']
 
 function getThreadNameCandidateFromSessionTitle({
   sessionTitle,
@@ -599,13 +563,8 @@ function getWorktreePromptKey(worktree: WorktreeInfo | undefined): string | null
   if (!worktree) {
     return null
   }
-  return [
-    worktree.worktreeDirectory,
-    worktree.branch,
-    worktree.mainRepoDirectory,
-  ].join('::')
+  return [worktree.worktreeDirectory, worktree.branch, worktree.mainRepoDirectory].join('::')
 }
-
 
 // ── Runtime class ────────────────────────────────────────────────
 
@@ -665,9 +624,7 @@ export class ThreadSessionRuntime {
   private static EVENT_BUFFER_TEXT_MAX_CHARS = 512
   private eventBuffer: EventBufferEntry[] = []
   private nextEventIndex = 0
-  private persistEventBufferDebounced: ReturnType<
-    typeof createDebouncedProcessFlush
-  >
+  private persistEventBufferDebounced: ReturnType<typeof createDebouncedProcessFlush>
   private readonly sentPartIdsBootstrap: Promise<void>
 
   // Serialized action queue for per-thread runtime transitions.
@@ -729,9 +686,7 @@ export class ThreadSessionRuntime {
     })
   }
 
-  private consumeWorktreePromptChange(
-    worktree: WorktreeInfo | undefined,
-  ): boolean {
+  private consumeWorktreePromptChange(worktree: WorktreeInfo | undefined): boolean {
     const nextKey = getWorktreePromptKey(worktree)
     const changed = this.lastPromptWorktreeKey !== nextKey
     this.lastPromptWorktreeKey = nextKey
@@ -747,11 +702,7 @@ export class ThreadSessionRuntime {
     return this.isMainSessionBusy() ? 'running' : 'idle'
   }
 
-  private getLastRuntimeActivityTimestamp({
-    nowMs: _nowMs,
-  }: {
-    nowMs: number
-  }): number {
+  private getLastRuntimeActivityTimestamp({ nowMs: _nowMs }: { nowMs: number }): number {
     const lastEvent = this.eventBuffer[this.eventBuffer.length - 1]
     const lastEventTimestamp = lastEvent?.timestamp
     if (typeof lastEventTimestamp === 'number' && Number.isFinite(lastEventTimestamp)) {
@@ -759,9 +710,9 @@ export class ThreadSessionRuntime {
     }
     const threadCreatedTimestamp = this.thread.createdTimestamp
     if (
-      typeof threadCreatedTimestamp === 'number'
-      && Number.isFinite(threadCreatedTimestamp)
-      && threadCreatedTimestamp > 0
+      typeof threadCreatedTimestamp === 'number' &&
+      Number.isFinite(threadCreatedTimestamp) &&
+      threadCreatedTimestamp > 0
     ) {
       return threadCreatedTimestamp
     }
@@ -788,11 +739,7 @@ export class ThreadSessionRuntime {
     return true
   }
 
-  getInactivitySnapshot({
-    nowMs,
-  }: {
-    nowMs: number
-  }): {
+  getInactivitySnapshot({ nowMs }: { nowMs: number }): {
     idleCandidate: boolean
     inactiveForMs: number
   } {
@@ -803,13 +750,7 @@ export class ThreadSessionRuntime {
     }
   }
 
-  isIdleForInactivityTimeout({
-    idleMs,
-    nowMs,
-  }: {
-    idleMs: number
-    nowMs: number
-  }): boolean {
+  isIdleForInactivityTimeout({ idleMs, nowMs }: { idleMs: number; nowMs: number }): boolean {
     const snapshot = this.getInactivitySnapshot({ nowMs })
     if (!snapshot.idleCandidate) {
       return false
@@ -859,9 +800,7 @@ export class ThreadSessionRuntime {
 
     this.eventBuffer = hydratedEvents.slice(-ThreadSessionRuntime.EVENT_BUFFER_MAX)
     const lastHydratedEvent = this.eventBuffer[this.eventBuffer.length - 1]
-    this.nextEventIndex = lastHydratedEvent
-      ? Number(lastHydratedEvent.eventIndex || 0) + 1
-      : 0
+    this.nextEventIndex = lastHydratedEvent ? Number(lastHydratedEvent.eventIndex || 0) + 1 : 0
     logger.log(
       `[SESSION EVENT DB] Hydrated ${this.eventBuffer.length} events for session ${sessionId}`,
     )
@@ -874,9 +813,10 @@ export class ThreadSessionRuntime {
     }
 
     const events = this.eventBuffer.flatMap((entry) => {
-      const eventSessionId = entry.event.type === 'queue.question-handoff-started'
-        ? entry.event.properties.sessionID
-        : getOpencodeEventSessionId(entry.event)
+      const eventSessionId =
+        entry.event.type === 'queue.question-handoff-started'
+          ? entry.event.properties.sessionID
+          : getOpencodeEventSessionId(entry.event)
       if (eventSessionId !== sessionId) {
         return []
       }
@@ -906,9 +846,10 @@ export class ThreadSessionRuntime {
     if (!sessionId) {
       return 'none'
     }
-    const latestAssistant = this.getLatestAssistantMessageIdForCurrentTurn({
-      sessionId,
-    }) || 'none'
+    const latestAssistant =
+      this.getLatestAssistantMessageIdForCurrentTurn({
+        sessionId,
+      }) || 'none'
     const assistantCount = this.getAssistantMessageIdsForCurrentTurn({
       sessionId,
     }).size
@@ -1019,10 +960,7 @@ export class ThreadSessionRuntime {
     return value !== undefined
   }
 
-  private pruneLargeStringsForEventBuffer(
-    value: unknown,
-    seen: WeakSet<object>,
-  ): void {
+  private pruneLargeStringsForEventBuffer(value: unknown, seen: WeakSet<object>): void {
     if (typeof value !== 'object' || value === null) {
       return
     }
@@ -1062,16 +1000,12 @@ export class ThreadSessionRuntime {
     }
   }
 
-  private finalizeCompactedEventForEventBuffer(
-    event: EventBufferEvent,
-  ): EventBufferEvent {
+  private finalizeCompactedEventForEventBuffer(event: EventBufferEvent): EventBufferEvent {
     this.pruneLargeStringsForEventBuffer(event, new WeakSet<object>())
     return event
   }
 
-  private compactEventForEventBuffer(
-    event: EventBufferEvent,
-  ): EventBufferEvent | undefined {
+  private compactEventForEventBuffer(event: EventBufferEvent): EventBufferEvent | undefined {
     if (event.type === 'queue.question-handoff-started') {
       return this.finalizeCompactedEventForEventBuffer(structuredClone(event))
     }
@@ -1095,10 +1029,7 @@ export class ThreadSessionRuntime {
               return [] as Array<{ id: string; type: string }>
             }
             const candidate = part as { id?: unknown; type?: unknown }
-            if (
-              typeof candidate.id !== 'string'
-              || typeof candidate.type !== 'string'
-            ) {
+            if (typeof candidate.id !== 'string' || typeof candidate.type !== 'string') {
               return [] as Array<{ id: string; type: string }>
             }
             return [{ id: candidate.id, type: candidate.type }]
@@ -1147,8 +1078,7 @@ export class ThreadSessionRuntime {
     const state = part.state
     // Preserve subagent_type for task tools so derivation can build labels
     // like "explore-1" instead of generic "task-1" after compaction strips input
-    const taskSubagentType =
-      part.tool === 'task' ? state.input?.subagent_type : undefined
+    const taskSubagentType = part.tool === 'task' ? state.input?.subagent_type : undefined
     state.input = {}
     if (typeof taskSubagentType === 'string') {
       state.input.subagent_type = taskSubagentType
@@ -1260,9 +1190,7 @@ export class ThreadSessionRuntime {
       await delay(pollMs)
     }
 
-    logger.warn(
-      `[WAIT EVENT] Timeout after ${timeoutMs}ms for thread ${this.threadId}, proceeding`,
-    )
+    logger.warn(`[WAIT EVENT] Timeout after ${timeoutMs}ms for thread ${this.threadId}, proceeding`)
     return undefined
   }
 
@@ -1309,9 +1237,10 @@ export class ThreadSessionRuntime {
     const sessionId = this.state?.sessionId
 
     const eventSessionId = getOpencodeEventSessionId(event)
-    const toastSessionId = event.type === 'tui.toast.show'
-      ? extractToastSessionId({ message: event.properties.message })
-      : undefined
+    const toastSessionId =
+      event.type === 'tui.toast.show'
+        ? extractToastSessionId({ message: event.properties.message })
+        : undefined
 
     if (shouldLogSessionEvents) {
       const eventDetails = (() => {
@@ -1330,9 +1259,10 @@ export class ThreadSessionRuntime {
           const partType = event.properties.part.type
           const partId = event.properties.part.id
           const messageId = event.properties.part.messageID
-          const toolSuffix = partType === 'tool'
-            ? ` tool=${event.properties.part.tool} status=${event.properties.part.state.status}`
-            : ''
+          const toolSuffix =
+            partType === 'tool'
+              ? ` tool=${event.properties.part.tool} status=${event.properties.part.state.status}`
+              : ''
           return ` part=${partType} partID=${partId} messageID=${messageId}${toolSuffix}`
         }
         return ''
@@ -1365,10 +1295,7 @@ export class ThreadSessionRuntime {
         event,
       })
       if (eventLogResult instanceof Error) {
-        logger.error(
-          '[SESSION EVENT JSONL] Failed to write session event log:',
-          eventLogResult,
-        )
+        logger.error('[SESSION EVENT JSONL] Failed to write session event log:', eventLogResult)
       }
     }
 
@@ -1424,7 +1351,9 @@ export class ThreadSessionRuntime {
           resolve()
           return
         }
-        const result = await action().catch((e) => new OpenCodeSdkError({ operation: 'dispatchAction', cause: e }))
+        const result = await action().catch(
+          (e) => new OpenCodeSdkError({ operation: 'dispatchAction', cause: e }),
+        )
         if (result instanceof Error) {
           reject(result)
           return
@@ -1452,7 +1381,9 @@ export class ThreadSessionRuntime {
         // Each queued action already wraps itself with .catch()
         // and calls resolve/reject, so this should not throw. But if it
         // does, the try/finally ensures we don't deadlock.
-        const result = await next().catch((e) => new OpenCodeSdkError({ operation: 'processAction', cause: e }))
+        const result = await next().catch(
+          (e) => new OpenCodeSdkError({ operation: 'processAction', cause: e }),
+        )
         if (result instanceof Error) {
           logger.error('[ACTION QUEUE] Unexpected action failure:', result)
         }
@@ -1474,19 +1405,15 @@ export class ThreadSessionRuntime {
     if (this.hasPendingQuestionUi()) {
       return true
     }
-    const hasPendingActionButtons = [...pendingActionButtonContexts.values()].some(
-      (ctx) => {
-        return ctx.thread.id === this.thread.id
-      },
-    )
+    const hasPendingActionButtons = [...pendingActionButtonContexts.values()].some((ctx) => {
+      return ctx.thread.id === this.thread.id
+    })
     if (hasPendingActionButtons) {
       return true
     }
-    const hasPendingFileUpload = [...pendingFileUploadContexts.values()].some(
-      (ctx) => {
-        return ctx.thread.id === this.thread.id
-      },
-    )
+    const hasPendingFileUpload = [...pendingFileUploadContexts.values()].some((ctx) => {
+      return ctx.thread.id === this.thread.id
+    })
     if (hasPendingFileUpload) {
       return true
     }
@@ -1515,7 +1442,8 @@ export class ThreadSessionRuntime {
   }
 
   private async sendTypingPulse(): Promise<void> {
-    const result = await this.thread.sendTyping()
+    const result = await this.thread
+      .sendTyping()
       .catch((e) => new DiscordOperationError({ operation: 'sendTyping', cause: e }))
     if (result instanceof Error) {
       discordLogger.log(`Failed to send typing: ${result}`)
@@ -1530,11 +1458,7 @@ export class ThreadSessionRuntime {
     this.typingKeepaliveTimeout = null
   }
 
-  private armTypingKeepalive({
-    delayMs,
-  }: {
-    delayMs: number
-  }): void {
+  private armTypingKeepalive({ delayMs }: { delayMs: number }): void {
     this.typingKeepaliveTimeout = setTimeout(() => {
       const activeTimer = this.typingKeepaliveTimeout
       if (!activeTimer) {
@@ -1558,11 +1482,7 @@ export class ThreadSessionRuntime {
     }, delayMs)
   }
 
-  private restartTypingKeepalive({
-    sendNow,
-  }: {
-    sendNow: boolean
-  }): void {
+  private restartTypingKeepalive({ sendNow }: { sendNow: boolean }): void {
     this.clearTypingKeepalive()
     this.armTypingKeepalive({ delayMs: sendNow ? 0 : 7000 })
   }
@@ -1613,8 +1533,7 @@ export class ThreadSessionRuntime {
   }
 
   private storePart(part: Part): void {
-    const messageParts =
-      this.partBuffer.get(part.messageID) || new Map<string, Part>()
+    const messageParts = this.partBuffer.get(part.messageID) || new Map<string, Part>()
     messageParts.set(part.id, part)
     this.partBuffer.set(part.messageID, messageParts)
   }
@@ -1636,13 +1555,7 @@ export class ThreadSessionRuntime {
     })
   }
 
-  private shouldSendPart({
-    part,
-    force,
-  }: {
-    part: Part
-    force: boolean
-  }): boolean {
+  private shouldSendPart({ part, force }: { part: Part; force: boolean }): boolean {
     if (part.type === 'step-start' || part.type === 'step-finish') {
       return false
     }
@@ -1690,18 +1603,16 @@ export class ThreadSessionRuntime {
       return { ...t, sentPartIds: newIds }
     })
 
-    const sendResult = await sendThreadMessage(this.thread, content)
-      .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
+    const sendResult = await sendThreadMessage(this.thread, content).catch(
+      (e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }),
+    )
     if (sendResult instanceof Error) {
       threadState.updateThread(this.threadId, (t) => {
         const newIds = new Set(t.sentPartIds)
         newIds.delete(part.id)
         return { ...t, sentPartIds: newIds }
       })
-      discordLogger.error(
-        `ERROR: Failed to send part ${part.id}:`,
-        sendResult,
-      )
+      discordLogger.error(`ERROR: Failed to send part ${part.id}:`, sendResult)
       return
     }
     await setPartMessage({ partId: part.id, messageId: sendResult.id, threadId: this.thread.id })
@@ -1812,24 +1723,22 @@ export class ThreadSessionRuntime {
     if (!client) {
       return
     }
-    const providersResponse = await client.provider.list({ directory: this.sdkDirectory })
+    const providersResponse = await client.provider
+      .list({ directory: this.sdkDirectory })
       .catch((e) => new OpenCodeSdkError({ operation: 'provider.list', cause: e }))
     if (providersResponse instanceof Error) {
-      logger.error(
-        'Failed to fetch provider info for context limit:',
-        providersResponse,
-      )
+      logger.error('Failed to fetch provider info for context limit:', providersResponse)
       return
     }
-    const provider = providersResponse.data?.all?.find(
-      (p) => {
-        return p.id === providerID
-      },
-    )
-    const model = provider?.models?.[modelID]
-    const contextLimit = model?.limit?.context || getFallbackContextLimit({
-      providerID,
+    const provider = providersResponse.data?.all?.find((p) => {
+      return p.id === providerID
     })
+    const model = provider?.models?.[modelID]
+    const contextLimit =
+      model?.limit?.context ||
+      getFallbackContextLimit({
+        providerID,
+      })
     if (!contextLimit) {
       return
     }
@@ -1853,12 +1762,16 @@ export class ThreadSessionRuntime {
     if (!sessionId) {
       return
     }
-    if (!isAssistantMessageInLatestUserTurn({
-      events: this.eventBuffer,
-      sessionId,
-      messageId: msg.id,
-    })) {
-      logger.info(`[SKIP] message.updated for old assistant message ${msg.id}, not in latest user turn`)
+    if (
+      !isAssistantMessageInLatestUserTurn({
+        events: this.eventBuffer,
+        sessionId,
+        messageId: msg.id,
+      })
+    ) {
+      logger.info(
+        `[SKIP] message.updated for old assistant message ${msg.id}, not in latest user turn`,
+      )
       return
     }
 
@@ -1907,9 +1820,9 @@ export class ThreadSessionRuntime {
     })
     const completedAt = msg.time.completed
     if (
-      !wasAlreadyCompleted
-      && typeof completedAt === 'number'
-      && isAssistantMessageNaturalCompletion({ message: msg })
+      !wasAlreadyCompleted &&
+      typeof completedAt === 'number' &&
+      isAssistantMessageNaturalCompletion({ message: msg })
     ) {
       await this.handleNaturalAssistantCompletion({
         completedMessageId: msg.id,
@@ -1930,11 +1843,7 @@ export class ThreadSessionRuntime {
       events: this.eventBuffer,
       sessionId,
     })
-    if (
-      latestRunInfo.tokensUsed === 0
-      || !latestRunInfo.providerID
-      || !latestRunInfo.model
-    ) {
+    if (latestRunInfo.tokensUsed === 0 || !latestRunInfo.providerID || !latestRunInfo.model) {
       return
     }
     await this.ensureModelContextLimit({
@@ -1944,19 +1853,15 @@ export class ThreadSessionRuntime {
     if (!this.modelContextLimit) {
       return
     }
-    const currentPercentage = Math.floor(
-      (latestRunInfo.tokensUsed / this.modelContextLimit) * 100,
-    )
+    const currentPercentage = Math.floor((latestRunInfo.tokensUsed / this.modelContextLimit) * 100)
     const thresholdCrossed = Math.floor(currentPercentage / 10) * 10
-    if (
-      thresholdCrossed <= this.lastDisplayedContextPercentage ||
-      thresholdCrossed < 10
-    ) {
+    if (thresholdCrossed <= this.lastDisplayedContextPercentage || thresholdCrossed < 10) {
       return
     }
     this.lastDisplayedContextPercentage = thresholdCrossed
     const chunk = `⬦ context usage ${currentPercentage}%`
-    const sendResult = await this.thread.send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
+    const sendResult = await this.thread
+      .send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
       .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
     if (sendResult instanceof Error) {
       discordLogger.error('Failed to send context usage notice:', sendResult)
@@ -2001,17 +1906,13 @@ export class ThreadSessionRuntime {
       // Track task tool spawning subtask sessions
       if (part.tool === 'task' && !this.state?.sentPartIds.has(part.id)) {
         const description =
-          typeof part.state.input?.description === 'string'
-            ? part.state.input.description
-            : ''
+          typeof part.state.input?.description === 'string' ? part.state.input.description : ''
         const agent =
           typeof part.state.input?.subagent_type === 'string'
             ? part.state.input.subagent_type
             : 'task'
         const childSessionId =
-          typeof part.state.metadata?.sessionId === 'string'
-            ? part.state.metadata.sessionId
-            : ''
+          typeof part.state.metadata?.sessionId === 'string' ? part.state.metadata.sessionId : ''
         if (description && childSessionId) {
           if ((await this.getVerbosity()) !== 'text_only') {
             const taskDisplay = `┣ ${agent} **${description}**`
@@ -2020,21 +1921,23 @@ export class ThreadSessionRuntime {
               newIds.add(part.id)
               return { ...t, sentPartIds: newIds }
             })
-            const sendResult = await sendThreadMessage(this.thread, taskDisplay + '\n\n')
-              .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
+            const sendResult = await sendThreadMessage(this.thread, taskDisplay + '\n\n').catch(
+              (e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }),
+            )
             if (sendResult instanceof Error) {
               threadState.updateThread(this.threadId, (t) => {
                 const newIds = new Set(t.sentPartIds)
                 newIds.delete(part.id)
                 return { ...t, sentPartIds: newIds }
               })
-              discordLogger.error(
-                `ERROR: Failed to send task part ${part.id}:`,
-                sendResult,
-              )
+              discordLogger.error(`ERROR: Failed to send task part ${part.id}:`, sendResult)
               return
             }
-            await setPartMessage({ partId: part.id, messageId: sendResult.id, threadId: this.thread.id })
+            await setPartMessage({
+              partId: part.id,
+              messageId: sendResult.id,
+              threadId: this.thread.id,
+            })
           }
         }
       }
@@ -2060,15 +1963,11 @@ export class ThreadSessionRuntime {
             timeoutMs: 1500,
           })
           if (!request) {
-            logger.warn(
-              `[ACTION] No queued action-buttons request found for session ${sessionId}`,
-            )
+            logger.warn(`[ACTION] No queued action-buttons request found for session ${sessionId}`)
             return
           }
           if (request.threadId !== this.thread.id) {
-            logger.warn(
-              `[ACTION] Ignoring queued action-buttons for different thread`,
-            )
+            logger.warn(`[ACTION] Ignoring queued action-buttons for different thread`)
             return
           }
           const showResult = await showActionButtons({
@@ -2079,10 +1978,7 @@ export class ThreadSessionRuntime {
             silent: this.getQueueLength() > 0,
           }).catch((e) => new DiscordOperationError({ operation: 'showActionButtons', cause: e }))
           if (showResult instanceof Error) {
-            logger.error(
-              '[ACTION] Failed to show action buttons:',
-              showResult,
-            )
+            logger.error('[ACTION] Failed to show action buttons:', showResult)
             await sendThreadMessage(
               this.thread,
               `Failed to show action buttons: ${showResult.message}`,
@@ -2104,7 +2000,9 @@ export class ThreadSessionRuntime {
           messageId: part.messageID,
         })
         if (!isCurrentRunMessage) {
-          logger.info(`[SKIP] tool part ${part.id} for old assistant message ${part.messageID}, not in latest user turn`)
+          logger.info(
+            `[SKIP] tool part ${part.id} for old assistant message ${part.messageID}, not in latest user turn`,
+          )
           return
         }
       }
@@ -2136,9 +2034,7 @@ export class ThreadSessionRuntime {
             }
           }
           const formattedTokens =
-            outputTokens >= 1000
-              ? `${(outputTokens / 1000).toFixed(1)}k`
-              : String(outputTokens)
+            outputTokens >= 1000 ? `${(outputTokens / 1000).toFixed(1)}k` : String(outputTokens)
           const percentageSuffix = (() => {
             if (!this.modelContextLimit) {
               return ''
@@ -2150,10 +2046,12 @@ export class ThreadSessionRuntime {
             return ` (${pct.toFixed(1)}%)`
           })()
           const chunk = `⬦ ${part.tool} returned ${formattedTokens} tokens${percentageSuffix}`
-          const largeOutputResult = await this.thread.send({
-            content: chunk,
-            flags: SILENT_MESSAGE_FLAGS,
-          }).catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
+          const largeOutputResult = await this.thread
+            .send({
+              content: chunk,
+              flags: SILENT_MESSAGE_FLAGS,
+            })
+            .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
           if (largeOutputResult instanceof Error) {
             discordLogger.error('Failed to send large output notice:', largeOutputResult)
           }
@@ -2202,10 +2100,7 @@ export class ThreadSessionRuntime {
     if (part.type === 'text') {
       return
     }
-    if (
-      !subtaskInfo.assistantMessageId ||
-      part.messageID !== subtaskInfo.assistantMessageId
-    ) {
+    if (!subtaskInfo.assistantMessageId || part.messageID !== subtaskInfo.assistantMessageId) {
       return
     }
 
@@ -2213,13 +2108,11 @@ export class ThreadSessionRuntime {
     if (!content.trim() || this.state?.sentPartIds.has(part.id)) {
       return
     }
-    const sendResult = await sendThreadMessage(this.thread, content + '\n\n')
-      .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
+    const sendResult = await sendThreadMessage(this.thread, content + '\n\n').catch(
+      (e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }),
+    )
     if (sendResult instanceof Error) {
-      discordLogger.error(
-        `ERROR: Failed to send subtask part ${part.id}:`,
-        sendResult,
-      )
+      discordLogger.error(`ERROR: Failed to send subtask part ${part.id}:`, sendResult)
       return
     }
     threadState.updateThread(this.threadId, (t) => {
@@ -2237,9 +2130,7 @@ export class ThreadSessionRuntime {
     // ── Subtask idle ──────────────────────────────────────────
     const subtask = this.getSubtaskInfoForSession(idleSessionId)
     if (subtask) {
-      logger.log(
-        `[SUBTASK IDLE] Subtask "${subtask?.label}" completed`,
-      )
+      logger.log(`[SUBTASK IDLE] Subtask "${subtask?.label}" completed`)
       return
     }
 
@@ -2280,9 +2171,7 @@ export class ThreadSessionRuntime {
       return
     }
 
-    const assistantMessageIds = [
-      ...this.getAssistantMessageIdsForCurrentTurn({ sessionId }),
-    ]
+    const assistantMessageIds = [...this.getAssistantMessageIdsForCurrentTurn({ sessionId })]
     if (assistantMessageIds.length === 0) {
       return
     }
@@ -2343,15 +2232,11 @@ export class ThreadSessionRuntime {
       return
     }
 
-    const errorMessage = truncateSessionErrorMessage(
-      formatSessionErrorFromProps(properties.error),
-    )
+    const errorMessage = truncateSessionErrorMessage(formatSessionErrorFromProps(properties.error))
     logger.error(`Sending error to thread: ${errorMessage}`)
-    await sendThreadMessage(
-      this.thread,
-      `✗ opencode session error: ${errorMessage}`,
-      { flags: NOTIFY_MESSAGE_FLAGS },
-    )
+    await sendThreadMessage(this.thread, `✗ opencode session error: ${errorMessage}`, {
+      flags: NOTIFY_MESSAGE_FLAGS,
+    })
     await this.persistEventBufferDebounced.flush()
 
     // Inject synthetic idle so isSessionBusy() returns false and queued
@@ -2362,9 +2247,7 @@ export class ThreadSessionRuntime {
     await this.tryDrainQueue({ showIndicator: true })
   }
 
-  private async handlePermissionAsked(
-    permission: PermissionRequest,
-  ): Promise<void> {
+  private async handlePermissionAsked(permission: PermissionRequest): Promise<void> {
     const sessionId = this.state?.sessionId
     const subtaskInfo = this.getSubtaskInfoForSession(permission.sessionID)
     const isMainSession = permission.sessionID === sessionId
@@ -2422,9 +2305,7 @@ export class ThreadSessionRuntime {
         requestId: permission.id,
       })
       if (!added) {
-        logger.log(
-          `[PERMISSION] Failed to attach duplicate request ${permission.id} to context`,
-        )
+        logger.log(`[PERMISSION] Failed to attach duplicate request ${permission.id} to context`)
       }
       return
     }
@@ -2468,9 +2349,7 @@ export class ThreadSessionRuntime {
       return
     }
 
-    logger.log(
-      `Permission ${properties.requestID} replied with: ${properties.reply}`,
-    )
+    logger.log(`Permission ${properties.requestID} replied with: ${properties.reply}`)
 
     const threadPermissions = pendingPermissions.get(this.thread.id)
     if (!threadPermissions) {
@@ -2488,9 +2367,7 @@ export class ThreadSessionRuntime {
     this.onInteractiveUiStateChanged()
   }
 
-  private async handleQuestionAsked(
-    questionRequest: QuestionRequest,
-  ): Promise<void> {
+  private async handleQuestionAsked(questionRequest: QuestionRequest): Promise<void> {
     const sessionId = this.state?.sessionId
     if (questionRequest.sessionID !== sessionId) {
       logger.log(
@@ -2558,10 +2435,12 @@ export class ThreadSessionRuntime {
     if (!sessionId) {
       return
     }
-    if (didQuestionQueueHandoffSinceLatestQuestionAsked({
-      events: this.eventBuffer,
-      sessionId,
-    })) {
+    if (
+      didQuestionQueueHandoffSinceLatestQuestionAsked({
+        events: this.eventBuffer,
+        sessionId,
+      })
+    ) {
       return
     }
     if (this.getQueueLength() === 0) {
@@ -2575,14 +2454,16 @@ export class ThreadSessionRuntime {
     )
     this.questionQueueHandoffPromise = this.handoffQueuedItemForPendingQuestion({
       sessionId,
-    }).catch((error) => {
-      logger.error('[QUESTION QUEUE HANDOFF] Failed to hand off queued message:', error)
-      if (error instanceof Error) {
-        void notifyError(error, 'Failed to hand off queued message during pending question')
-      }
-    }).finally(() => {
-      this.questionQueueHandoffPromise = null
     })
+      .catch((error) => {
+        logger.error('[QUESTION QUEUE HANDOFF] Failed to hand off queued message:', error)
+        if (error instanceof Error) {
+          void notifyError(error, 'Failed to hand off queued message during pending question')
+        }
+      })
+      .finally(() => {
+        this.questionQueueHandoffPromise = null
+      })
   }
 
   private async handoffQueuedItemForPendingQuestion({
@@ -2609,10 +2490,7 @@ export class ThreadSessionRuntime {
       ? `/${next.command.name}`
       : `${next.prompt.slice(0, 150)}${next.prompt.length > 150 ? '...' : ''}`
     if (displayText.trim()) {
-      await sendThreadMessage(
-        this.thread,
-        `» **${next.username}:** ${displayText}`,
-      )
+      await sendThreadMessage(this.thread, `» **${next.username}:** ${displayText}`)
     }
 
     this.markQuestionQueueHandoffStarted(sessionId)
@@ -2665,7 +2543,8 @@ export class ThreadSessionRuntime {
     })()
 
     const chunk = `⬦ ${message} - retrying in ${duration} (attempt #${attempt})`
-    const retryResult = await this.thread.send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
+    const retryResult = await this.thread
+      .send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
       .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
     if (retryResult instanceof Error) {
       discordLogger.error('Failed to send retry notice:', retryResult)
@@ -2681,18 +2560,14 @@ export class ThreadSessionRuntime {
   // - race setName() against an AbortSignal.timeout() so a throttled call never
   //   blocks the event loop
   // - fail soft (log + continue) on timeout, 429, or any other error
-  private async handleSessionUpdated(info: {
-    id: string
-    title: string
-  }): Promise<void> {
+  private async handleSessionUpdated(info: { id: string; title: string }): Promise<void> {
     // Only act on the main session for this thread
     if (info.id !== this.state?.sessionId) {
       return
     }
     if (this.lastSyncedThreadName === undefined) {
       const persistedName = await this.loadLastSyncedThreadName().catch(
-        (e) =>
-          new Error('Failed to read persisted thread rename state', { cause: e }),
+        (e) => new Error('Failed to read persisted thread rename state', { cause: e }),
       )
       if (persistedName instanceof Error) {
         logger.warn(`[TITLE] ${persistedName.message} for thread ${this.threadId}`)
@@ -2728,12 +2603,12 @@ export class ThreadSessionRuntime {
     const RENAME_TIMEOUT_MS = 3000
     const timeoutSignal = AbortSignal.timeout(RENAME_TIMEOUT_MS)
     const renameResult = await Promise.race([
-      this.thread.setName(desiredName)
-        .catch((e) =>
+      this.thread.setName(desiredName).catch(
+        (e) =>
           new Error('Failed to rename thread from OpenCode title', {
             cause: e,
           }),
-        ),
+      ),
       new Promise<'timeout'>((resolve) => {
         timeoutSignal.addEventListener('abort', () => {
           resolve('timeout')
@@ -2748,9 +2623,7 @@ export class ThreadSessionRuntime {
       return
     }
     if (renameResult instanceof Error) {
-      logger.warn(
-        `[TITLE] Could not rename thread ${this.threadId}: ${renameResult.message}`,
-      )
+      logger.warn(`[TITLE] Could not rename thread ${this.threadId}: ${renameResult.message}`)
       return
     }
     await this.persistLastSyncedThreadName(desiredName)
@@ -2771,7 +2644,8 @@ export class ThreadSessionRuntime {
   private async persistLastSyncedThreadName(name: string): Promise<void> {
     this.lastSyncedThreadName = name
     const db = await getDb()
-    const result = await db.update(schema.thread_sessions)
+    const result = await db
+      .update(schema.thread_sessions)
       .set({ last_synced_name: name })
       .where(orm.eq(schema.thread_sessions.thread_id, this.threadId))
       .catch(
@@ -2802,11 +2676,10 @@ export class ThreadSessionRuntime {
     if (!toastMessage) {
       return
     }
-    const titlePrefix = properties.title
-      ? `${properties.title.trim()}: `
-      : ''
+    const titlePrefix = properties.title ? `${properties.title.trim()}: ` : ''
     const chunk = `⬦ ${properties.variant}: ${titlePrefix}${toastMessage}`
-    const toastResult = await this.thread.send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
+    const toastResult = await this.thread
+      .send({ content: chunk, flags: SILENT_MESSAGE_FLAGS })
       .catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
     if (toastResult instanceof Error) {
       discordLogger.error('Failed to send toast notice:', toastResult)
@@ -2827,10 +2700,7 @@ export class ThreadSessionRuntime {
     let skippedBySessionGuard = false
 
     await this.dispatchAction(async () => {
-      if (
-        input.expectedSessionId &&
-        this.state?.sessionId !== input.expectedSessionId
-      ) {
+      if (input.expectedSessionId && this.state?.sessionId !== input.expectedSessionId) {
         logger.log(
           `[ENQUEUE] Skipping stale promptAsync enqueue for thread ${this.threadId}: expected session ${input.expectedSessionId}, current session ${this.state?.sessionId || 'none'}`,
         )
@@ -2872,7 +2742,9 @@ export class ThreadSessionRuntime {
         permissionRules: input.permissionRules,
       })
       if (updatePermissionsResult instanceof Error) {
-        await cleanupOnError(`Failed to update session permissions: ${updatePermissionsResult.message}`)
+        await cleanupOnError(
+          `Failed to update session permissions: ${updatePermissionsResult.message}`,
+        )
         return
       }
 
@@ -2958,7 +2830,8 @@ export class ThreadSessionRuntime {
         if (!preferredVariant) {
           return undefined
         }
-        const providersResponse = await getClient().provider.list({ directory: this.sdkDirectory })
+        const providersResponse = await getClient()
+          .provider.list({ directory: this.sdkDirectory })
           .catch((e) => new OpenCodeSdkError({ operation: 'provider.list', cause: e }))
         if (providersResponse instanceof Error || !providersResponse.data) {
           return undefined
@@ -2971,15 +2844,15 @@ export class ThreadSessionRuntime {
         if (availableValues.length === 0) {
           return undefined
         }
-        return matchThinkingValue({
-          requestedValue: preferredVariant,
-          availableValues,
-        }) || undefined
+        return (
+          matchThinkingValue({
+            requestedValue: preferredVariant,
+            availableValues,
+          }) || undefined
+        )
       })()
 
-      const variantField = thinkingValue
-        ? { variant: thinkingValue }
-        : {}
+      const variantField = thinkingValue ? { variant: thinkingValue } : {}
 
       await this.sendNewSessionModelInfo({
         createdNewSession,
@@ -3019,7 +2892,8 @@ export class ThreadSessionRuntime {
         if (!channelId) {
           return undefined
         }
-        const fetched = await this.thread.guild.channels.fetch(channelId)
+        const fetched = await this.thread.guild.channels
+          .fetch(channelId)
           .catch((e) => new DiscordOperationError({ operation: 'fetchChannel', cause: e }))
         if (fetched instanceof Error || !fetched) {
           return undefined
@@ -3064,15 +2938,15 @@ export class ThreadSessionRuntime {
         ...(modelField ? { model: modelField } : {}),
         ...variantField,
       }
-      const promptResult = await getClient().session.promptAsync(request)
+      const promptResult = await getClient()
+        .session.promptAsync(request)
         .catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
       if (promptResult instanceof Error || promptResult.error) {
-        const errorMessage = promptResult instanceof Error
-          ? promptResult.message
-          : extractSdkErrorMessage(promptResult.error)
-        const errObj = promptResult instanceof Error
-          ? promptResult
-          : new Error(errorMessage)
+        const errorMessage =
+          promptResult instanceof Error
+            ? promptResult.message
+            : extractSdkErrorMessage(promptResult.error)
+        const errObj = promptResult instanceof Error ? promptResult : new Error(errorMessage)
         void notifyError(errObj, 'promptAsync failed in submitViaOpencodeQueue')
         await cleanupOnError(`✗ OpenCode API error: ${errorMessage}`)
         return
@@ -3125,14 +2999,9 @@ export class ThreadSessionRuntime {
       const stateAfterEnqueue = threadState.getThreadState(this.threadId)
       const position = stateAfterEnqueue?.queueItems.length ?? 0
       const willDrainNow = stateAfterEnqueue
-        ? (
-          stateAfterEnqueue.queueItems.length > 0
-          && !this.isMainSessionBusy()
-        )
+        ? stateAfterEnqueue.queueItems.length > 0 && !this.isMainSessionBusy()
         : false
-      result = !willDrainNow && position > 0
-        ? { queued: true, position }
-        : { queued: false }
+      result = !willDrainNow && position > 0 ? { queued: true, position } : { queued: false }
 
       if (this.hasPendingQuestionUi()) {
         this.maybeHandoffQueuedItemForPendingQuestion({
@@ -3221,19 +3090,14 @@ export class ThreadSessionRuntime {
           // no explicit agent was already set (CLI --agent flag wins).
           agent: input.agent || result.agent,
           repliedMessage: result.repliedMessage,
-          permissionRules: [
-            ...(input.permissionRules ?? []),
-            ...(result.permissionRules ?? []),
-          ],
+          permissionRules: [...(input.permissionRules ?? []), ...(result.permissionRules ?? [])],
           preprocess: undefined,
         })
 
         const hasPromptText = resolvedInput.prompt.trim().length > 0
         const hasImages = (resolvedInput.images?.length || 0) > 0
         if (!hasPromptText && !hasImages && !resolvedInput.command) {
-          logger.warn(
-            `[INGRESS] Skipping empty preprocessed input threadId=${this.threadId}`,
-          )
+          logger.warn(`[INGRESS] Skipping empty preprocessed input threadId=${this.threadId}`)
           resolveOuter({ queued: false })
           return
         }
@@ -3276,13 +3140,13 @@ export class ThreadSessionRuntime {
     }
 
     const startedAt = Date.now()
-    logger.log(
-      `[ABORT API] id=${abortId} reason=${reason} sessionId=${sessionId} start`,
-    )
-    const abortResult = await client.session.abort({
-      sessionID: sessionId,
-      directory: this.sdkDirectory,
-    }).catch((e) => new OpenCodeSdkError({ operation: 'session.abort', cause: e }))
+    logger.log(`[ABORT API] id=${abortId} reason=${reason} sessionId=${sessionId} start`)
+    const abortResult = await client.session
+      .abort({
+        sessionID: sessionId,
+        directory: this.sdkDirectory,
+      })
+      .catch((e) => new OpenCodeSdkError({ operation: 'session.abort', cause: e }))
     if (!(abortResult instanceof Error)) {
       logger.log(
         `[ABORT API] id=${abortId} reason=${reason} sessionId=${sessionId} success durationMs=${Date.now() - startedAt}`,
@@ -3294,11 +3158,7 @@ export class ThreadSessionRuntime {
     )
   }
 
-  private abortActiveRunInternal({
-    reason,
-  }: {
-    reason: string
-  }): AbortRunOutcome {
+  private abortActiveRunInternal({ reason }: { reason: string }): AbortRunOutcome {
     const abortId = this.nextAbortId(reason)
     const state = this.state
     if (!state) {
@@ -3380,8 +3240,10 @@ export class ThreadSessionRuntime {
     }
     await this.waitForEvent({
       predicate: (event) => {
-        return event.type === 'session.idle'
-          && (event.properties as { sessionID?: string }).sessionID === sessionId
+        return (
+          event.type === 'session.idle' &&
+          (event.properties as { sessionID?: string }).sessionID === sessionId
+        )
       },
       sinceTimestamp: waitSinceTimestamp,
       timeoutMs,
@@ -3396,9 +3258,7 @@ export class ThreadSessionRuntime {
   /** NOTIFY_MESSAGE_FLAGS unless queue has a next item, then SILENT.
    * Permissions should NOT use this — they always notify. */
   private getNotifyFlags(): number {
-    return this.getQueueLength() > 0
-      ? SILENT_MESSAGE_FLAGS
-      : NOTIFY_MESSAGE_FLAGS
+    return this.getQueueLength() > 0 ? SILENT_MESSAGE_FLAGS : NOTIFY_MESSAGE_FLAGS
   }
 
   /** Clear all queued messages. */
@@ -3472,9 +3332,7 @@ export class ThreadSessionRuntime {
       return
     }
 
-    logger.log(
-      `[QUEUE DRAIN] Processing queued message from ${next.username}`,
-    )
+    logger.log(`[QUEUE DRAIN] Processing queued message from ${next.username}`)
 
     // Show queued message indicator only for messages that actually waited
     // behind a running request — not for the first immediate dispatch.
@@ -3483,10 +3341,7 @@ export class ThreadSessionRuntime {
         ? `/${next.command.name}`
         : `${next.prompt.slice(0, 150)}${next.prompt.length > 150 ? '...' : ''}`
       if (displayText.trim()) {
-        await sendThreadMessage(
-          this.thread,
-          `» **${next.username}:** ${displayText}`,
-        )
+        await sendThreadMessage(this.thread, `» **${next.username}:** ${displayText}`)
       }
     }
 
@@ -3499,17 +3354,19 @@ export class ThreadSessionRuntime {
     if (dispatchSessionId) {
       this.markQueueDispatchBusy(dispatchSessionId)
     }
-    void this.dispatchPrompt(next).catch(async (err) => {
-      logger.error('[DISPATCH] Prompt dispatch failed:', err)
-      void notifyError(err, 'Runtime prompt dispatch failed')
-      if (dispatchSessionId) {
-        this.markQueueDispatchIdle(dispatchSessionId)
-      }
-    }).finally(() => {
-      void this.dispatchAction(() => {
-        return this.tryDrainQueue({ showIndicator: true })
+    void this.dispatchPrompt(next)
+      .catch(async (err) => {
+        logger.error('[DISPATCH] Prompt dispatch failed:', err)
+        void notifyError(err, 'Runtime prompt dispatch failed')
+        if (dispatchSessionId) {
+          this.markQueueDispatchIdle(dispatchSessionId)
+        }
       })
-    })
+      .finally(() => {
+        void this.dispatchAction(() => {
+          return this.tryDrainQueue({ showIndicator: true })
+        })
+      })
   }
 
   // ── Prompt Dispatch ─────────────────────────────────────────
@@ -3533,11 +3390,9 @@ export class ThreadSessionRuntime {
     })
     if (sessionResult instanceof Error) {
       this.stopTyping()
-      await sendThreadMessage(
-        this.thread,
-        `✗ ${sessionResult.message}`,
-        { flags: NOTIFY_MESSAGE_FLAGS },
-      )
+      await sendThreadMessage(this.thread, `✗ ${sessionResult.message}`, {
+        flags: NOTIFY_MESSAGE_FLAGS,
+      })
       // Show indicator: this dispatch failed, so the next queued message
       // has been waiting — the user needs to see which one is starting.
       await this.tryDrainQueue({ showIndicator: true })
@@ -3595,11 +3450,9 @@ export class ThreadSessionRuntime {
     }).catch((e) => new OpenCodeSdkError({ operation: 'resolveAgent', cause: e }))
     if (earlyAgentResult instanceof Error) {
       this.stopTyping()
-      await sendThreadMessage(
-        this.thread,
-        `Failed to resolve agent: ${earlyAgentResult.message}`,
-        { flags: NOTIFY_MESSAGE_FLAGS },
-      )
+      await sendThreadMessage(this.thread, `Failed to resolve agent: ${earlyAgentResult.message}`, {
+        flags: NOTIFY_MESSAGE_FLAGS,
+      })
       // Show indicator: dispatch failed mid-setup, next queued message was waiting.
       await this.tryDrainQueue({ showIndicator: true })
       return
@@ -3637,11 +3490,9 @@ export class ThreadSessionRuntime {
     ])
     if (earlyModelResult instanceof Error) {
       this.stopTyping()
-      await sendThreadMessage(
-        this.thread,
-        `Failed to resolve model: ${earlyModelResult.message}`,
-        { flags: NOTIFY_MESSAGE_FLAGS },
-      )
+      await sendThreadMessage(this.thread, `Failed to resolve model: ${earlyModelResult.message}`, {
+        flags: NOTIFY_MESSAGE_FLAGS,
+      })
       // Show indicator: dispatch failed mid-setup, next queued message was waiting.
       await this.tryDrainQueue({ showIndicator: true })
       return
@@ -3663,7 +3514,8 @@ export class ThreadSessionRuntime {
       if (!preferredVariant) {
         return undefined
       }
-      const providersResponse = await getClient().provider.list({ directory: this.sdkDirectory })
+      const providersResponse = await getClient()
+        .provider.list({ directory: this.sdkDirectory })
         .catch((e) => new OpenCodeSdkError({ operation: 'provider.list', cause: e }))
       if (providersResponse instanceof Error || !providersResponse.data) {
         return undefined
@@ -3676,10 +3528,12 @@ export class ThreadSessionRuntime {
       if (availableValues.length === 0) {
         return undefined
       }
-      return matchThinkingValue({
-        requestedValue: preferredVariant,
-        availableValues,
-      }) || undefined
+      return (
+        matchThinkingValue({
+          requestedValue: preferredVariant,
+          availableValues,
+        }) || undefined
+      )
     })()
 
     await this.ensureModelContextLimit({
@@ -3725,7 +3579,8 @@ export class ThreadSessionRuntime {
       if (!channelId) {
         return undefined
       }
-      const fetched = await this.thread.guild.channels.fetch(channelId)
+      const fetched = await this.thread.guild.channels
+        .fetch(channelId)
         .catch((e) => new DiscordOperationError({ operation: 'fetchChannel', cause: e }))
       if (fetched instanceof Error || !fetched) {
         return undefined
@@ -3752,25 +3607,14 @@ export class ThreadSessionRuntime {
       ...images,
     ]
 
-    const variantField = earlyThinkingValue
-      ? { variant: earlyThinkingValue }
-      : {}
+    const variantField = earlyThinkingValue ? { variant: earlyThinkingValue } : {}
 
     const parseOpenCodeErrorMessage = (err: unknown): string => {
       if (err && typeof err === 'object') {
-        if (
-          'data' in err &&
-          err.data &&
-          typeof err.data === 'object' &&
-          'message' in err.data
-        ) {
+        if ('data' in err && err.data && typeof err.data === 'object' && 'message' in err.data) {
           return String(err.data.message)
         }
-        if (
-          'errors' in err &&
-          Array.isArray(err.errors) &&
-          err.errors.length > 0
-        ) {
+        if ('errors' in err && Array.isArray(err.errors) && err.errors.length > 0) {
           return JSON.stringify(err.errors)
         }
         if ('message' in err && typeof err.message === 'string') {
@@ -3793,19 +3637,21 @@ export class ThreadSessionRuntime {
         sourceThreadId: input.sourceThreadId,
         repliedMessage: input.repliedMessage,
       })
-      const commandResponse = await getClient().session.command(
-        {
-          sessionID: session.id,
+      const commandResponse = await getClient()
+        .session.command(
+          {
+            sessionID: session.id,
 
-          directory: this.sdkDirectory,
-          command: queuedCommand.name,
-          arguments: queuedCommand.arguments + (discordTag ? `\n${discordTag}` : ''),
-          agent: earlyAgentPreference,
-          model: `${earlyModelParam.providerID}/${earlyModelParam.modelID}`,
-          ...variantField,
-        },
-        { signal: commandSignal },
-      ).catch((e) => new OpenCodeSdkError({ operation: 'session.command', cause: e }))
+            directory: this.sdkDirectory,
+            command: queuedCommand.name,
+            arguments: queuedCommand.arguments + (discordTag ? `\n${discordTag}` : ''),
+            agent: earlyAgentPreference,
+            model: `${earlyModelParam.providerID}/${earlyModelParam.modelID}`,
+            ...variantField,
+          },
+          { signal: commandSignal },
+        )
+        .catch((e) => new OpenCodeSdkError({ operation: 'session.command', cause: e }))
 
       if (commandResponse instanceof Error) {
         const timeoutReason = commandSignal.reason
@@ -3814,9 +3660,7 @@ export class ThreadSessionRuntime {
           timeoutReason instanceof Error &&
           timeoutReason.name === 'TimeoutError'
         if (timedOut) {
-          logger.warn(
-            `[DISPATCH] Command timed out after 30s sessionId=${session.id}`,
-          )
+          logger.warn(`[DISPATCH] Command timed out after 30s sessionId=${session.id}`)
           this.stopTyping()
           await sendThreadMessage(
             this.thread,
@@ -3831,23 +3675,17 @@ export class ThreadSessionRuntime {
 
         const commandErrorForAbortCheck: unknown = commandResponse
         if (isAbortError(commandErrorForAbortCheck)) {
-          logger.log(
-            `[DISPATCH] Command aborted (expected) sessionId=${session.id}`,
-          )
+          logger.log(`[DISPATCH] Command aborted (expected) sessionId=${session.id}`)
           this.stopTyping()
           return
         }
 
-        logger.error(
-          `[DISPATCH] Command SDK call failed: ${commandResponse.message}`,
-        )
+        logger.error(`[DISPATCH] Command SDK call failed: ${commandResponse.message}`)
         void notifyError(commandResponse, 'Failed to send command to OpenCode')
         this.stopTyping()
-        await sendThreadMessage(
-          this.thread,
-          `✗ Unexpected bot Error: ${commandResponse.message}`,
-          { flags: NOTIFY_MESSAGE_FLAGS },
-        )
+        await sendThreadMessage(this.thread, `✗ Unexpected bot Error: ${commandResponse.message}`, {
+          flags: NOTIFY_MESSAGE_FLAGS,
+        })
         await this.dispatchAction(() => {
           return this.tryDrainQueue({ showIndicator: true })
         })
@@ -3857,9 +3695,7 @@ export class ThreadSessionRuntime {
       if (commandResponse.error) {
         const errorMessage = parseOpenCodeErrorMessage(commandResponse.error)
         if (errorMessage.includes('aborted')) {
-          logger.log(
-            `[DISPATCH] Command aborted (expected) sessionId=${session.id}`,
-          )
+          logger.log(`[DISPATCH] Command aborted (expected) sessionId=${session.id}`)
           this.stopTyping()
           return
         }
@@ -3880,33 +3716,33 @@ export class ThreadSessionRuntime {
       return
     }
 
-    const promptResponse = await getClient().session.promptAsync({
-      sessionID: session.id,
-      directory: this.sdkDirectory,
-      parts,
-      system: getOpencodeSystemMessage({
-        sessionId: session.id,
-        channelId,
-        guildId: this.thread.guildId,
-        threadId: this.thread.id,
-        channelTopic,
-        agents: earlyAvailableAgents,
-        username: this.state?.sessionUsername || input.username,
-        userId: this.state?.sessionUserId || input.userId,
-      }),
-      model: earlyModelParam,
-      agent: earlyAgentPreference,
-      ...variantField,
-    }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
+    const promptResponse = await getClient()
+      .session.promptAsync({
+        sessionID: session.id,
+        directory: this.sdkDirectory,
+        parts,
+        system: getOpencodeSystemMessage({
+          sessionId: session.id,
+          channelId,
+          guildId: this.thread.guildId,
+          threadId: this.thread.id,
+          channelTopic,
+          agents: earlyAvailableAgents,
+          username: this.state?.sessionUsername || input.username,
+          userId: this.state?.sessionUserId || input.userId,
+        }),
+        model: earlyModelParam,
+        agent: earlyAgentPreference,
+        ...variantField,
+      })
+      .catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
 
     if (promptResponse instanceof Error || promptResponse.error) {
       const errorMessage = (() => {
         if (promptResponse instanceof Error) return promptResponse.message
         return parseOpenCodeErrorMessage(promptResponse.error)
       })()
-      const errorObject = promptResponse instanceof Error
-        ? promptResponse
-        : new Error(errorMessage)
+      const errorObject = promptResponse instanceof Error ? promptResponse : new Error(errorMessage)
       logger.error(`[DISPATCH] Prompt API call failed: ${errorMessage}`)
       void notifyError(errorObject, 'OpenCode API error during local queue prompt')
       this.stopTyping()
@@ -3944,18 +3780,17 @@ export class ThreadSessionRuntime {
       return null
     }
 
-    const rules = [
-      ...(permissionRules ?? []),
-      ...parsePermissionRules(permissions ?? []),
-    ]
+    const rules = [...(permissionRules ?? []), ...parsePermissionRules(permissions ?? [])]
     if (rules.length === 0) {
       return null
     }
 
-    const updateResult = await client.session.update({
-      sessionID: sessionId,
-      permission: rules,
-    }).catch((e) => new OpenCodeSdkError({ operation: 'session.update', cause: e }))
+    const updateResult = await client.session
+      .update({
+        sessionID: sessionId,
+        permission: rules,
+      })
+      .catch((e) => new OpenCodeSdkError({ operation: 'session.update', cause: e }))
     if (updateResult instanceof Error) return updateResult
     if (updateResult.error) {
       return new Error('OpenCode rejected permission update')
@@ -3992,13 +3827,23 @@ export class ThreadSessionRuntime {
 
     // Resolve worktree info for server initialization
     const worktreeInfo = await getThreadWorktree(this.thread.id)
+
+    // Auto-recover missing worktree directory
+    if (worktreeInfo?.status === 'ready' && worktreeInfo.worktree_directory) {
+      const { recoverWorktreeDirectory } = await import('../worktrees.js')
+      const recovery = await recoverWorktreeDirectory({ threadId: this.thread.id })
+      if (!recovery.recovered) {
+        logger.warn(
+          `[WORKTREE] Worktree directory recovery failed: ${recovery.reason}${recovery.error ? ' - ' + recovery.error.message : ''}`,
+        )
+      }
+    }
+
     const worktreeDirectory =
       worktreeInfo?.status === 'ready' && worktreeInfo.worktree_directory
         ? worktreeInfo.worktree_directory
         : undefined
-    const originalRepoDirectory = worktreeDirectory
-      ? worktreeInfo?.project_directory
-      : undefined
+    const originalRepoDirectory = worktreeDirectory ? worktreeInfo?.project_directory : undefined
 
     const getClientResult = await initializeOpencodeForDirectory(directory, {
       originalRepoDirectory,
@@ -4011,17 +3856,19 @@ export class ThreadSessionRuntime {
     let sessionId = this.state?.sessionId
     if (!sessionId) {
       // Fallback to DB
-      sessionId = await getThreadSession(this.thread.id) || undefined
+      sessionId = (await getThreadSession(this.thread.id)) || undefined
     }
 
     let session: { id: string } | undefined
     let createdNewSession = false
 
     if (sessionId) {
-      const sessionResponse = await getClient().session.get({
-        sessionID: sessionId,
-        directory: this.sdkDirectory,
-      }).catch((e) => new OpenCodeSdkError({ operation: 'session.get', cause: e }))
+      const sessionResponse = await getClient()
+        .session.get({
+          sessionID: sessionId,
+          directory: this.sdkDirectory,
+        })
+        .catch((e) => new OpenCodeSdkError({ operation: 'session.get', cause: e }))
       if (sessionResponse instanceof Error) {
         logger.warn(
           `[ENSURE SESSION] Failed to get existing session ${sessionId}: ${sessionResponse.message}`,
@@ -4051,14 +3898,14 @@ export class ThreadSessionRuntime {
         ...parsePermissionRules(permissions ?? []),
       ]
       // Omit title so OpenCode auto-generates a summary from the conversation
-      const createResult = await getClient().session.create({
-        directory: this.sdkDirectory,
-        permission: sessionPermissions,
-      }).catch((e) => new OpenCodeSdkError({ operation: 'session.create', cause: e }))
+      const createResult = await getClient()
+        .session.create({
+          directory: this.sdkDirectory,
+          permission: sessionPermissions,
+        })
+        .catch((e) => new OpenCodeSdkError({ operation: 'session.create', cause: e }))
       if (createResult instanceof Error) {
-        logger.error(
-          `[ENSURE SESSION] session.create failed: ${createResult.message}`,
-        )
+        logger.error(`[ENSURE SESSION] session.create failed: ${createResult.message}`)
         return new Error(
           `Failed to create session: ${createResult.message}, threadId=${this.thread.id}, directory=${this.sdkDirectory}`,
           { cause: createResult },
@@ -4102,13 +3949,9 @@ export class ThreadSessionRuntime {
         sessionId: session.id,
         scheduleKind: sessionStartScheduleKind,
         scheduledTaskId: sessionStartScheduledTaskId,
-      }).catch((e) =>
-        new OpenCodeSdkError({ operation: 'setSessionStartSource', cause: e }),
-      )
+      }).catch((e) => new OpenCodeSdkError({ operation: 'setSessionStartSource', cause: e }))
       if (sessionStartSourceResult instanceof Error) {
-        logger.warn(
-          `[SESSION START SOURCE] ${sessionStartSourceResult.message}`,
-        )
+        logger.warn(`[SESSION START SOURCE] ${sessionStartSourceResult.message}`)
       }
     }
 
@@ -4138,14 +3981,10 @@ export class ThreadSessionRuntime {
     }
 
     const modelLabel = `${model.providerID}/${model.modelID}`
-    const agentLabel = agent && agent.toLowerCase() !== 'build'
-      ? ` ⋅ ${agent}`
-      : ''
-    const result = await sendThreadMessage(
-      this.thread,
-      `*using ${modelLabel}${agentLabel}*`,
-      { flags: SILENT_MESSAGE_FLAGS },
-    ).catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
+    const agentLabel = agent && agent.toLowerCase() !== 'build' ? ` ⋅ ${agent}` : ''
+    const result = await sendThreadMessage(this.thread, `*using ${modelLabel}${agentLabel}*`, {
+      flags: SILENT_MESSAGE_FLAGS,
+    }).catch((e) => new DiscordOperationError({ operation: 'sendMessage', cause: e }))
     if (result instanceof Error) {
       logger.warn(`[SESSION INFO] Failed to send model info: ${result.message}`)
     }
@@ -4167,21 +4006,17 @@ export class ThreadSessionRuntime {
     const runInfo = sessionId
       ? getLatestRunInfo({ events: this.eventBuffer, sessionId })
       : {
-        model: undefined,
-        providerID: undefined,
-        agent: undefined,
-        tokensUsed: 0,
-      }
+          model: undefined,
+          providerID: undefined,
+          agent: undefined,
+          tokensUsed: 0,
+        }
     const elapsedMs = completedAt - runStartTime
     const sessionDuration =
-      elapsedMs < 1000
-        ? '<1s'
-        : prettyMilliseconds(elapsedMs, { secondsDecimalDigits: 0 })
+      elapsedMs < 1000 ? '<1s' : prettyMilliseconds(elapsedMs, { secondsDecimalDigits: 0 })
     const modelInfo = runInfo.model ? ` ⋅ ${runInfo.model}` : ''
     const agentInfo =
-      runInfo.agent && runInfo.agent.toLowerCase() !== 'build'
-        ? ` ⋅ **${runInfo.agent}**`
-        : ''
+      runInfo.agent && runInfo.agent.toLowerCase() !== 'build' ? ` ⋅ **${runInfo.agent}**` : ''
     let contextInfo = ''
     const folderName = path.basename(this.sdkDirectory)
 
@@ -4200,29 +4035,31 @@ export class ThreadSessionRuntime {
         // Fetch final token count from API
         const [messagesResult, providersResult] = await Promise.all([
           tokensUsed === 0
-            ? client.session.messages({
-                sessionID: sessionId,
-                directory: this.sdkDirectory,
-              }).catch((e) => new OpenCodeSdkError({ operation: 'session.messages', cause: e }))
+            ? client.session
+                .messages({
+                  sessionID: sessionId,
+                  directory: this.sdkDirectory,
+                })
+                .catch((e) => new OpenCodeSdkError({ operation: 'session.messages', cause: e }))
             : null,
-          client.provider.list({
-            directory: this.sdkDirectory,
-          }).catch((e) => new OpenCodeSdkError({ operation: 'provider.list', cause: e })),
+          client.provider
+            .list({
+              directory: this.sdkDirectory,
+            })
+            .catch((e) => new OpenCodeSdkError({ operation: 'provider.list', cause: e })),
         ])
 
         if (messagesResult && !(messagesResult instanceof Error)) {
           const messages = messagesResult.data || []
-          const lastAssistant = [...messages]
-            .reverse()
-            .find((m) => {
-              if (m.info.role !== 'assistant') {
-                return false
-              }
-              if (!m.info.tokens) {
-                return false
-              }
-              return getTokenTotal(m.info.tokens) > 0
-            })
+          const lastAssistant = [...messages].reverse().find((m) => {
+            if (m.info.role !== 'assistant') {
+              return false
+            }
+            if (!m.info.tokens) {
+              return false
+            }
+            return getTokenTotal(m.info.tokens) > 0
+          })
           if (lastAssistant && 'tokens' in lastAssistant.info) {
             tokensUsed = getTokenTotal(lastAssistant.info.tokens)
           }
@@ -4244,20 +4081,14 @@ export class ThreadSessionRuntime {
         }
 
         if (contextLimit) {
-          const percentage = Math.round(
-            (tokensUsed / contextLimit) * 100,
-          )
+          const percentage = Math.round((tokensUsed / contextLimit) * 100)
           contextInfo = ` ⋅ ${percentage}%`
         }
       })().catch((e) => new OpenCodeSdkError({ operation: 'resolveModelPreference', cause: e })),
     ])
-    const branchName =
-      branchResult instanceof Error ? '' : branchResult.stdout.trim()
+    const branchName = branchResult instanceof Error ? '' : branchResult.stdout.trim()
     if (contextResult instanceof Error) {
-      logger.error(
-        'Failed to fetch provider info for context percentage:',
-        contextResult,
-      )
+      logger.error('Failed to fetch provider info for context percentage:', contextResult)
     }
 
     const truncate = (s: string, max: number) => {
@@ -4327,8 +4158,10 @@ export class ThreadSessionRuntime {
     if (needsIdleWait) {
       await this.waitForEvent({
         predicate: (event) => {
-          return event.type === 'session.idle'
-            && (event.properties as { sessionID?: string }).sessionID === sessionId
+          return (
+            event.type === 'session.idle' &&
+            (event.properties as { sessionID?: string }).sessionID === sessionId
+          )
         },
         sinceTimestamp: waitSinceTimestamp,
         timeoutMs: 2000,
@@ -4341,15 +4174,11 @@ export class ThreadSessionRuntime {
     }
 
     if (this.state?.sessionId !== sessionId) {
-      logger.log(
-        `[RETRY] Session changed before retry for thread ${this.threadId}`,
-      )
+      logger.log(`[RETRY] Session changed before retry for thread ${this.threadId}`)
       return false
     }
 
-    logger.log(
-      `[RETRY] Re-submitting with empty prompt for session ${sessionId}`,
-    )
+    logger.log(`[RETRY] Re-submitting with empty prompt for session ${sessionId}`)
 
     // 2. Re-submit with empty prompt so opencode continues from session history.
     await this.enqueueIncoming({
@@ -4363,9 +4192,7 @@ export class ThreadSessionRuntime {
     })
 
     if (this.state?.sessionId !== sessionId) {
-      logger.log(
-        `[RETRY] Session changed while retry was enqueued for thread ${this.threadId}`,
-      )
+      logger.log(`[RETRY] Session changed while retry was enqueued for thread ${this.threadId}`)
       return false
     }
 
@@ -4388,11 +4215,7 @@ function buildPermissionDedupeKey({
   return `${directory}::${permission.permission}::${normalizedPatterns.join('|')}`
 }
 
-function getFallbackContextLimit({
-  providerID,
-}: {
-  providerID: string
-}): number | undefined {
+function getFallbackContextLimit({ providerID }: { providerID: string }): number | undefined {
   if (providerID === 'deterministic-provider') {
     return DETERMINISTIC_CONTEXT_LIMIT
   }

--- a/cli/src/worktrees.test.ts
+++ b/cli/src/worktrees.test.ts
@@ -12,6 +12,7 @@ import {
   mergeWorktree,
   parseGitmodulesFileContent,
   parseGitWorktreeListPorcelain,
+  recoverWorktreeFromInfo,
   resolveSessionWorkingDirectory,
 } from './worktrees.js'
 import { TargetDirtyWorktreeError } from './errors.js'
@@ -24,13 +25,7 @@ import { setDataDir } from './config.js'
 
 const GIT_TIMEOUT_MS = 60_000
 
-async function git({
-  cwd,
-  args,
-}: {
-  cwd: string
-  args: string[]
-}): Promise<string> {
+async function git({ cwd, args }: { cwd: string; args: string[] }): Promise<string> {
   const command = `git ${args
     .map((arg) => {
       return JSON.stringify(arg)
@@ -82,10 +77,7 @@ describe('worktrees', () => {
     const plan = buildSubmoduleReferencePlan({
       sourceDirectory,
       submodulePaths: ['errore', 'gateway-proxy', 'traforo'],
-      existingSourceSubmoduleDirectories: new Set([
-        '/repo/errore',
-        '/repo/gateway-proxy',
-      ]),
+      existingSourceSubmoduleDirectories: new Set(['/repo/errore', '/repo/gateway-proxy']),
     })
 
     expect(plan).toMatchInlineSnapshot(`
@@ -155,14 +147,7 @@ describe('worktrees', () => {
 
       await git({
         cwd: parentRepo,
-        args: [
-          '-c',
-          'protocol.file.allow=always',
-          'submodule',
-          'add',
-          submoduleRemote,
-          'errore',
-        ],
+        args: ['-c', 'protocol.file.allow=always', 'submodule', 'add', submoduleRemote, 'errore'],
       })
       await git({ cwd: parentRepo, args: ['commit', '-am', 'add submodule at v1'] })
 
@@ -350,35 +335,35 @@ describe('worktrees', () => {
   })
 
   test('shortenWorktreeSlug leaves short slugs alone', () => {
-    expect(shortenWorktreeSlug('short-name')).toMatchInlineSnapshot(
-      `"short-name"`,
-    )
+    expect(shortenWorktreeSlug('short-name')).toMatchInlineSnapshot(`"short-name"`)
     expect(shortenWorktreeSlug('exactly-twenty-chars')).toMatchInlineSnapshot(
       `"exactly-twenty-chars"`,
     )
   })
 
   test('shortenWorktreeSlug strips vowels from long slugs', () => {
-    expect(
-      shortenWorktreeSlug('configurable-sidebar-width-by-component'),
-    ).toMatchInlineSnapshot(`"cnfgrbl-sdbr-wdth-by-cmpnnt"`)
-    expect(
-      shortenWorktreeSlug('add-dark-mode-toggle-to-settings-page'),
-    ).toMatchInlineSnapshot(`"add-drk-md-tggl-t-sttngs-pg"`)
+    expect(shortenWorktreeSlug('configurable-sidebar-width-by-component')).toMatchInlineSnapshot(
+      `"cnfgrbl-sdbr-wdth-by-cmpnnt"`,
+    )
+    expect(shortenWorktreeSlug('add-dark-mode-toggle-to-settings-page')).toMatchInlineSnapshot(
+      `"add-drk-md-tggl-t-sttngs-pg"`,
+    )
   })
 
   test('formatWorktreeName keeps user-provided slugs verbatim', () => {
-    expect(
-      formatWorktreeName('Configurable sidebar width by component'),
-    ).toMatchInlineSnapshot(`"opencode/kimaki-configurable-sidebar-width-by-component"`)
+    expect(formatWorktreeName('Configurable sidebar width by component')).toMatchInlineSnapshot(
+      `"opencode/kimaki-configurable-sidebar-width-by-component"`,
+    )
     expect(formatWorktreeName('my-feature')).toMatchInlineSnapshot(`"opencode/kimaki-my-feature"`)
   })
 
   test('formatAutoWorktreeName compresses long auto-derived slugs', () => {
-    expect(
-      formatAutoWorktreeName('Configurable sidebar width by component'),
-    ).toMatchInlineSnapshot(`"opencode/kimaki-cnfgrbl-sdbr-wdth-by-cmpnnt"`)
-    expect(formatAutoWorktreeName('my-feature')).toMatchInlineSnapshot(`"opencode/kimaki-my-feature"`)
+    expect(formatAutoWorktreeName('Configurable sidebar width by component')).toMatchInlineSnapshot(
+      `"opencode/kimaki-cnfgrbl-sdbr-wdth-by-cmpnnt"`,
+    )
+    expect(formatAutoWorktreeName('my-feature')).toMatchInlineSnapshot(
+      `"opencode/kimaki-my-feature"`,
+    )
   })
 
   test('getManagedWorktreeDirectory writes under kimaki data dir and strips prefix', () => {
@@ -483,11 +468,7 @@ describe('worktrees', () => {
         cwd: projectDirectory,
         args: ['config', 'user.name', 'Kimaki Tests'],
       })
-      fs.writeFileSync(
-        path.join(projectDirectory, 'README.md'),
-        'project\n',
-        'utf-8',
-      )
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'project\n', 'utf-8')
       await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
       await git({ cwd: projectDirectory, args: ['commit', '-m', 'init'] })
       await git({
@@ -534,9 +515,7 @@ describe('worktrees', () => {
       expect(result).toBeInstanceOf(Error)
       const message = result instanceof Error ? result.message : ''
       expect(
-        message
-          .replace(projectDirectory, '<project>')
-          .replace(siblingDirectory, '<sibling>'),
+        message.replace(projectDirectory, '<project>').replace(siblingDirectory, '<sibling>'),
       ).toMatchInlineSnapshot(
         `"Working directory must be inside <project> or a git worktree of it: <sibling>"`,
       )
@@ -653,13 +632,102 @@ describe('parseGitWorktreeListPorcelain', () => {
   })
 
   test('returns empty array when only main worktree exists', () => {
-    const output = [
-      'worktree /Users/me/project',
-      'HEAD abc123',
-      'branch refs/heads/main',
-      '',
-    ].join('\n')
+    const output = ['worktree /Users/me/project', 'HEAD abc123', 'branch refs/heads/main', ''].join(
+      '\n',
+    )
 
     expect(parseGitWorktreeListPorcelain(output)).toMatchInlineSnapshot(`[]`)
+  })
+})
+
+describe('recoverWorktreeFromInfo', () => {
+  test('returns dir-exists when worktree directory is present', async () => {
+    const sandbox = createTestRoot()
+    try {
+      // Init a git repo as the "project"
+      await git({ cwd: sandbox, args: ['init'] })
+      await git({ cwd: sandbox, args: ['config', 'user.email', 'test@test.com'] })
+      await git({ cwd: sandbox, args: ['config', 'user.name', 'Test'] })
+      fs.writeFileSync(path.join(sandbox, 'readme.md'), 'project')
+      await git({ cwd: sandbox, args: ['add', '.'] })
+      await git({ cwd: sandbox, args: ['commit', '-m', 'init'] })
+
+      // Create a branch for the worktree and switch back to main so we can add it
+      await git({ cwd: sandbox, args: ['checkout', '-b', 'opencode/kimaki-test-worktree'] })
+      await git({ cwd: sandbox, args: ['checkout', 'main'] })
+
+      const worktreeDir = path.join(sandbox, '..', 'kimaki-test-worktree')
+      await git({
+        cwd: sandbox,
+        args: ['worktree', 'add', worktreeDir, 'opencode/kimaki-test-worktree'],
+      })
+
+      const result = await recoverWorktreeFromInfo({
+        projectDirectory: sandbox,
+        worktreeName: 'opencode/kimaki-test-worktree',
+        worktreeDirectory: worktreeDir,
+      })
+
+      expect(result).toEqual({ recovered: false, reason: 'dir-exists' })
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('returns branch-missing when branch does not exist', async () => {
+    const sandbox = createTestRoot()
+    try {
+      // Init a git repo
+      await git({ cwd: sandbox, args: ['init'] })
+      await git({ cwd: sandbox, args: ['config', 'user.email', 'test@test.com'] })
+      await git({ cwd: sandbox, args: ['config', 'user.name', 'Test'] })
+      fs.writeFileSync(path.join(sandbox, 'readme.md'), 'project')
+      await git({ cwd: sandbox, args: ['add', '.'] })
+      await git({ cwd: sandbox, args: ['commit', '-m', 'init'] })
+
+      const result = await recoverWorktreeFromInfo({
+        projectDirectory: sandbox,
+        worktreeName: 'opencode/kimaki-nonexistent-branch',
+        worktreeDirectory: path.join(sandbox, '..', 'nonexistent-worktree'),
+      })
+
+      if (result.recovered) {
+        throw new Error('Expected recovery to fail')
+      }
+      expect(result.reason).toBe('branch-missing')
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('returns project-missing when project directory is gone', async () => {
+    const result = await recoverWorktreeFromInfo({
+      projectDirectory: '/tmp/nonexistent-project-directory-12345',
+      worktreeName: 'opencode/kimaki-test',
+      worktreeDirectory: '/tmp/nonexistent-worktree-12345',
+    })
+
+    expect(result).toEqual({ recovered: false, reason: 'project-missing' })
+  })
+
+  test('returns branch-missing when project is not a git repo', async () => {
+    const sandbox = createTestRoot()
+    try {
+      // Create a directory that is NOT a git repo
+      fs.mkdirSync(path.join(sandbox, 'not-a-repo'), { recursive: true })
+
+      const result = await recoverWorktreeFromInfo({
+        projectDirectory: path.join(sandbox, 'not-a-repo'),
+        worktreeName: 'opencode/kimaki-test',
+        worktreeDirectory: path.join(sandbox, 'nonexistent-worktree'),
+      })
+
+      if (result.recovered) {
+        throw new Error('Expected recovery to fail')
+      }
+      expect(result.reason).toBe('branch-missing')
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
   })
 })

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -172,9 +172,7 @@ export function parseGitmodulesFileContent(
   return configs
 }
 
-async function readSubmoduleConfigs(
-  directory: string,
-): Promise<GitSubmoduleConfig[] | Error> {
+async function readSubmoduleConfigs(directory: string): Promise<GitSubmoduleConfig[] | Error> {
   const gitmodulesPath = path.join(directory, '.gitmodules')
   const gitmodulesExists = await fs.promises
     .access(gitmodulesPath)
@@ -188,12 +186,12 @@ async function readSubmoduleConfigs(
     return []
   }
 
-  const gitmodulesContent = await fs.promises.readFile(gitmodulesPath, 'utf-8')
-    .catch((e) =>
+  const gitmodulesContent = await fs.promises.readFile(gitmodulesPath, 'utf-8').catch(
+    (e) =>
       new Error(`Failed to read ${gitmodulesPath}`, {
         cause: e,
       }),
-    )
+  )
   if (gitmodulesContent instanceof Error) return gitmodulesContent
 
   const parsed = parseGitmodulesFileContent(gitmodulesContent)
@@ -329,18 +327,17 @@ async function initializeSubmodulesWithLocalReferences({
     const result = await execAsync(command, {
       cwd: worktreeDirectory,
       timeout: SUBMODULE_INIT_TIMEOUT_MS,
-    }).catch((e) =>
-      new Error(
-        `git ${commandArgs.join(' ')} failed for ${planItem.path}: ${formatCommandError(e)}`,
-        { cause: e },
-      ),
+    }).catch(
+      (e) =>
+        new Error(
+          `git ${commandArgs.join(' ')} failed for ${planItem.path}: ${formatCommandError(e)}`,
+          { cause: e },
+        ),
     )
     if (result instanceof Error) {
       // Non-fatal: broken .gitmodules entries (e.g. path listed but not in tree)
       // should not block worktree creation. Log and continue with remaining submodules.
-      logger.warn(
-        `Skipping submodule ${planItem.path}: ${result.message}`,
-      )
+      logger.warn(`Skipping submodule ${planItem.path}: ${result.message}`)
     }
   }
 }
@@ -420,9 +417,7 @@ function parseSubmoduleGitdir(gitFileContent: string): string | Error {
   return gitdir
 }
 
-async function validateSubmodulePointers(
-  directory: string,
-): Promise<void | Error> {
+async function validateSubmodulePointers(directory: string): Promise<void | Error> {
   const submodulePaths = await getSubmodulePaths(directory)
   if (submodulePaths.length === 0) {
     return
@@ -448,14 +443,11 @@ async function validateSubmodulePointers(
         return
       }
 
-      const gitFileContentResult = await fs.promises.readFile(submoduleGitFile, 'utf-8')
-        .catch((e) =>
-          new Error(`Failed to read .git for ${submodulePath}`, { cause: e }),
-        )
+      const gitFileContentResult = await fs.promises
+        .readFile(submoduleGitFile, 'utf-8')
+        .catch((e) => new Error(`Failed to read .git for ${submodulePath}`, { cause: e }))
       if (gitFileContentResult instanceof Error) {
-        validationIssues.push(
-          `${submodulePath}: ${gitFileContentResult.message}`,
-        )
+        validationIssues.push(`${submodulePath}: ${gitFileContentResult.message}`)
         return
       }
 
@@ -476,9 +468,7 @@ async function validateSubmodulePointers(
           return false
         })
       if (!headExists) {
-        validationIssues.push(
-          `${submodulePath}: gitdir missing HEAD (${resolvedGitdir})`,
-        )
+        validationIssues.push(`${submodulePath}: gitdir missing HEAD (${resolvedGitdir})`)
       }
     }),
   )
@@ -486,9 +476,7 @@ async function validateSubmodulePointers(
   const submoduleStatusResult = await execAsync('git submodule status --recursive', {
     cwd: directory,
     timeout: SUBMODULE_INIT_TIMEOUT_MS,
-  }).catch((e) =>
-    new Error('git submodule status --recursive failed', { cause: e }),
-  )
+  }).catch((e) => new Error('git submodule status --recursive failed', { cause: e }))
   if (submoduleStatusResult instanceof Error) {
     validationIssues.push(submoduleStatusResult.message)
   }
@@ -497,9 +485,7 @@ async function validateSubmodulePointers(
     return
   }
 
-  return new Error(
-    `Submodule validation failed: ${validationIssues.join('; ')}`,
-  )
+  return new Error(`Submodule validation failed: ${validationIssues.join('; ')}`)
 }
 
 type WorktreeResult = {
@@ -507,9 +493,7 @@ type WorktreeResult = {
   branch: string
 }
 
-async function resolveDefaultWorktreeTarget(
-  directory: string,
-): Promise<string> {
+async function resolveDefaultWorktreeTarget(directory: string): Promise<string> {
   return 'HEAD'
 }
 
@@ -536,14 +520,8 @@ export function getManagedWorktreeDirectory({
   directory: string
   name: string
 }): string {
-  const projectHash = crypto
-    .createHash('sha1')
-    .update(directory)
-    .digest('hex')
-    .slice(0, 8)
-  const withoutPrefix = name
-    .replace(/^opencode\/kimaki-/, '')
-    .replaceAll('/', '-')
+  const projectHash = crypto.createHash('sha1').update(directory).digest('hex').slice(0, 8)
+  const withoutPrefix = name.replace(/^opencode\/kimaki-/, '').replaceAll('/', '-')
   return path.join(getDataDir(), 'worktrees', projectHash, withoutPrefix)
 }
 
@@ -578,10 +556,11 @@ export async function createWorktreeWithSubmodules({
   const createResult = await execAsync(createCommand, {
     cwd: directory,
     timeout: SUBMODULE_INIT_TIMEOUT_MS,
-  }).catch((e) =>
-    new Error(`git worktree add failed: ${formatCommandError(e)}`, {
-      cause: e,
-    }),
+  }).catch(
+    (e) =>
+      new Error(`git worktree add failed: ${formatCommandError(e)}`, {
+        cause: e,
+      }),
   )
   if (createResult instanceof Error) return createResult
 
@@ -593,9 +572,7 @@ export async function createWorktreeWithSubmodules({
   // For each submodule we use git's built-in --reference mechanism when the
   // source checkout already has that submodule cloned. This preserves commit
   // pinning while allowing local-only submodule commits to resolve reliably.
-  logger.log(
-    `Initializing submodules in ${worktreeDir} (timeout=${SUBMODULE_INIT_TIMEOUT_MS}ms)`,
-  )
+  logger.log(`Initializing submodules in ${worktreeDir} (timeout=${SUBMODULE_INIT_TIMEOUT_MS}ms)`)
   const submoduleInitResult = await initializeSubmodulesWithLocalReferences({
     sourceDirectory: directory,
     worktreeDirectory: worktreeDir,
@@ -679,6 +656,96 @@ export type MergeSuccess = {
   shortSha: string
 }
 
+export type RecoverWorktreeResult =
+  | {
+      recovered: false
+      reason:
+        | 'no-worktree-entry'
+        | 'dir-exists'
+        | 'project-missing'
+        | 'branch-missing'
+        | 'creation-failed'
+      error?: Error
+    }
+  | { recovered: true; worktreeDirectory: string; worktreeName: string }
+
+/**
+ * Recover a worktree by looking up the stored info from the database.
+ * This is the public API called by session runtime and commands.
+ */
+export async function recoverWorktreeDirectory({
+  threadId,
+}: {
+  threadId: string
+}): Promise<RecoverWorktreeResult> {
+  const { getThreadWorktree, setWorktreeReady, setWorktreeError } = await import('./database.js')
+
+  const worktreeInfo = await getThreadWorktree(threadId)
+  if (!worktreeInfo || worktreeInfo.status !== 'ready' || !worktreeInfo.worktree_directory) {
+    return { recovered: false, reason: 'no-worktree-entry' }
+  }
+
+  const result = await recoverWorktreeFromInfo({
+    projectDirectory: worktreeInfo.project_directory,
+    worktreeName: worktreeInfo.worktree_name,
+    worktreeDirectory: worktreeInfo.worktree_directory,
+  })
+
+  if (result.recovered) {
+    await setWorktreeReady({ threadId, worktreeDirectory: result.worktreeDirectory })
+  } else if (result.reason === 'creation-failed' && result.error) {
+    await setWorktreeError({ threadId, errorMessage: result.error.message })
+  }
+
+  return result
+}
+
+/**
+ * Attempt to recreate a missing worktree directory from git.
+ * Takes worktree info directly (no DB dependency) — testable in unit tests.
+ */
+export async function recoverWorktreeFromInfo({
+  projectDirectory,
+  worktreeName,
+  worktreeDirectory,
+}: {
+  projectDirectory: string
+  worktreeName: string
+  worktreeDirectory: string
+}): Promise<RecoverWorktreeResult> {
+  // If directory already exists, no recovery needed
+  if (fs.existsSync(worktreeDirectory)) {
+    return { recovered: false, reason: 'dir-exists' }
+  }
+
+  // If project directory is gone, can't recover
+  if (!fs.existsSync(projectDirectory)) {
+    return { recovered: false, reason: 'project-missing' }
+  }
+
+  // Check if the git branch still exists
+  const branchCheck = await git(projectDirectory, `rev-parse --verify ${worktreeName}`)
+  if (branchCheck instanceof Error) {
+    return { recovered: false, reason: 'branch-missing', error: branchCheck }
+  }
+
+  // Recreate the worktree
+  const result = await createWorktreeWithSubmodules({
+    directory: projectDirectory,
+    name: worktreeName,
+  })
+
+  if (result instanceof Error) {
+    return { recovered: false, reason: 'creation-failed', error: result }
+  }
+
+  const recoveredDir = getManagedWorktreeDirectory({
+    directory: projectDirectory,
+    name: worktreeName,
+  })
+  return { recovered: true, worktreeDirectory: recoveredDir, worktreeName }
+}
+
 export async function git(
   dir: string,
   args: string,
@@ -724,8 +791,7 @@ export async function deleteWorktree({
   // Retry with --force which bypasses this guard. This is safe because
   // canDeleteWorktree already verified the worktree is clean and merged.
   if (removeResult instanceof Error) {
-    const stderr =
-      (removeResult.cause as { stderr?: string } | undefined)?.stderr ?? ''
+    const stderr = (removeResult.cause as { stderr?: string } | undefined)?.stderr ?? ''
     if (stderr.includes('containing submodules')) {
       removeResult = await git(
         projectDirectory,
@@ -759,10 +825,7 @@ export async function deleteWorktree({
   }
 }
 
-export async function isDirty(
-  dir: string,
-  opts?: { timeout?: number },
-): Promise<boolean> {
+export async function isDirty(dir: string, opts?: { timeout?: number }): Promise<boolean> {
   const status = await git(dir, 'status --porcelain', opts)
   if (status instanceof Error) return false
   return status.length > 0
@@ -783,17 +846,15 @@ async function getGitCommonDir(dir: string): Promise<GitCommandError | string> {
   return path.resolve(dir, commonDir)
 }
 
-async function isAncestor(
-  {
-    dir,
-    ref1,
-    ref2,
-  }: {
-    dir: string
-    ref1: string
-    ref2: string
-  },
-): Promise<boolean> {
+async function isAncestor({
+  dir,
+  ref1,
+  ref2,
+}: {
+  dir: string
+  ref1: string
+  ref2: string
+}): Promise<boolean> {
   const result = await git(dir, `merge-base --is-ancestor "${ref1}" "${ref2}"`)
   return !(result instanceof Error)
 }
@@ -832,9 +893,7 @@ async function isRebaseInProgress(dir: string): Promise<boolean> {
   for (const rebaseDir of ['rebase-merge', 'rebase-apply']) {
     const gitPath = await git(dir, `rev-parse --git-path ${rebaseDir}`)
     if (gitPath instanceof Error) continue
-    const resolvedPath = path.isAbsolute(gitPath)
-      ? gitPath
-      : path.resolve(dir, gitPath)
+    const resolvedPath = path.isAbsolute(gitPath) ? gitPath : path.resolve(dir, gitPath)
     const exists = await fs.promises
       .access(resolvedPath)
       .then(() => {
@@ -903,10 +962,7 @@ export async function mergeWorktree({
       )
     }
 
-    const deleteTempBranchResult = await git(
-      worktreeDir,
-      `branch -D "${tempBranch}"`,
-    )
+    const deleteTempBranchResult = await git(worktreeDir, `branch -D "${tempBranch}"`)
     if (deleteTempBranchResult instanceof Error) {
       logger.warn(
         `[MERGE CLEANUP] Failed to delete temp branch ${tempBranch}: ${deleteTempBranchResult.message}`,
@@ -937,17 +993,10 @@ export async function mergeWorktree({
   // half; we keep it implicit here.
   const alreadyRebased = await isRebasedOnto(worktreeDir, defaultBranch)
 
-  const mergeBaseResult = await git(
-    worktreeDir,
-    `merge-base HEAD "${defaultBranch}"`,
-  )
-  const mergeBase =
-    mergeBaseResult instanceof Error ? defaultBranch : mergeBaseResult
+  const mergeBaseResult = await git(worktreeDir, `merge-base HEAD "${defaultBranch}"`)
+  const mergeBase = mergeBaseResult instanceof Error ? defaultBranch : mergeBaseResult
 
-  const commitCountResult = await git(
-    worktreeDir,
-    `rev-list --count "${mergeBase}..HEAD"`,
-  )
+  const commitCountResult = await git(worktreeDir, `rev-list --count "${mergeBase}..HEAD"`)
   if (commitCountResult instanceof Error) {
     await cleanupTempBranch()
     return commitCountResult
@@ -1039,10 +1088,7 @@ export async function mergeWorktree({
   }
 
   if (branchName !== worktreeName && worktreeName) {
-    const deleteWorktreeBranchResult = await git(
-      worktreeDir,
-      `branch -D "${worktreeName}"`,
-    )
+    const deleteWorktreeBranchResult = await git(worktreeDir, `branch -D "${worktreeName}"`)
     if (deleteWorktreeBranchResult instanceof Error) {
       logger.warn(
         `[MERGE CLEANUP] Failed to delete worktree branch ${worktreeName}: ${deleteWorktreeBranchResult.message}`,
@@ -1154,9 +1200,7 @@ export async function validateWorktreeDirectory({
     })
 
   if (!worktreePaths.includes(absoluteCandidate)) {
-    return new Error(
-      `Directory is not a git worktree of ${projectDirectory}: ${absoluteCandidate}`,
-    )
+    return new Error(`Directory is not a git worktree of ${projectDirectory}: ${absoluteCandidate}`)
   }
 
   return absoluteCandidate
@@ -1175,10 +1219,7 @@ function isSameOrInsideDirectory({
   candidateDirectory: string
 }) {
   const relativePath = path.relative(parentDirectory, candidateDirectory)
-  return (
-    relativePath === '' ||
-    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
-  )
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
 }
 
 export async function resolveSessionWorkingDirectory({
@@ -1260,9 +1301,7 @@ function flushGitWorktreeEntry(current: PartialGitWorktree): GitWorktree | null 
 
 // Parse `git worktree list --porcelain` output into structured entries.
 // Skips the first entry (the main checkout) since that's the project root.
-export function parseGitWorktreeListPorcelain(
-  output: string,
-): GitWorktree[] {
+export function parseGitWorktreeListPorcelain(output: string): GitWorktree[] {
   const entries: GitWorktree[] = []
   let current: PartialGitWorktree = {}
 


### PR DESCRIPTION
## Summary

When a worktree directory is deleted from disk (e.g. by git worktree prune or rm -rf), the thread_worktrees table still holds the reference. Previously the bot would fail with DirectoryNotAccessibleError. Now it attempts to recreate the worktree from the git branch.

## Changes

- **worktrees.ts**: Added RecoverWorktreeResult type, recoverWorktreeDirectory (public API with DB lookup), recoverWorktreeFromInfo (pure testable function)
- **discord-utils.ts**: Calls recovery in resolveWorkingDirectory after reading worktree info
- **thread-session-runtime.ts**: Calls recovery in ensureSession after reading worktree info
- **worktrees.test.ts**: 4 unit tests covering dir-exists, branch-missing, project-missing, non-git-repo

## Behavior

| Scenario | Result |
|---|---|
| Worktree dir exists | No recovery needed |
| Worktree missing, branch exists | Recreated from git branch |
| Worktree missing, branch gone | Returns branch-missing, falls through to existing error handling |
| Project directory gone | Skips recovery |