### PR TITLE
fix: auto-recover worktrees with old path format and stale sessions

### DIFF
--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -17,6 +17,7 @@ import type {
   Message as OpenCodeMessage,
 } from '@opencode-ai/sdk/v2'
 import path from 'node:path'
+import fs from 'node:fs'
 import prettyMilliseconds from 'pretty-ms'
 import * as errore from 'errore'
 import * as threadState from './thread-runtime-state.js'
@@ -4032,6 +4033,27 @@ export class ThreadSessionRuntime {
         logger.warn(
           `[ENSURE SESSION] session.get returned no data for ${sessionId}, response=${JSON.stringify(sessionResponse)}`,
         )
+      }
+    }
+
+    // Check if existing session has a stale worktree path
+    if (session && worktreeInfo?.status === 'ready' && worktreeInfo.worktree_directory) {
+      const isOldPathFormat = worktreeInfo.worktree_directory.includes('/.local/share/opencode/worktree/')
+      const dirExists = fs.existsSync(worktreeInfo.worktree_directory)
+      
+      if (isOldPathFormat || !dirExists) {
+        logger.log(
+          `[ENSURE SESSION] Existing session ${session.id} has stale worktree path: ${worktreeInfo.worktree_directory}`,
+        )
+        
+        await getClient()
+          .session.abort({ sessionID: session.id, directory: this.sdkDirectory })
+          .catch((e) => new OpenCodeSdkError({ operation: 'session.abort', cause: e }))
+        
+        const { recoverWorktreeDirectory } = await import('../worktrees.js')
+        await recoverWorktreeDirectory({ threadId: this.thread.id })
+        
+        session = undefined
       }
     }
 

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 import { getDataDir } from './config.js'
 import { execAsync } from './exec-async.js'
 import { createLogger, LogPrefix } from './logger.js'
+import { deleteThreadWorktree, getThreadWorktree } from './database.js'
 
 export { execAsync } from './exec-async.js'
 
@@ -1160,6 +1161,61 @@ export async function validateWorktreeDirectory({
   }
 
   return absoluteCandidate
+}
+
+/**
+ * Recovers a worktree directory that has an old path format or is missing.
+ * Detects old paths like ~/.local/share/opencode/worktree/... and recreates
+ * the worktree with the new path format.
+ */
+export async function recoverWorktreeDirectory({
+  threadId,
+}: {
+  threadId: string
+}): Promise<{ recovered: boolean; reason?: string } | Error> {
+  const worktreeInfo = await getThreadWorktree(threadId)
+  if (!worktreeInfo || worktreeInfo.status !== 'ready' || !worktreeInfo.worktree_directory) {
+    return { recovered: false, reason: 'no-worktree' }
+  }
+
+  const worktreeDirectory = worktreeInfo.worktree_directory
+  const projectDirectory = worktreeInfo.project_directory
+
+  // Detect old path format (~/.local/share/opencode/worktree/...) and treat as missing
+  const isOldPathFormat = worktreeDirectory.includes('/.local/share/opencode/worktree/')
+
+  // If directory already exists and is NOT old format, no recovery needed
+  if (!isOldPathFormat && fs.existsSync(worktreeDirectory)) {
+    return { recovered: false, reason: 'dir-exists' }
+  }
+
+  // Directory is missing or has old path format - need to recover
+  logger.log(
+    `[RECOVER WORKTREE] Worktree directory needs recovery: ${worktreeDirectory} (oldFormat=${isOldPathFormat}, exists=${fs.existsSync(worktreeDirectory)})`,
+  )
+
+  // Delete the stale worktree entry from DB
+  await deleteThreadWorktree(threadId)
+
+  // Recreate the worktree using the worktree name from DB
+  const worktreeName = worktreeInfo.worktree_name
+  if (!worktreeName) {
+    return new Error('Cannot recover worktree: missing worktree_name in database')
+  }
+
+  // Create a new worktree with the correct path
+  const createResult = await createWorktreeWithSubmodules({
+    directory: projectDirectory,
+    name: worktreeName,
+  })
+
+  if (createResult instanceof Error) {
+    logger.error(`[RECOVER WORKTREE] Failed to recreate worktree: ${createResult.message}`)
+    return createResult
+  }
+
+  logger.log(`[RECOVER WORKTREE] Successfully recovered worktree: ${createResult.directory}`)
+  return { recovered: true, reason: 'recreated' }
 }
 
 export type SessionWorkingDirectory = {


### PR DESCRIPTION
Fixes worktree recovery for old path format and stale opencode sessions.