### PR TITLE
feat: run slash command referenced by clicked question option

### DIFF
--- a/.changeset/question-option-run-slash-command.md
+++ b/.changeset/question-option-run-slash-command.md
@@ -1,0 +1,5 @@
+---
+"kimaki": minor
+---
+
+Run the slash command referenced by a question option when it is clicked. Selecting an `AskUserQuestion` option whose label or description points at a registered command (for example Prometheus' "Start Work" option, described as "Execute now with `/start-work`") now executes that command — switching agent exactly like typing it does — instead of sending the option label back to the current agent, which could not switch agents or run commands.

--- a/cli/src/commands/ask-question.test.ts
+++ b/cli/src/commands/ask-question.test.ts
@@ -6,8 +6,11 @@ import {
   areAllQuestionsAnswered,
   deletePendingQuestionContextsForRequest,
   pendingQuestionContexts,
+  resolveSelectedOptionCommand,
   showAskUserQuestionDropdowns,
+  type AskUserQuestionInput,
 } from './ask-question.js'
+import type { RegisteredUserCommand } from '../store.js'
 
 function createFakeThread(): ThreadChannel {
   const send = vi.fn(async () => {
@@ -126,5 +129,93 @@ describe('ask-question', () => {
         2: ['Gamma'],
       },
     })).toBe(true)
+  })
+})
+
+describe('resolveSelectedOptionCommand', () => {
+  const registered: RegisteredUserCommand[] = [
+    {
+      name: 'start-work',
+      discordCommandName: 'start-work',
+      description: 'start a work session',
+      source: 'command',
+    },
+  ]
+
+  const handoffQuestions: AskUserQuestionInput['questions'] = [
+    {
+      question: 'Plan ready. What next?',
+      header: 'Handoff',
+      options: [
+        {
+          label: 'Start Work',
+          description: 'Execute now with `/start-work {name}`. Plan looks solid.',
+        },
+        {
+          label: 'High Accuracy Review',
+          description: 'Run an extra review pass before executing.',
+        },
+      ],
+    },
+  ]
+
+  test('returns the command for a command-bearing option', () => {
+    expect(
+      resolveSelectedOptionCommand({
+        questions: handoffQuestions,
+        totalQuestions: 1,
+        questionIndex: 0,
+        selectedValues: ['0'],
+        registered,
+      }),
+    ).toEqual({ name: 'start-work', arguments: '' })
+  })
+
+  test('returns null for an option without a command', () => {
+    expect(
+      resolveSelectedOptionCommand({
+        questions: handoffQuestions,
+        totalQuestions: 1,
+        questionIndex: 0,
+        selectedValues: ['1'],
+        registered,
+      }),
+    ).toBeNull()
+  })
+
+  test('ignores multi-question forms', () => {
+    expect(
+      resolveSelectedOptionCommand({
+        questions: handoffQuestions,
+        totalQuestions: 2,
+        questionIndex: 0,
+        selectedValues: ['0'],
+        registered,
+      }),
+    ).toBeNull()
+  })
+
+  test('ignores multi-select answers', () => {
+    expect(
+      resolveSelectedOptionCommand({
+        questions: handoffQuestions,
+        totalQuestions: 1,
+        questionIndex: 0,
+        selectedValues: ['0', '1'],
+        registered,
+      }),
+    ).toBeNull()
+  })
+
+  test('ignores the free-text "Other" choice', () => {
+    expect(
+      resolveSelectedOptionCommand({
+        questions: handoffQuestions,
+        totalQuestions: 1,
+        questionIndex: 0,
+        selectedValues: ['other'],
+        registered,
+      }),
+    ).toBeNull()
   })
 })

--- a/cli/src/commands/ask-question.ts
+++ b/cli/src/commands/ask-question.ts
@@ -10,9 +10,17 @@ import {
   MessageFlags,
 } from 'discord.js'
 import crypto from 'node:crypto'
-import { sendThreadMessage, NOTIFY_MESSAGE_FLAGS, SILENT_MESSAGE_FLAGS } from '../discord-utils.js'
+import {
+  sendThreadMessage,
+  NOTIFY_MESSAGE_FLAGS,
+  SILENT_MESSAGE_FLAGS,
+  resolveWorkingDirectory,
+} from '../discord-utils.js'
 import { getOpencodeClient } from '../opencode.js'
 import { createLogger, LogPrefix } from '../logger.js'
+import { extractOpencodeCommandReference } from '../opencode-command-detection.js'
+import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js'
+import type { RegisteredUserCommand } from '../store.js'
 
 const logger = createLogger(LogPrefix.ASK_QUESTION)
 
@@ -316,7 +324,95 @@ export async function handleAskQuestionSelectMenu(
       threadId: context.thread.id,
       requestId: context.requestId,
     })
+    await maybeQueueCommandFromSelectedOption({
+      context,
+      questionIndex,
+      selectedValues,
+      interaction,
+    })
   }
+}
+
+// Decides whether a dropdown selection should run a registered opencode command
+// instead of replying its label. Scoped to single-question, single-select
+// answers so multi-question forms and free-text "Other" are left alone, and only
+// registered commands match. Pure so the guard logic is unit-testable.
+export function resolveSelectedOptionCommand({
+  questions,
+  totalQuestions,
+  questionIndex,
+  selectedValues,
+  registered,
+}: {
+  questions: AskUserQuestionInput['questions']
+  totalQuestions: number
+  questionIndex: number
+  selectedValues: string[]
+  registered?: RegisteredUserCommand[]
+}): { name: string; arguments: string } | null {
+  if (totalQuestions !== 1) return null
+  if (selectedValues.length !== 1) return null
+  const selected = selectedValues[0]
+  if (!selected || selected === 'other') return null
+
+  const option = questions[questionIndex]?.options[parseInt(selected, 10)]
+  if (!option) return null
+
+  const detected = extractOpencodeCommandReference(
+    `${option.label}\n${option.description}`,
+    registered,
+  )
+  return detected?.command ?? null
+}
+
+// Routes a command-bearing option through opencode's command path (which
+// switches agent), instead of replying the bare label to the current agent.
+async function maybeQueueCommandFromSelectedOption({
+  context,
+  questionIndex,
+  selectedValues,
+  interaction,
+}: {
+  context: PendingQuestionContext
+  questionIndex: number
+  selectedValues: string[]
+  interaction: StringSelectMenuInteraction
+}): Promise<void> {
+  const command = resolveSelectedOptionCommand({
+    questions: context.questions,
+    totalQuestions: context.totalQuestions,
+    questionIndex,
+    selectedValues,
+  })
+  if (!command) return
+
+  const thread = context.thread
+  const resolved = await resolveWorkingDirectory({ channel: thread })
+  if (!resolved) {
+    logger.error(
+      'Could not resolve project directory for command option enqueue',
+    )
+    return
+  }
+
+  const username = interaction.user.globalName || interaction.user.username
+  const runtime = getOrCreateRuntime({
+    threadId: thread.id,
+    thread,
+    projectDirectory: resolved.projectDirectory,
+    sdkDirectory: resolved.workingDirectory,
+    channelId: thread.parentId || thread.id,
+  })
+  await runtime.enqueueIncoming({
+    prompt: '',
+    userId: interaction.user.id,
+    username,
+    command,
+    mode: 'local-queue',
+  })
+  logger.log(
+    `Queued /${command.name} from selected option in session ${context.sessionId}`,
+  )
 }
 
 /**

--- a/cli/src/opencode-command-detection.test.ts
+++ b/cli/src/opencode-command-detection.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from 'vitest'
-import { extractLeadingOpencodeCommand } from './opencode-command-detection.js'
+import {
+  extractLeadingOpencodeCommand,
+  extractOpencodeCommandReference,
+} from './opencode-command-detection.js'
 import type { RegisteredUserCommand } from './store.js'
 
 const fixtures: RegisteredUserCommand[] = [
@@ -303,5 +306,101 @@ describe('extractLeadingOpencodeCommand', () => {
         },
       }
     `)
+  })
+})
+
+const optionFixtures: RegisteredUserCommand[] = [
+  {
+    name: 'start-work',
+    discordCommandName: 'start-work',
+    description: 'start a work session',
+    source: 'command',
+  },
+  {
+    name: 'build',
+    discordCommandName: 'build-cmd',
+    description: 'build the project',
+    source: 'command',
+  },
+]
+
+describe('extractOpencodeCommandReference', () => {
+  test('detects a command in the middle of an option description', () => {
+    expect(
+      extractOpencodeCommandReference(
+        'Execute now with /start-work {name}. Plan looks solid.',
+        optionFixtures,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "command": {
+          "arguments": "",
+          "name": "start-work",
+        },
+      }
+    `)
+  })
+
+  test('detects a backtick-wrapped command and drops placeholder args', () => {
+    expect(
+      extractOpencodeCommandReference(
+        'Execute now with `/start-work {name}`. Plan looks solid.',
+        optionFixtures,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "command": {
+          "arguments": "",
+          "name": "start-work",
+        },
+      }
+    `)
+  })
+
+  test('resolves a discord-suffixed token mid-text', () => {
+    expect(
+      extractOpencodeCommandReference('Run /build-cmd to compile', optionFixtures),
+    ).toMatchInlineSnapshot(`
+      {
+        "command": {
+          "arguments": "",
+          "name": "build",
+        },
+      }
+    `)
+  })
+
+  test('ignores unregistered slash tokens (URLs, prose)', () => {
+    expect(
+      extractOpencodeCommandReference(
+        'See https://example.com/start and/or the docs',
+        optionFixtures,
+      ),
+    ).toMatchInlineSnapshot(`null`)
+  })
+
+  test('returns the first registered command when several are referenced', () => {
+    expect(
+      extractOpencodeCommandReference('first /build then /start-work', optionFixtures),
+    ).toMatchInlineSnapshot(`
+      {
+        "command": {
+          "arguments": "",
+          "name": "build",
+        },
+      }
+    `)
+  })
+
+  test('empty string returns null', () => {
+    expect(extractOpencodeCommandReference('', optionFixtures)).toMatchInlineSnapshot(
+      `null`,
+    )
+  })
+
+  test('plain label with no slash returns null', () => {
+    expect(
+      extractOpencodeCommandReference('Start Work', optionFixtures),
+    ).toMatchInlineSnapshot(`null`)
   })
 })

--- a/cli/src/opencode-command-detection.ts
+++ b/cli/src/opencode-command-detection.ts
@@ -74,3 +74,26 @@ export function extractLeadingOpencodeCommand(
   }
   return null
 }
+
+// Like extractLeadingOpencodeCommand, but finds a registered `/command` token
+// anywhere in a short UI label/description (not just line-leading), e.g.
+// "Execute now with `/start-work {name}`." Arguments are dropped on purpose:
+// descriptions hold prose/placeholders, not real args, so it mirrors typing the
+// bare command. Only registered commands match, ignoring casual prose slashes.
+export function extractOpencodeCommandReference(
+  text: string,
+  registered: RegisteredUserCommand[] = store.getState().registeredUserCommands,
+): { command: { name: string; arguments: string } } | null {
+  if (!text) return null
+
+  const slashTokenRegex = /\/([A-Za-z0-9:_-]+)/g
+  let match: RegExpExecArray | null
+  while ((match = slashTokenRegex.exec(text)) !== null) {
+    const token = match[1]
+    if (!token) continue
+    const name = resolveCommandName({ token, registered })
+    if (!name) continue
+    return { command: { name, arguments: '' } }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Clicking a Discord question option whose label/description points at a registered opencode command now **runs that command** (switching agent the same way typing it does), instead of sending the option label back to the current agent.

The motivating case: planner agents like OMO's **Prometheus** end a planning session by asking a question with a **"Start Work"** option (described as *"Execute now with `/start-work`"*). Today, clicking it just replies the text `Start Work` to the still-active planner agent, which by design refuses to execute and tells you to run `/start-work` yourself. So the button looks actionable but does nothing useful — you always have to type the slash command manually.

## Root cause

When a user selects an `AskUserQuestion` option, kimaki calls `client.question.reply()` with the option **label**. That answer goes back to the **same session on the same agent**. A slash command typed in chat, by contrast, is detected by `extractLeadingOpencodeCommand` and routed through `session.command()`, which is what lets opencode resolve the command's bound `agent` and switch to it. A clicked option never reaches that path, so it can neither switch agents nor run a command.

## Solution

After a single-question handoff is answered, check whether the selected option references a **registered** opencode command, and if so queue that command through the existing local-queue → `session.command()` path — identical to typing the slash command. The answer is still replied normally, so the planner can do its own handoff cleanup first; the queued command then drains and runs with the correct agent.

Two small pieces:

- `extractOpencodeCommandReference()` — like the existing `extractLeadingOpencodeCommand`, but matches a registered `/command` token appearing **anywhere** in a short UI label/description (not just line-leading), e.g. ``Execute now with `/start-work {name}` ``. Arguments are dropped on purpose: descriptions hold prose/placeholders (`{name}`), not real args, so it mirrors typing the bare command. Only registered commands match, so casual prose slashes (URLs, `and/or`) are ignored.
- `resolveSelectedOptionCommand()` + `maybeQueueCommandFromSelectedOption()` in the question handler — enqueue the command via the runtime, reusing the same `/queue`-during-question machinery that already exists.

### Scope / guards

Deliberately narrow to avoid surprises:

- Only single-question, single-select answers (multi-question forms and free-text **"Other"** are untouched).
- Only options that resolve to a **registered** command trigger it.
- Reuses the proven command + queue paths; no new session/abort handling.

## Verification

- `cli/src/opencode-command-detection.test.ts` — 30 pass (7 new cases for mid-text detection, backticks, suffix tokens, prose/URL rejection, multi-command precedence).
- `cli/src/commands/ask-question.test.ts` — 8 pass (5 new cases for the guard logic: command-bearing option, non-command option, multi-question, multi-select, "Other").
- `tsc --noEmit` — no errors in the changed files or anywhere in `cli/src`.

```
✓ src/commands/ask-question.test.ts (8 tests)
✓ src/opencode-command-detection.test.ts (30 tests)
Test Files  2 passed (2)
     Tests  38 passed (38)
```

## Risk / residuals

- Behavior only changes when a single-select option text contains a token resolving to a registered command — existing questions without such tokens are unaffected.
- The command runs after the question reply, so the planner's own handoff turn still happens first.
