### PR TITLE
Fix Windows gateway install URL opening

### DIFF
--- a/.changeset/fix-windows-gateway-install-url.md
+++ b/.changeset/fix-windows-gateway-install-url.md
@@ -1,0 +1,5 @@
+---
+'kimaki': patch
+---
+
+Open the Discord gateway install URL correctly on Windows during onboarding, preventing setup from waiting on credentials that were never authorized.

--- a/cli/src/cli-runner.test.ts
+++ b/cli/src/cli-runner.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { getOpenUrlCommand } from './cli-runner.js'
+
+describe('getOpenUrlCommand', () => {
+  const installUrl = 'https://kimaki.dev/discord-install?clientId=abc&clientSecret=def'
+
+  test('uses a shell-free opener on Windows', () => {
+    expect(getOpenUrlCommand(installUrl, 'win32')).toEqual({
+      command: 'rundll32.exe',
+      args: ['url.dll,FileProtocolHandler', installUrl],
+    })
+  })
+
+  test('uses open on macOS', () => {
+    expect(getOpenUrlCommand(installUrl, 'darwin')).toEqual({
+      command: 'open',
+      args: [installUrl],
+    })
+  })
+
+  test('uses xdg-open on Linux', () => {
+    expect(getOpenUrlCommand(installUrl, 'linux')).toEqual({
+      command: 'xdg-open',
+      args: [installUrl],
+    })
+  })
+})

--- a/cli/src/cli-runner.ts
+++ b/cli/src/cli-runner.ts
@@ -87,6 +87,40 @@ export const KIMAKI_GATEWAY_PROXY_REST_BASE_URL = getGatewayProxyRestBaseUrl({
   gatewayUrl: KIMAKI_GATEWAY_PROXY_URL,
 })
 
+export type OpenUrlCommand = {
+  command: string
+  args: string[]
+}
+
+export function getOpenUrlCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): OpenUrlCommand {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [url] }
+  }
+  if (platform === 'win32') {
+    return { command: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', url] }
+  }
+  return { command: 'xdg-open', args: [url] }
+}
+
+function openUrlInDefaultBrowser(url: string): void {
+  const { command, args } = getOpenUrlCommand(url)
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  child.on('error', (error) => {
+    cliLogger.warn(
+      'Failed to open install URL:',
+      error instanceof Error ? error.message : String(error),
+    )
+  })
+  child.unref()
+}
+
 // Strip bracketed paste escape sequences from terminal input.
 // iTerm2 and other terminals wrap pasted content with \x1b[200~ and \x1b[201~
 // which can cause validation to fail on macOS. See: https://github.com/remorses/kimaki/issues/18
@@ -1197,14 +1231,7 @@ export async function resolveCredentials({
       )
 
       // Open URL in default browser
-      const { exec } = await import('node:child_process')
-      const openCmd =
-        process.platform === 'darwin'
-          ? 'open'
-          : process.platform === 'win32'
-            ? 'start'
-            : 'xdg-open'
-      exec(`${openCmd} "${oauthUrl}"`)
+      openUrlInDefaultBrowser(oauthUrl)
     } else {
       // Non-TTY: emit structured JSON so the host process can show the URL to the user.
       emitJsonEvent({ type: 'install_url', url: oauthUrl })


### PR DESCRIPTION
## What?
Fix gateway onboarding's browser opener so Windows launches the Kimaki Discord install URL through the default browser without shell parsing.

## Why?
On Windows, the previous `start "<url>"` command could treat the quoted URL as the window title instead of opening the active install URL. That leaves the CLI polling onboarding status even after the user thinks they authorized the bot.

## How?
Added a small URL-opener helper used by the interactive gateway onboarding flow. Windows now uses `rundll32.exe url.dll,FileProtocolHandler <url>`, avoiding `cmd`/`start` quoting and preserving credentialed query strings. macOS and Linux still use `open` and `xdg-open`.

## Testing?
- `pnpm tsc` from `cli`
- `pnpm test --run src/cli-runner.test.ts` from `cli`

## Screenshots (optional)
Not applicable; this is CLI/browser-launch behavior.

## Anything Else?
Added a patch changeset for `kimaki`.
