### PR TITLE
Add Claude Code agent backend via the Claude Agent SDK

### DIFF
--- a/.changeset/claude-code-backend.md
+++ b/.changeset/claude-code-backend.md
@@ -1,0 +1,11 @@
+---
+'kimaki': minor
+---
+
+Add Claude Code as an agent backend via the Claude Agent SDK.
+
+Pick any `claude-code/*` model in `/model` (Claude Code shows up as a regular provider) and new sessions in that channel run on Claude Code instead of OpenCode — using your existing Claude Code login (Pro/Max subscription or `ANTHROPIC_API_KEY`), your `CLAUDE.md`, settings, and `.claude` project configuration.
+
+Everything works the same as OpenCode threads: streaming replies and tool calls, permission Accept/Always/Deny buttons (including persisted "always" rules), AskUserQuestion dropdowns, the queue, interrupts, `/model` with effort-level variants (low/medium/high/xhigh/max), `/compact`, `/fork`, `/abort`, session resume after bot restarts (transcripts persist under `~/.claude`), images and PDFs, per-turn diff summaries, cost/token footers, and worktrees. Claude sessions also get the `kimaki_file_upload` and `kimaki_action_buttons` tools through an in-process MCP server.
+
+Under the hood kimaki now routes all OpenCode SDK calls through a local backend router that serves Claude Code sessions in-process (translating Agent SDK messages onto the OpenCode wire protocol) and transparently proxies everything else to the opencode server.

--- a/cli/package.json
+++ b/cli/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.53",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.202",
     "@ai-sdk/openai": "^3.0.31",
     "@ai-sdk/provider": "^3.0.8",
     "@clack/prompts": "^1.3.0",

--- a/cli/src/claude-code/ids.ts
+++ b/cli/src/claude-code/ids.ts
@@ -1,0 +1,56 @@
+// ID helpers for the Claude Code backend.
+//
+// Claude-backed sessions live behind the same OpenCode wire protocol as real
+// opencode sessions, so every id must be distinguishable at the router layer:
+// requests carrying a claude id are handled by the in-process shim, everything
+// else is proxied to the real opencode server.
+
+import crypto from 'node:crypto'
+
+const SESSION_PREFIX = 'ses_claude_'
+const PERMISSION_PREFIX = 'perm_claude_'
+const QUESTION_PREFIX = 'que_claude_'
+
+let counter = 0
+
+/** Monotonic, sortable suffix so message/part ids order correctly. */
+function nextOrdinal(): string {
+  counter += 1
+  return `${Date.now().toString(36)}${counter.toString(36).padStart(6, '0')}`
+}
+
+export function createClaudeSessionId(): string {
+  return `${SESSION_PREFIX}${crypto.randomBytes(8).toString('hex')}`
+}
+
+export function isClaudeCodeSessionId(sessionId: string | undefined | null): boolean {
+  return typeof sessionId === 'string' && sessionId.startsWith(SESSION_PREFIX)
+}
+
+export function createClaudePermissionId(): string {
+  return `${PERMISSION_PREFIX}${crypto.randomBytes(8).toString('hex')}`
+}
+
+export function isClaudeCodePermissionId(requestId: string | undefined | null): boolean {
+  return typeof requestId === 'string' && requestId.startsWith(PERMISSION_PREFIX)
+}
+
+export function createClaudeQuestionId(): string {
+  return `${QUESTION_PREFIX}${crypto.randomBytes(8).toString('hex')}`
+}
+
+export function isClaudeCodeQuestionId(requestId: string | undefined | null): boolean {
+  return typeof requestId === 'string' && requestId.startsWith(QUESTION_PREFIX)
+}
+
+export function createClaudeMessageId(): string {
+  return `msg_claude_${nextOrdinal()}`
+}
+
+export function createClaudePartId(): string {
+  return `prt_claude_${nextOrdinal()}`
+}
+
+export function createClaudeEventId(): string {
+  return `evt_claude_${nextOrdinal()}`
+}

--- a/cli/src/claude-code/kimaki-mcp.ts
+++ b/cli/src/claude-code/kimaki-mcp.ts
@@ -1,0 +1,202 @@
+// In-process MCP server exposing kimaki's Discord tools to Claude sessions.
+//
+// OpenCode sessions get kimaki_file_upload / kimaki_action_buttons via the
+// ipc-tools plugin running inside the opencode server process. Claude Code
+// sessions run in the bot process itself, so the same tools are provided as
+// an SDK MCP server writing to the identical ipc_requests table — the
+// existing ipc-polling machinery picks the rows up and renders the Discord UI
+// with no backend-specific code.
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk'
+import { z } from 'zod'
+import dedent from 'string-dedent'
+import { createIpcRequest, getIpcRequestById, getThreadIdBySessionId } from '../database.js'
+
+const FILE_UPLOAD_TIMEOUT_MS = 6 * 60 * 1000
+const DEFAULT_FILE_UPLOAD_MAX_FILES = 5
+const ACTION_BUTTON_TIMEOUT_MS = 30 * 1000
+
+async function pollIpcResponse({
+  id,
+  timeoutMs,
+  pollIntervalMs,
+  cancelledMessage,
+  timeoutMessage,
+  parse,
+}: {
+  id: string
+  timeoutMs: number
+  pollIntervalMs: number
+  cancelledMessage: string
+  timeoutMessage: string
+  parse: (response: string) => string
+}): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, pollIntervalMs)
+    })
+    const updated = await getIpcRequestById({ id })
+    if (!updated || updated.status === 'cancelled') {
+      return cancelledMessage
+    }
+    if (updated.response) {
+      return parse(updated.response)
+    }
+  }
+  return timeoutMessage
+}
+
+function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] }
+}
+
+/**
+ * Build the kimaki MCP server for one Claude session. The wire session id is
+ * the shim session id (ses_claude_...), which thread_sessions maps back to a
+ * Discord thread — same lookup the opencode plugin does.
+ */
+export function createKimakiMcpServer({
+  sessionId,
+  directory,
+}: {
+  sessionId: string
+  directory: string
+}) {
+  return createSdkMcpServer({
+    name: 'kimaki',
+    version: '1.0.0',
+    tools: [
+      tool(
+        'kimaki_file_upload',
+        'Prompt the Discord user to upload files using a native file picker modal. ' +
+          'The user sees a button, clicks it, and gets a file upload dialog. ' +
+          'Returns the local file paths of downloaded files in the project directory. ' +
+          'Use this when you need the user to provide files (images, documents, configs, etc.). ' +
+          'IMPORTANT: Always call this tool last in your message, after all text parts.',
+        {
+          prompt: z.string().describe('Message shown to the user explaining what files to upload'),
+          maxFiles: z
+            .number()
+            .min(1)
+            .max(10)
+            .optional()
+            .describe('Maximum number of files the user can upload (1-10, default 5)'),
+        },
+        async ({ prompt, maxFiles }) => {
+          const threadId = await getThreadIdBySessionId(sessionId)
+          if (!threadId) {
+            return textResult('Could not find thread for current session')
+          }
+          const ipcRow = await createIpcRequest({
+            type: 'file_upload',
+            sessionId,
+            threadId,
+            payload: JSON.stringify({
+              prompt,
+              maxFiles: maxFiles || DEFAULT_FILE_UPLOAD_MAX_FILES,
+              directory,
+            }),
+          })
+          const result = await pollIpcResponse({
+            id: ipcRow.id,
+            timeoutMs: FILE_UPLOAD_TIMEOUT_MS,
+            pollIntervalMs: 300,
+            cancelledMessage: 'File upload was cancelled',
+            timeoutMessage:
+              'File upload timed out - user did not upload files within the time limit',
+            parse: (response) => {
+              const parsed = JSON.parse(response) as {
+                filePaths?: string[]
+                error?: string
+              }
+              if (parsed.error) {
+                return `File upload failed: ${parsed.error}`
+              }
+              const filePaths = parsed.filePaths || []
+              if (filePaths.length === 0) {
+                return 'No files were uploaded (user may have cancelled or sent a new message)'
+              }
+              return `Files uploaded successfully:\n${filePaths.join('\n')}`
+            },
+          })
+          return textResult(result)
+        },
+      ),
+      tool(
+        'kimaki_action_buttons',
+        dedent`
+          Show action buttons in the current Discord thread for quick confirmations.
+          Use this when the user can respond by clicking one of up to 3 buttons.
+          Prefer a single button whenever possible.
+          Default color is white (same visual style as permission deny button).
+          If you need more than 3 options, use the AskUserQuestion tool instead.
+          IMPORTANT: Always call this tool last in your message, after all text parts.
+
+          Examples:
+          - buttons: [{"label":"Yes, proceed"}]
+          - buttons: [{"label":"Approve","color":"green"}]
+          - buttons: [
+              {"label":"Confirm","color":"blue"},
+              {"label":"Cancel","color":"white"}
+            ]
+        `,
+        {
+          buttons: z
+            .array(
+              z.object({
+                label: z
+                  .string()
+                  .min(1)
+                  .max(80)
+                  .describe('Button label shown to the user (1-80 chars)'),
+                color: z
+                  .enum(['white', 'blue', 'green', 'red'])
+                  .optional()
+                  .describe(
+                    'Optional button color. white is default and preferred for most confirmations.',
+                  ),
+              }),
+            )
+            .min(1)
+            .max(3)
+            .describe('Array of 1-3 action buttons. Prefer one button whenever possible.'),
+        },
+        async ({ buttons }) => {
+          const threadId = await getThreadIdBySessionId(sessionId)
+          if (!threadId) {
+            return textResult('Could not find thread for current session')
+          }
+          const ipcRow = await createIpcRequest({
+            type: 'action_buttons',
+            sessionId,
+            threadId,
+            payload: JSON.stringify({ buttons, directory }),
+          })
+          const result = await pollIpcResponse({
+            id: ipcRow.id,
+            timeoutMs: ACTION_BUTTON_TIMEOUT_MS,
+            pollIntervalMs: 200,
+            cancelledMessage: 'Action button request was cancelled',
+            timeoutMessage: 'Action button request timed out',
+            parse: (response) => {
+              const parsed = JSON.parse(response) as {
+                ok?: boolean
+                error?: string
+              }
+              if (parsed.error) {
+                return `Action button request failed: ${parsed.error}`
+              }
+              return `Action button(s) shown: ${buttons
+                .map((button) => {
+                  return button.label
+                })
+                .join(', ')}`
+            },
+          })
+          return textResult(result)
+        },
+      ),
+    ],
+  })
+}

--- a/cli/src/claude-code/models.ts
+++ b/cli/src/claude-code/models.ts
@@ -1,0 +1,161 @@
+// Claude Code model catalog exposed through OpenCode's provider surface.
+//
+// Kimaki's /model picker works off provider.list() ({ all, connected,
+// default }). The router merges the provider built here into the upstream
+// opencode response, so Claude Code shows up as just another provider —
+// selecting one of its models routes new sessions to the Claude backend.
+//
+// Model variants map to Claude Code effort levels, so kimaki's existing
+// thinking-variant picker doubles as the effort selector.
+
+import type { Model, Provider } from '@opencode-ai/sdk/v2'
+import type { ModelInfo } from '@anthropic-ai/claude-agent-sdk'
+
+export const CLAUDE_CODE_PROVIDER_ID = 'claude-code'
+export const CLAUDE_CODE_PROVIDER_NAME = 'Claude Code'
+
+export const DEFAULT_CLAUDE_MODEL_ID = 'claude-opus-4-8'
+
+const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+type StaticModel = {
+  id: string
+  name: string
+  releaseDate: string
+  effortLevels: readonly string[]
+}
+
+// Fallback catalog used until (or if) live enumeration via the SDK succeeds.
+// Kept intentionally small: the live list from supportedModels() replaces it.
+const STATIC_MODELS: StaticModel[] = [
+  {
+    id: 'claude-opus-4-8',
+    name: 'Claude Opus 4.8',
+    releaseDate: '2026-05-01',
+    effortLevels: EFFORT_LEVELS,
+  },
+  {
+    id: 'claude-sonnet-5',
+    name: 'Claude Sonnet 5',
+    releaseDate: '2026-03-01',
+    effortLevels: EFFORT_LEVELS,
+  },
+  {
+    id: 'claude-haiku-4-5',
+    name: 'Claude Haiku 4.5',
+    releaseDate: '2025-10-01',
+    effortLevels: [],
+  },
+]
+
+function buildModel({
+  id,
+  name,
+  releaseDate,
+  effortLevels,
+}: {
+  id: string
+  name: string
+  releaseDate: string
+  effortLevels: readonly string[]
+}): Model {
+  const variants: Record<string, Record<string, unknown>> = {}
+  for (const level of effortLevels) {
+    variants[level] = { effort: level }
+  }
+  return {
+    id,
+    providerID: CLAUDE_CODE_PROVIDER_ID,
+    api: { id, url: '', npm: '@anthropic-ai/claude-agent-sdk' },
+    name,
+    capabilities: {
+      temperature: false,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: true,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 200_000, output: 64_000 },
+    status: 'active',
+    options: {},
+    headers: {},
+    release_date: releaseDate,
+    ...(Object.keys(variants).length > 0 ? { variants } : {}),
+  }
+}
+
+let liveModels: Model[] | null = null
+
+/**
+ * Replace the static catalog with the live list reported by the Claude Code
+ * runtime (Query.supportedModels()). Called opportunistically whenever a
+ * session initializes, so the picker converges on the real model list.
+ */
+export function updateLiveModels(models: ModelInfo[]): void {
+  if (models.length === 0) {
+    return
+  }
+  const seen = new Set<string>()
+  const mapped: Model[] = []
+  for (const info of models) {
+    // Alias rows (e.g. "sonnet" → claude-sonnet-5) duplicate their resolved
+    // model; keep the canonical id only once.
+    const id = info.resolvedModel || info.value
+    if (!id || seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    mapped.push(
+      buildModel({
+        id,
+        name: info.displayName || id,
+        releaseDate: '',
+        effortLevels:
+          info.supportsEffort && info.supportedEffortLevels ? info.supportedEffortLevels : [],
+      }),
+    )
+  }
+  if (mapped.length > 0) {
+    liveModels = mapped
+  }
+}
+
+export function getClaudeCodeModels(): Model[] {
+  if (liveModels) {
+    return liveModels
+  }
+  return STATIC_MODELS.map(buildModel)
+}
+
+export function getClaudeCodeProvider(): Provider {
+  const models: Record<string, Model> = {}
+  for (const model of getClaudeCodeModels()) {
+    models[model.id] = model
+  }
+  return {
+    id: CLAUDE_CODE_PROVIDER_ID,
+    name: CLAUDE_CODE_PROVIDER_NAME,
+    source: 'custom',
+    env: [],
+    options: {},
+    models,
+  }
+}
+
+export function isClaudeCodeModel(modelString: string | undefined | null): boolean {
+  return typeof modelString === 'string' && modelString.startsWith(`${CLAUDE_CODE_PROVIDER_ID}/`)
+}
+
+/** Effort levels supported by the given model id, for variant validation. */
+export function getEffortLevelsForModel(modelId: string): string[] {
+  const model = getClaudeCodeModels().find((candidate) => {
+    return candidate.id === modelId
+  })
+  if (!model?.variants) {
+    return []
+  }
+  return Object.keys(model.variants)
+}

--- a/cli/src/claude-code/permission-map.test.ts
+++ b/cli/src/claude-code/permission-map.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest'
+import {
+  buildAlwaysRules,
+  describeToolPermission,
+  evaluatePermission,
+  wildcardMatchValue,
+} from './permission-map.js'
+
+describe('wildcardMatchValue', () => {
+  test('star matches any run', () => {
+    expect(wildcardMatchValue({ value: 'git push origin', pattern: 'git *' })).toBe(true)
+    expect(wildcardMatchValue({ value: 'rm -rf /', pattern: 'git *' })).toBe(false)
+  })
+
+  test('trailing " *" also matches the bare prefix', () => {
+    expect(wildcardMatchValue({ value: 'git', pattern: 'git *' })).toBe(true)
+  })
+
+  test('star alone matches everything', () => {
+    expect(wildcardMatchValue({ value: 'anything at all', pattern: '*' })).toBe(true)
+  })
+})
+
+describe('evaluatePermission', () => {
+  test('defaults: bash asks, webfetch allows', () => {
+    expect(evaluatePermission({ rules: [], permission: 'bash', patterns: ['ls'] })).toBe('ask')
+    expect(
+      evaluatePermission({
+        rules: [],
+        permission: 'webfetch',
+        patterns: ['https://example.com'],
+      }),
+    ).toBe('allow')
+  })
+
+  test('last matching rule wins', () => {
+    const rules = [
+      { permission: 'bash', pattern: '*', action: 'allow' as const },
+      { permission: 'bash', pattern: 'rm *', action: 'deny' as const },
+    ]
+    expect(evaluatePermission({ rules, permission: 'bash', patterns: ['ls -la'] })).toBe('allow')
+    expect(evaluatePermission({ rules, permission: 'bash', patterns: ['rm -rf dist'] })).toBe(
+      'deny',
+    )
+  })
+
+  test('deny wins over ask across multiple patterns', () => {
+    const rules = [{ permission: 'external_directory', pattern: '/etc/*', action: 'deny' as const }]
+    expect(
+      evaluatePermission({
+        rules,
+        permission: 'external_directory',
+        patterns: ['/home/user/x', '/etc/passwd'],
+      }),
+    ).toBe('deny')
+  })
+
+  test('unknown permission defaults to allow', () => {
+    expect(evaluatePermission({ rules: [], permission: 'somethingelse', patterns: ['*'] })).toBe(
+      'allow',
+    )
+  })
+})
+
+describe('describeToolPermission', () => {
+  test('Bash maps to bash permission with command pattern', () => {
+    const descriptor = describeToolPermission({
+      toolName: 'Bash',
+      input: { command: 'git push origin main' },
+      directory: '/repo',
+    })
+    expect(descriptor).toMatchObject({
+      permission: 'bash',
+      patterns: ['git push origin main'],
+      always: ['git *'],
+    })
+  })
+
+  test('Edit maps to edit permission with workspace-relative path', () => {
+    const descriptor = describeToolPermission({
+      toolName: 'Edit',
+      input: { file_path: '/repo/src/index.ts' },
+      directory: '/repo',
+    })
+    expect(descriptor).toMatchObject({
+      permission: 'edit',
+      patterns: ['src/index.ts'],
+      always: ['*'],
+    })
+  })
+
+  test('blockedPath maps to external_directory', () => {
+    const descriptor = describeToolPermission({
+      toolName: 'Read',
+      input: { file_path: '/outside/secret.txt' },
+      directory: '/repo',
+      blockedPath: '/outside',
+    })
+    expect(descriptor).toMatchObject({
+      permission: 'external_directory',
+      patterns: ['/outside'],
+      always: ['/outside', '/outside/*'],
+    })
+  })
+
+  test('safe read-only tools inside workspace are auto-allowed', () => {
+    expect(
+      describeToolPermission({
+        toolName: 'Read',
+        input: { file_path: '/repo/a.ts' },
+        directory: '/repo',
+      }),
+    ).toBeUndefined()
+    expect(
+      describeToolPermission({
+        toolName: 'Grep',
+        input: { pattern: 'foo' },
+        directory: '/repo',
+      }),
+    ).toBeUndefined()
+    expect(
+      describeToolPermission({
+        toolName: 'mcp__kimaki__kimaki_action_buttons',
+        input: {},
+        directory: '/repo',
+      }),
+    ).toBeUndefined()
+  })
+
+  test('WebFetch always pattern is host-scoped', () => {
+    const descriptor = describeToolPermission({
+      toolName: 'WebFetch',
+      input: { url: 'https://docs.example.com/page?q=1' },
+      directory: '/repo',
+    })
+    expect(descriptor).toMatchObject({
+      permission: 'webfetch',
+      always: ['https://docs.example.com*'],
+    })
+  })
+})
+
+describe('buildAlwaysRules', () => {
+  test('builds allow rules from always patterns', () => {
+    expect(buildAlwaysRules({ permission: 'bash', always: ['git *'] })).toEqual([
+      { permission: 'bash', pattern: 'git *', action: 'allow' },
+    ])
+  })
+
+  test('falls back to star when empty', () => {
+    expect(buildAlwaysRules({ permission: 'edit', always: [] })).toEqual([
+      { permission: 'edit', pattern: '*', action: 'allow' },
+    ])
+  })
+})

--- a/cli/src/claude-code/permission-map.ts
+++ b/cli/src/claude-code/permission-map.ts
@@ -1,0 +1,281 @@
+// Maps Claude Agent SDK tool calls onto OpenCode's permission model.
+//
+// OpenCode gates tools with a PermissionRuleset: rules of
+// { permission, pattern, action } evaluated with last-match-wins (findLast)
+// semantics. Kimaki builds those rulesets at session.create time and renders
+// permission.asked events as Discord buttons. The Claude backend replicates
+// that flow: every canUseTool callback is translated into a permission
+// descriptor here, evaluated against the session ruleset, and only escalated
+// to Discord when the resolved action is "ask".
+
+import path from 'node:path'
+import type { PermissionRule, PermissionRuleset } from '@opencode-ai/sdk/v2'
+
+export type PermissionDescriptor = {
+  /** OpenCode permission name, e.g. "bash", "edit", "external_directory". */
+  permission: string
+  /** Patterns shown to the user and matched against the ruleset. */
+  patterns: string[]
+  /** Patterns persisted as allow rules when the user picks "Accept Always". */
+  always: string[]
+  metadata: Record<string, unknown>
+}
+
+/**
+ * Wildcard matching with the same semantics as commands/permissions.ts —
+ * `*` matches any run, `?` matches one char, and a trailing " *" also matches
+ * the bare prefix (so "git *" matches "git").
+ */
+export function wildcardMatchValue({
+  value,
+  pattern,
+}: {
+  value: string
+  pattern: string
+}): boolean {
+  let escapedPattern = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.')
+
+  if (escapedPattern.endsWith(' .*')) {
+    escapedPattern = escapedPattern.slice(0, -3) + '( .*)?'
+  }
+
+  return new RegExp(`^${escapedPattern}$`, 's').test(value)
+}
+
+/**
+ * Default actions matching the opencode server config kimaki generates:
+ * bash/edit/external_directory prompt by default, everything else runs.
+ */
+const DEFAULT_ACTIONS: Record<string, 'allow' | 'deny' | 'ask'> = {
+  bash: 'ask',
+  edit: 'ask',
+  external_directory: 'ask',
+  webfetch: 'allow',
+  websearch: 'allow',
+}
+
+export function evaluatePermission({
+  rules,
+  permission,
+  patterns,
+}: {
+  rules: PermissionRuleset
+  permission: string
+  patterns: string[]
+}): 'allow' | 'deny' | 'ask' {
+  // Every pattern must independently resolve to allow for the call to be
+  // auto-allowed; any deny wins immediately; otherwise ask.
+  let sawAsk = false
+  for (const value of patterns) {
+    const matched = findLastMatchingRule({ rules, permission, value })
+    const action = matched?.action ?? DEFAULT_ACTIONS[permission] ?? 'allow'
+    if (action === 'deny') {
+      return 'deny'
+    }
+    if (action === 'ask') {
+      sawAsk = true
+    }
+  }
+  return sawAsk ? 'ask' : 'allow'
+}
+
+function findLastMatchingRule({
+  rules,
+  permission,
+  value,
+}: {
+  rules: PermissionRuleset
+  permission: string
+  value: string
+}): PermissionRule | undefined {
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i]
+    if (!rule || rule.permission !== permission) {
+      continue
+    }
+    if (wildcardMatchValue({ value, pattern: rule.pattern })) {
+      return rule
+    }
+  }
+  return undefined
+}
+
+function toWorkspacePattern({
+  filePath,
+  directory,
+}: {
+  filePath: string
+  directory: string
+}): string {
+  const normalized = filePath.replaceAll('\\', '/')
+  const normalizedDirectory = directory.replaceAll('\\', '/')
+  if (!path.isAbsolute(normalized)) {
+    return normalized
+  }
+  const relative = path.relative(normalizedDirectory, normalized).replaceAll('\\', '/')
+  if (relative && !relative.startsWith('..')) {
+    return relative
+  }
+  return normalized
+}
+
+function readString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/** First shell word of a bash command, used for "Accept Always" patterns. */
+function bashAlwaysPattern(command: string): string {
+  const trimmed = command.trim()
+  const firstToken = trimmed.split(/\s+/)[0]
+  if (!firstToken) {
+    return trimmed || '*'
+  }
+  if (firstToken === trimmed) {
+    return firstToken
+  }
+  return `${firstToken} *`
+}
+
+/**
+ * Tools that never need a permission prompt from kimaki's point of view.
+ * Read/Glob/Grep inside the workspace are safe; task orchestration, todo
+ * bookkeeping, and kimaki's own MCP tools are side-effect free for the host.
+ */
+const AUTO_ALLOWED_TOOLS = new Set([
+  'Task',
+  'TodoWrite',
+  'ExitPlanMode',
+  'BashOutput',
+  'KillShell',
+  'KillBash',
+  'Skill',
+  'SlashCommand',
+  'ListMcpResources',
+  'ReadMcpResource',
+  'NotebookRead',
+  'LS',
+])
+
+/**
+ * Translate a Claude tool call into an OpenCode permission descriptor.
+ * Returns undefined when the call should be auto-allowed without consulting
+ * the ruleset (safe read-only tools inside the workspace).
+ */
+export function describeToolPermission({
+  toolName,
+  input,
+  directory,
+  blockedPath,
+}: {
+  toolName: string
+  input: Record<string, unknown>
+  directory: string
+  blockedPath?: string
+}): PermissionDescriptor | undefined {
+  // Paths outside the workspace surface as external_directory regardless of
+  // which tool triggered them — mirrors opencode's external_directory gate.
+  if (blockedPath) {
+    const pattern = blockedPath.replaceAll('\\', '/')
+    return {
+      permission: 'external_directory',
+      patterns: [pattern],
+      always: [pattern, `${pattern}/*`],
+      metadata: { tool: toolName, blockedPath },
+    }
+  }
+
+  if (toolName === 'Bash') {
+    const command = readString(input, 'command') ?? ''
+    return {
+      permission: 'bash',
+      patterns: [command || '*'],
+      always: [bashAlwaysPattern(command)],
+      metadata: { tool: toolName, command },
+    }
+  }
+
+  if (
+    toolName === 'Edit' ||
+    toolName === 'Write' ||
+    toolName === 'MultiEdit' ||
+    toolName === 'NotebookEdit'
+  ) {
+    const filePath = readString(input, 'file_path') ?? readString(input, 'notebook_path') ?? ''
+    const pattern = filePath ? toWorkspacePattern({ filePath, directory }) : '*'
+    return {
+      permission: 'edit',
+      patterns: [pattern],
+      // Accept Always on an edit permission allows all future edits, which is
+      // what opencode does for its edit gate as well.
+      always: ['*'],
+      metadata: { tool: toolName, filePath },
+    }
+  }
+
+  if (toolName === 'WebFetch') {
+    const url = readString(input, 'url') ?? '*'
+    const always = (() => {
+      const parsed = (() => {
+        if (url === '*') return null
+        return URL.canParse(url) ? new URL(url) : null
+      })()
+      if (!parsed) {
+        return [url]
+      }
+      return [`${parsed.protocol}//${parsed.hostname}*`]
+    })()
+    return {
+      permission: 'webfetch',
+      patterns: [url],
+      always,
+      metadata: { tool: toolName, url },
+    }
+  }
+
+  if (toolName === 'WebSearch') {
+    const searchQuery = readString(input, 'query') ?? '*'
+    return {
+      permission: 'websearch',
+      patterns: [searchQuery],
+      always: ['*'],
+      metadata: { tool: toolName, query: searchQuery },
+    }
+  }
+
+  if (
+    toolName === 'Read' ||
+    toolName === 'Glob' ||
+    toolName === 'Grep' ||
+    AUTO_ALLOWED_TOOLS.has(toolName) ||
+    toolName.startsWith('mcp__')
+  ) {
+    return undefined
+  }
+
+  // Unknown tool: surface it under its own name so deny/allow rules written
+  // as `<tool>:action` still apply, defaulting to allow.
+  return {
+    permission: toolName.toLowerCase(),
+    patterns: ['*'],
+    always: ['*'],
+    metadata: { tool: toolName },
+  }
+}
+
+/** Rules appended to the session ruleset after an "Accept Always" reply. */
+export function buildAlwaysRules({
+  permission,
+  always,
+}: {
+  permission: string
+  always: string[]
+}): PermissionRuleset {
+  const patterns = always.length > 0 ? always : ['*']
+  return patterns.map((pattern) => {
+    return { permission, pattern, action: 'allow' as const }
+  })
+}

--- a/cli/src/claude-code/router.e2e.test.ts
+++ b/cli/src/claude-code/router.e2e.test.ts
@@ -1,0 +1,676 @@
+// Hermetic end-to-end test for the Claude Code backend router.
+//
+// Uses the REAL @opencode-ai/sdk/v2 client against the router (full wire
+// protocol), a fake upstream opencode server, and a scriptable fake Agent SDK
+// query implementation — no Claude subprocess, no network.
+
+import http from 'node:http'
+import os from 'node:os'
+import fs from 'node:fs'
+import path from 'node:path'
+import { once } from 'node:events'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { createOpencodeClient, type Event as OpenCodeEvent } from '@opencode-ai/sdk/v2'
+import type {
+  Options,
+  PermissionResult,
+  Query,
+  SDKMessage,
+  SDKUserMessage,
+} from '@anthropic-ai/claude-agent-sdk'
+import { setDataDir } from '../config.js'
+import { startClaudeCodeRouter, type ClaudeCodeRouter } from './server.js'
+import type { QueryImpl } from './sessions.js'
+
+// ── Fake Agent SDK query ─────────────────────────────────────────
+
+type FakeQueryContext = {
+  options: Options
+  nextInput: () => Promise<SDKUserMessage>
+  emit: (message: SDKMessage) => void
+  onInterrupt: (handler: () => void) => void
+  canUseTool: (
+    toolName: string,
+    input: Record<string, unknown>,
+    extra: { toolUseID: string },
+  ) => Promise<PermissionResult | null>
+}
+
+type FakeScript = (ctx: FakeQueryContext) => Promise<void>
+
+function createFakeQueryImpl(script: FakeScript): QueryImpl {
+  const impl = ({
+    prompt,
+    options,
+  }: {
+    prompt: string | AsyncIterable<SDKUserMessage>
+    options?: Options
+  }): Query => {
+    const output: SDKMessage[] = []
+    let outputNotify: (() => void) | null = null
+    let scriptDone = false
+    let interruptHandler: (() => void) | null = null
+
+    const inputIterator = typeof prompt === 'string' ? null : prompt[Symbol.asyncIterator]()
+
+    const ctx: FakeQueryContext = {
+      options: options ?? {},
+      nextInput: async () => {
+        if (!inputIterator) {
+          throw new Error('fake query requires streaming input')
+        }
+        const result = await inputIterator.next()
+        if (result.done) {
+          throw new Error('input ended')
+        }
+        return result.value
+      },
+      emit: (message) => {
+        output.push(message)
+        outputNotify?.()
+        outputNotify = null
+      },
+      onInterrupt: (handler) => {
+        interruptHandler = handler
+      },
+      canUseTool: async (toolName, input, extra) => {
+        const handler = options?.canUseTool
+        if (!handler) {
+          return { behavior: 'allow', updatedInput: input }
+        }
+        const abortController = new AbortController()
+        return handler(toolName, input, {
+          signal: abortController.signal,
+          toolUseID: extra.toolUseID,
+          requestId: `req_${extra.toolUseID}`,
+        })
+      },
+    }
+
+    void script(ctx)
+      .catch(() => {
+        // input ended or script error — just finish the stream
+      })
+      .finally(() => {
+        scriptDone = true
+        outputNotify?.()
+        outputNotify = null
+      })
+
+    const generator = (async function* () {
+      while (true) {
+        const message = output.shift()
+        if (message) {
+          yield message
+          continue
+        }
+        if (scriptDone) {
+          return
+        }
+        await new Promise<void>((resolve) => {
+          outputNotify = resolve
+        })
+      }
+    })()
+
+    const fakeQuery = {
+      next: generator.next.bind(generator),
+      return: generator.return.bind(generator),
+      throw: generator.throw.bind(generator),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      [Symbol.asyncDispose]: async () => {},
+      interrupt: async () => {
+        interruptHandler?.()
+      },
+      close: () => {},
+      setModel: async () => {},
+      supportedCommands: async () => {
+        return []
+      },
+      supportedModels: async () => {
+        return []
+      },
+      rewindFiles: async () => {
+        return { canRewind: true }
+      },
+      streamInput: async () => {},
+    }
+    // The Query interface carries ~25 control methods; the fake implements the
+    // subset the backend uses and is bridged through unknown for the rest.
+    return fakeQuery as unknown as Query
+  }
+  return impl as QueryImpl
+}
+
+// ── Fake upstream opencode server ────────────────────────────────
+
+async function startFakeUpstream(): Promise<{ baseUrl: string; close: () => void }> {
+  const openStreams = new Set<http.ServerResponse>()
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost')
+    const respond = (body: unknown) => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(body))
+    }
+    if (url.pathname === '/global/event') {
+      // Never-ending SSE stream like the real opencode server.
+      res.writeHead(200, { 'content-type': 'text/event-stream' })
+      res.write(':connected\n\n')
+      openStreams.add(res)
+      req.on('close', () => {
+        openStreams.delete(res)
+      })
+      return
+    }
+    if (url.pathname === '/provider') {
+      respond({
+        all: [
+          {
+            id: 'anthropic',
+            name: 'Anthropic',
+            source: 'api',
+            env: [],
+            options: {},
+            models: {},
+          },
+        ],
+        default: { anthropic: 'claude-something' },
+        connected: ['anthropic'],
+      })
+      return
+    }
+    if (url.pathname === '/session/status') {
+      respond({ ses_upstream_1: { type: 'idle' } })
+      return
+    }
+    if (url.pathname === '/session' && req.method === 'GET') {
+      respond([])
+      return
+    }
+    if (url.pathname === '/session' && req.method === 'POST') {
+      respond({
+        id: 'ses_upstream_new',
+        slug: 'upstream',
+        projectID: 'p',
+        directory: '/tmp',
+        title: 'upstream session',
+        version: '1',
+        time: { created: Date.now(), updated: Date.now() },
+      })
+      return
+    }
+    res.writeHead(404, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ message: `no fake for ${req.method} ${url.pathname}` }))
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('fake upstream failed to bind')
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => {
+      for (const stream of openStreams) {
+        stream.end()
+      }
+      server.close()
+    },
+  }
+}
+
+// ── Scripts for each scenario, selected per session directory ────
+
+const scriptsByDirectory = new Map<string, FakeScript>()
+
+const dispatcherScript: FakeScript = async (ctx) => {
+  const directory = ctx.options.cwd ?? ''
+  const script = scriptsByDirectory.get(directory)
+  if (!script) {
+    throw new Error(`no fake script for directory ${directory}`)
+  }
+  await script(ctx)
+}
+
+function fakeInit(ctx: FakeQueryContext): SDKMessage {
+  return {
+    type: 'system',
+    subtype: 'init',
+    apiKeySource: 'none',
+    claude_code_version: '2.0.0',
+    cwd: ctx.options.cwd ?? '/tmp',
+    tools: ['Bash', 'Edit'],
+    mcp_servers: [],
+    model: 'claude-opus-4-8',
+    permissionMode: 'default',
+    slash_commands: ['compact', 'review'],
+    output_style: 'default',
+    skills: [],
+    plugins: [],
+    agents: ['general-purpose'],
+    uuid: crypto.randomUUID(),
+    session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001',
+  } as SDKMessage
+}
+
+function fakeAssistantText(text: string): SDKMessage {
+  return {
+    type: 'assistant',
+    message: {
+      id: 'msg_api_1',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-opus-4-8',
+      content: [{ type: 'text', text, citations: null }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001',
+  } as SDKMessage
+}
+
+function fakeResult(): SDKMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 100,
+    duration_api_ms: 80,
+    is_error: false,
+    num_turns: 1,
+    result: 'done',
+    stop_reason: 'end_turn',
+    total_cost_usd: 0.0123,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_creation_input_tokens: 1,
+      cache_read_input_tokens: 2,
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: crypto.randomUUID(),
+    session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001',
+  } as SDKMessage
+}
+
+// ── Test wiring ──────────────────────────────────────────────────
+
+let router: ClaudeCodeRouter
+let upstream: Awaited<ReturnType<typeof startFakeUpstream>>
+let collectedEvents: Array<{ directory: string; payload: OpenCodeEvent }> = []
+let eventAbort: AbortController
+
+function makeClient({ claudeBackend }: { claudeBackend: boolean }) {
+  return createOpencodeClient({
+    baseUrl: router.baseUrl,
+    ...(claudeBackend ? { headers: { 'x-kimaki-backend': 'claude-code' } } : {}),
+  })
+}
+
+async function waitForEvent(
+  predicate: (event: OpenCodeEvent) => boolean,
+  timeoutMs = 5000,
+): Promise<OpenCodeEvent> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const found = collectedEvents.find(({ payload }) => {
+      return predicate(payload)
+    })
+    if (found) {
+      return found.payload
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20)
+    })
+  }
+  throw new Error(
+    `Timed out waiting for event. Collected: ${collectedEvents
+      .map(({ payload }) => {
+        return payload.type
+      })
+      .join(', ')}`,
+  )
+}
+
+beforeAll(async () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimaki-claude-test-'))
+  setDataDir(dataDir)
+  upstream = await startFakeUpstream()
+  router = await startClaudeCodeRouter({
+    getUpstreamBaseUrl: () => {
+      return upstream.baseUrl
+    },
+    queryImpl: createFakeQueryImpl(dispatcherScript),
+  })
+
+  // Collect merged global events through the real SDK client.
+  eventAbort = new AbortController()
+  const client = makeClient({ claudeBackend: false })
+  const subscription = await client.global.event({ signal: eventAbort.signal })
+  void (async () => {
+    for await (const event of subscription.stream) {
+      collectedEvents.push(event as { directory: string; payload: OpenCodeEvent })
+    }
+  })().catch(() => {
+    // aborted at teardown
+  })
+})
+
+afterAll(async () => {
+  eventAbort?.abort()
+  await router?.close()
+  upstream?.close()
+})
+
+describe('claude-code router', () => {
+  test('creates sessions on the claude backend only with the header', async () => {
+    const claudeClient = makeClient({ claudeBackend: true })
+    const created = await claudeClient.session.create({ directory: '/tmp/proj-basic' })
+    expect(created.data?.id).toMatch(/^ses_claude_/)
+
+    const plainClient = makeClient({ claudeBackend: false })
+    const upstreamCreated = await plainClient.session.create({ directory: '/tmp/other' })
+    expect(upstreamCreated.data?.id).toBe('ses_upstream_new')
+  })
+
+  test('prompt flows through the fake agent and emits opencode events', async () => {
+    const directory = '/tmp/proj-basic'
+    scriptsByDirectory.set(directory, async (ctx) => {
+      await ctx.nextInput()
+      ctx.emit(fakeInit(ctx))
+      ctx.emit(fakeAssistantText('Hello from Claude Code'))
+      ctx.emit(fakeResult())
+      // Stay alive for a potential follow-up prompt.
+      await ctx.nextInput().catch(() => {
+        return undefined
+      })
+    })
+
+    const client = makeClient({ claudeBackend: true })
+    const created = await client.session.create({ directory })
+    const sessionId = created.data!.id
+
+    const promptResponse = await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      parts: [{ type: 'text', text: 'hi there' }],
+    })
+    expect(promptResponse.error).toBeFalsy()
+
+    await waitForEvent((event) => {
+      return (
+        event.type === 'session.status' &&
+        event.properties.sessionID === sessionId &&
+        event.properties.status.type === 'busy'
+      )
+    })
+    await waitForEvent((event) => {
+      return (
+        event.type === 'message.part.updated' &&
+        event.properties.sessionID === sessionId &&
+        event.properties.part.type === 'text' &&
+        event.properties.part.text.includes('Hello from Claude Code')
+      )
+    })
+    await waitForEvent((event) => {
+      return event.type === 'session.idle' && event.properties.sessionID === sessionId
+    })
+
+    const messages = await client.session.messages({ sessionID: sessionId, directory })
+    expect(messages.data).toBeTruthy()
+    const roles = messages.data!.map(({ info }) => {
+      return info.role
+    })
+    expect(roles).toEqual(['user', 'assistant'])
+    const assistant = messages.data![1]!
+    expect(assistant.info.role).toBe('assistant')
+    if (assistant.info.role === 'assistant') {
+      expect(assistant.info.cost).toBeCloseTo(0.0123)
+      expect(assistant.info.time.completed).toBeTruthy()
+    }
+
+    const statuses = await client.session.status({ directory })
+    expect(statuses.data?.[sessionId]).toEqual({ type: 'idle' })
+    // Upstream statuses are merged in.
+    expect(statuses.data?.ses_upstream_1).toEqual({ type: 'idle' })
+  })
+
+  test('permission ask → discord reply → allow, and always persists a rule', async () => {
+    const directory = '/tmp/proj-perms'
+    const permissionResults: Array<PermissionResult | null> = []
+    scriptsByDirectory.set(directory, async (ctx) => {
+      await ctx.nextInput()
+      ctx.emit(fakeInit(ctx))
+      const first = await ctx.canUseTool(
+        'Bash',
+        { command: 'git push origin main' },
+        { toolUseID: 'toolu_perm_1' },
+      )
+      permissionResults.push(first)
+      ctx.emit(fakeResult())
+      await ctx.nextInput()
+      const second = await ctx.canUseTool(
+        'Bash',
+        { command: 'git status' },
+        { toolUseID: 'toolu_perm_2' },
+      )
+      permissionResults.push(second)
+      ctx.emit(fakeResult())
+      await ctx.nextInput().catch(() => {
+        return undefined
+      })
+    })
+
+    const client = makeClient({ claudeBackend: true })
+    const created = await client.session.create({ directory })
+    const sessionId = created.data!.id
+
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      parts: [{ type: 'text', text: 'push my changes' }],
+    })
+
+    const asked = await waitForEvent((event) => {
+      return event.type === 'permission.asked' && event.properties.sessionID === sessionId
+    })
+    if (asked.type !== 'permission.asked') {
+      throw new Error('unreachable')
+    }
+    expect(asked.properties.permission).toBe('bash')
+    expect(asked.properties.patterns).toEqual(['git push origin main'])
+    expect(asked.properties.always).toEqual(['git *'])
+
+    const replyResponse = await client.permission.reply({
+      requestID: asked.properties.id,
+      directory,
+      reply: 'always',
+    })
+    expect(replyResponse.data).toBe(true)
+
+    await waitForEvent((event) => {
+      return (
+        event.type === 'permission.replied' && event.properties.requestID === asked.properties.id
+      )
+    })
+
+    // Second bash command matches the persisted `git *` rule → auto-allowed
+    // without a new permission.asked event.
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      parts: [{ type: 'text', text: 'now check status' }],
+    })
+    await waitForEvent((event) => {
+      return event.type === 'session.idle' && event.properties.sessionID === sessionId
+    })
+    const askedEvents = collectedEvents.filter(({ payload }) => {
+      return payload.type === 'permission.asked' && payload.properties.sessionID === sessionId
+    })
+    expect(askedEvents).toHaveLength(1)
+    expect(permissionResults[0]).toMatchObject({ behavior: 'allow' })
+    expect(permissionResults[1]).toMatchObject({ behavior: 'allow' })
+  })
+
+  test('AskUserQuestion becomes question.asked and answers flow back', async () => {
+    const directory = '/tmp/proj-question'
+    const questionResults: Array<PermissionResult | null> = []
+    scriptsByDirectory.set(directory, async (ctx) => {
+      await ctx.nextInput()
+      ctx.emit(fakeInit(ctx))
+      const result = await ctx.canUseTool(
+        'AskUserQuestion',
+        {
+          questions: [
+            {
+              question: 'Which framework?',
+              header: 'Framework',
+              multiSelect: false,
+              options: [
+                { label: 'React', description: 'UI library' },
+                { label: 'Vue', description: 'Framework' },
+              ],
+            },
+          ],
+        },
+        { toolUseID: 'toolu_q_1' },
+      )
+      questionResults.push(result)
+      ctx.emit(fakeResult())
+      await ctx.nextInput().catch(() => {
+        return undefined
+      })
+    })
+
+    const client = makeClient({ claudeBackend: true })
+    const created = await client.session.create({ directory })
+    const sessionId = created.data!.id
+
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      parts: [{ type: 'text', text: 'set up a frontend' }],
+    })
+
+    const asked = await waitForEvent((event) => {
+      return event.type === 'question.asked' && event.properties.sessionID === sessionId
+    })
+    if (asked.type !== 'question.asked') {
+      throw new Error('unreachable')
+    }
+    expect(asked.properties.questions[0]).toMatchObject({
+      question: 'Which framework?',
+      header: 'Framework',
+    })
+
+    const replyResponse = await client.question.reply({
+      requestID: asked.properties.id,
+      directory,
+      answers: [['React']],
+    })
+    expect(replyResponse.data).toBe(true)
+
+    await waitForEvent((event) => {
+      return event.type === 'question.replied' && event.properties.requestID === asked.properties.id
+    })
+
+    const result = questionResults[0]
+    expect(result).toBeTruthy()
+    if (result && result.behavior === 'allow') {
+      expect(result.updatedInput).toMatchObject({
+        answers: { 'Which framework?': 'React' },
+      })
+    } else {
+      throw new Error(`expected allow, got ${JSON.stringify(result)}`)
+    }
+  })
+
+  test('abort interrupts the live query and idles the session', async () => {
+    const directory = '/tmp/proj-abort'
+    let sawInterrupt = false
+    scriptsByDirectory.set(directory, async (ctx) => {
+      await ctx.nextInput()
+      ctx.emit(fakeInit(ctx))
+      // Simulate a long-running turn that only finishes when interrupted.
+      await new Promise<void>((resolve) => {
+        ctx.onInterrupt(() => {
+          sawInterrupt = true
+          resolve()
+        })
+      })
+      ctx.emit({
+        ...fakeResult(),
+        subtype: 'error_during_execution',
+        is_error: true,
+        errors: ['aborted'],
+      } as SDKMessage)
+      await ctx.nextInput().catch(() => {
+        return undefined
+      })
+    })
+
+    const client = makeClient({ claudeBackend: true })
+    const created = await client.session.create({ directory })
+    const sessionId = created.data!.id
+
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      parts: [{ type: 'text', text: 'do something slow' }],
+    })
+    await waitForEvent((event) => {
+      return (
+        event.type === 'session.status' &&
+        event.properties.sessionID === sessionId &&
+        event.properties.status.type === 'busy'
+      )
+    })
+
+    const abortResponse = await client.session.abort({ sessionID: sessionId, directory })
+    expect(abortResponse.data).toBe(true)
+
+    await waitForEvent((event) => {
+      return event.type === 'session.idle' && event.properties.sessionID === sessionId
+    })
+    expect(sawInterrupt).toBe(true)
+  })
+
+  test('provider.list merges the claude-code provider with upstream', async () => {
+    const client = makeClient({ claudeBackend: false })
+    const providers = await client.provider.list({ directory: '/tmp/anything' })
+    expect(providers.data).toBeTruthy()
+    const ids = providers.data!.all.map((provider) => {
+      return provider.id
+    })
+    expect(ids).toContain('anthropic')
+    expect(ids).toContain('claude-code')
+    expect(providers.data!.connected).toContain('claude-code')
+    const claudeProvider = providers.data!.all.find((provider) => {
+      return provider.id === 'claude-code'
+    })
+    expect(Object.keys(claudeProvider!.models).length).toBeGreaterThan(0)
+    const opus = claudeProvider!.models['claude-opus-4-8']
+    expect(opus?.variants).toMatchObject({ high: {}, max: {} })
+  })
+
+  test('session list merges claude sessions with upstream and session.get works', async () => {
+    const client = makeClient({ claudeBackend: true })
+    const created = await client.session.create({ directory: '/tmp/proj-list' })
+    const sessionId = created.data!.id
+
+    const list = await client.session.list({ directory: '/tmp/proj-list' })
+    const listed = list.data!.find((session) => {
+      return session.id === sessionId
+    })
+    expect(listed).toBeTruthy()
+
+    const fetched = await client.session.get({ sessionID: sessionId })
+    expect(fetched.data?.id).toBe(sessionId)
+    expect(fetched.data?.directory).toBe('/tmp/proj-list')
+  })
+})

--- a/cli/src/claude-code/server.ts
+++ b/cli/src/claude-code/server.ts
@@ -1,0 +1,690 @@
+// Backend router: a local HTTP server that speaks the OpenCode v2 protocol.
+//
+// Kimaki's OpencodeClient instances point at this router instead of the raw
+// opencode server. Each request is dispatched:
+//   - Claude Code sessions (ses_claude_* ids, perm_claude_*/que_claude_*
+//     request ids, or session.create with the x-kimaki-backend header) are
+//     handled in-process by the ClaudeCodeSessionManager.
+//   - provider/status/list responses are merged so Claude Code appears as a
+//     normal provider next to the upstream opencode ones.
+//   - /global/event is a merged SSE stream (upstream events + claude events).
+//   - Everything else is transparently proxied to the real opencode server.
+//
+// This keeps all 40+ existing OpencodeClient call sites working unchanged for
+// both backends.
+
+import http from 'node:http'
+import { once } from 'node:events'
+import type {
+  Event as OpenCodeEvent,
+  PermissionRuleset,
+  QuestionAnswer,
+  Session,
+  TextPartInput,
+  FilePartInput,
+} from '@opencode-ai/sdk/v2'
+import { createLogger, LogPrefix } from '../logger.js'
+import { ClaudeCodeSessionManager, type PromptRequest, type QueryImpl } from './sessions.js'
+import { isClaudeCodePermissionId, isClaudeCodeQuestionId, isClaudeCodeSessionId } from './ids.js'
+import {
+  CLAUDE_CODE_PROVIDER_ID,
+  DEFAULT_CLAUDE_MODEL_ID,
+  getClaudeCodeProvider,
+} from './models.js'
+
+const logger = createLogger(LogPrefix.SESSION)
+
+export const CLAUDE_BACKEND_HEADER = 'x-kimaki-backend'
+export const CLAUDE_BACKEND_VALUE = 'claude-code'
+
+type EventSubscriber = (directory: string, event: OpenCodeEvent) => void
+
+export type ClaudeCodeRouter = {
+  baseUrl: string
+  manager: ClaudeCodeSessionManager
+  close: () => Promise<void>
+}
+
+type RouterOptions = {
+  /** Returns the current upstream opencode base URL (may change on restart). */
+  getUpstreamBaseUrl: () => string | null
+  /** Extra headers to attach when proxying to the upstream server. */
+  getUpstreamHeaders?: () => Record<string, string>
+  /** Injectable for hermetic tests. */
+  queryImpl?: QueryImpl
+  /** Basic-auth credentials required from clients (mirrors opencode's). */
+  expectedAuthorization?: () => string | undefined
+}
+
+function readBody(req: http.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks))
+    })
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const payload = body === undefined ? '' : JSON.stringify(body)
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(payload)
+}
+
+function sendError(res: http.ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { message })
+}
+
+function parseJson(buffer: Buffer): Record<string, unknown> {
+  if (buffer.length === 0) {
+    return {}
+  }
+  const text = buffer.toString('utf8')
+  if (!text.trim()) {
+    return {}
+  }
+  const parseAttempt = (): unknown => {
+    return JSON.parse(text)
+  }
+  let parsed: unknown
+  try {
+    parsed = parseAttempt()
+  } catch {
+    return {}
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>
+  }
+  return {}
+}
+
+function promptRequestFromBody(body: Record<string, unknown>): PromptRequest {
+  const rawParts = Array.isArray(body.parts) ? body.parts : []
+  const parts: Array<TextPartInput | FilePartInput> = []
+  for (const raw of rawParts) {
+    if (!raw || typeof raw !== 'object') {
+      continue
+    }
+    const rec = raw as Record<string, unknown>
+    if (rec.type === 'text' && typeof rec.text === 'string') {
+      parts.push({
+        type: 'text',
+        text: rec.text,
+        ...(rec.synthetic === true ? { synthetic: true } : {}),
+      })
+    } else if (rec.type === 'file' && typeof rec.url === 'string' && typeof rec.mime === 'string') {
+      parts.push({
+        type: 'file',
+        mime: rec.mime,
+        url: rec.url,
+        ...(typeof rec.filename === 'string' ? { filename: rec.filename } : {}),
+      })
+    }
+  }
+  const model = (() => {
+    if (!body.model || typeof body.model !== 'object') {
+      return undefined
+    }
+    const rec = body.model as Record<string, unknown>
+    if (typeof rec.providerID === 'string' && typeof rec.modelID === 'string') {
+      return { providerID: rec.providerID, modelID: rec.modelID }
+    }
+    return undefined
+  })()
+  return {
+    parts,
+    ...(model ? { model } : {}),
+    ...(typeof body.agent === 'string' ? { agent: body.agent } : {}),
+    ...(typeof body.variant === 'string' ? { variant: body.variant } : {}),
+    ...(typeof body.system === 'string' ? { system: body.system } : {}),
+    ...(body.noReply === true ? { noReply: true } : {}),
+  }
+}
+
+/**
+ * Start the backend router. The returned baseUrl is what every
+ * OpencodeClient in kimaki should use as its server address.
+ */
+export async function startClaudeCodeRouter(options: RouterOptions): Promise<ClaudeCodeRouter> {
+  const subscribers = new Set<EventSubscriber>()
+
+  const manager = new ClaudeCodeSessionManager({
+    emitEvent: (directory, event) => {
+      for (const subscriber of subscribers) {
+        subscriber(directory, event)
+      }
+    },
+    queryImpl: options.queryImpl,
+  })
+
+  const server = http.createServer((req, res) => {
+    void handleRequest(req, res).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error(`[CLAUDE ROUTER] ${req.method} ${req.url} failed: ${message}`)
+      if (!res.headersSent) {
+        sendError(res, 500, message)
+      } else {
+        res.end()
+      }
+    })
+  })
+
+  async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const pathname = url.pathname
+    const method = req.method ?? 'GET'
+
+    const expectedAuth = options.expectedAuthorization?.()
+    if (expectedAuth && req.headers.authorization !== expectedAuth) {
+      sendError(res, 401, 'Unauthorized')
+      return
+    }
+
+    // ── Merged global event stream ─────────────────────────────
+    if (method === 'GET' && (pathname === '/global/event' || pathname === '/event')) {
+      handleGlobalEventStream(req, res)
+      return
+    }
+
+    // ── Claude-handled session endpoints ───────────────────────
+    const sessionMatch = /^\/session\/([^/]+)(\/.*)?$/.exec(pathname)
+    if (sessionMatch && isClaudeCodeSessionId(sessionMatch[1])) {
+      await handleClaudeSessionRoute({
+        req,
+        res,
+        method,
+        sessionId: sessionMatch[1]!,
+        subPath: sessionMatch[2] ?? '',
+      })
+      return
+    }
+
+    if (method === 'POST' && pathname === '/session') {
+      const backendHeader = req.headers[CLAUDE_BACKEND_HEADER]
+      if (backendHeader === CLAUDE_BACKEND_VALUE) {
+        const body = parseJson(await readBody(req))
+        const directory =
+          url.searchParams.get('directory') ??
+          (typeof body.directory === 'string' ? body.directory : undefined)
+        if (!directory) {
+          sendError(res, 400, 'directory is required for claude-code sessions')
+          return
+        }
+        const permission = Array.isArray(body.permission)
+          ? (body.permission as PermissionRuleset)
+          : []
+        const session = manager.create({
+          directory,
+          permission,
+          ...(typeof body.title === 'string' ? { title: body.title } : {}),
+          ...(typeof body.parentID === 'string' ? { parentID: body.parentID } : {}),
+          ...(typeof body.agent === 'string' ? { agent: body.agent } : {}),
+        })
+        sendJson(res, 200, session.toWire())
+        return
+      }
+      // fall through to proxy
+    }
+
+    const permissionReplyMatch = /^\/permission\/([^/]+)\/reply$/.exec(pathname)
+    if (
+      method === 'POST' &&
+      permissionReplyMatch &&
+      isClaudeCodePermissionId(permissionReplyMatch[1])
+    ) {
+      const body = parseJson(await readBody(req))
+      const reply = body.reply
+      if (reply !== 'once' && reply !== 'always' && reply !== 'reject') {
+        sendError(res, 400, `Invalid permission reply: ${String(reply)}`)
+        return
+      }
+      const ok = manager.replyPermission({
+        requestId: permissionReplyMatch[1]!,
+        reply,
+        ...(typeof body.message === 'string' ? { message: body.message } : {}),
+      })
+      sendJson(res, 200, ok)
+      return
+    }
+
+    const questionReplyMatch = /^\/question\/([^/]+)\/(reply|reject)$/.exec(pathname)
+    if (method === 'POST' && questionReplyMatch && isClaudeCodeQuestionId(questionReplyMatch[1])) {
+      const body = parseJson(await readBody(req))
+      if (questionReplyMatch[2] === 'reject') {
+        sendJson(res, 200, manager.rejectQuestion({ requestId: questionReplyMatch[1]! }))
+        return
+      }
+      const answers = Array.isArray(body.answers) ? (body.answers as QuestionAnswer[]) : []
+      sendJson(res, 200, manager.replyQuestion({ requestId: questionReplyMatch[1]!, answers }))
+      return
+    }
+
+    // ── Merged listings ────────────────────────────────────────
+    if (method === 'GET' && pathname === '/session/status') {
+      const directory = url.searchParams.get('directory') ?? undefined
+      const upstream = await proxyJson<Record<string, unknown>>({ req, url, method })
+      const merged: Record<string, unknown> = {
+        ...(upstream.ok ? upstream.body : {}),
+        ...manager.statuses({ directory }),
+      }
+      sendJson(res, 200, merged)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/session') {
+      const directory = url.searchParams.get('directory') ?? undefined
+      const upstream = await proxyJson<Session[]>({ req, url, method })
+      const upstreamSessions = upstream.ok && Array.isArray(upstream.body) ? upstream.body : []
+      const claudeSessions = manager.list({ directory })
+      const merged = [...claudeSessions, ...upstreamSessions].sort((a, b) => {
+        return (b.time?.updated ?? 0) - (a.time?.updated ?? 0)
+      })
+      sendJson(res, 200, merged)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/provider') {
+      const upstream = await proxyJson<{
+        all: unknown[]
+        default: Record<string, string>
+        connected: string[]
+      }>({ req, url, method })
+      const base = upstream.ok ? upstream.body : { all: [], default: {}, connected: [] }
+      const merged = {
+        all: [...(base.all ?? []), getClaudeCodeProvider()],
+        default: {
+          ...(base.default ?? {}),
+          [CLAUDE_CODE_PROVIDER_ID]: DEFAULT_CLAUDE_MODEL_ID,
+        },
+        connected: [...(base.connected ?? []), CLAUDE_CODE_PROVIDER_ID],
+      }
+      sendJson(res, 200, merged)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/config/providers') {
+      const upstream = await proxyJson<{
+        providers: unknown[]
+        default: Record<string, string>
+      }>({ req, url, method })
+      const base = upstream.ok ? upstream.body : { providers: [], default: {} }
+      const merged = {
+        providers: [...(base.providers ?? []), getClaudeCodeProvider()],
+        default: {
+          ...(base.default ?? {}),
+          [CLAUDE_CODE_PROVIDER_ID]: DEFAULT_CLAUDE_MODEL_ID,
+        },
+      }
+      sendJson(res, 200, merged)
+      return
+    }
+
+    await proxyPassthrough({ req, res, url, method })
+  }
+
+  async function handleClaudeSessionRoute({
+    req,
+    res,
+    method,
+    sessionId,
+    subPath,
+  }: {
+    req: http.IncomingMessage
+    res: http.ServerResponse
+    method: string
+    sessionId: string
+    subPath: string
+  }): Promise<void> {
+    const session = manager.get(sessionId)
+    if (!session) {
+      sendError(res, 404, `Session not found: ${sessionId}`)
+      return
+    }
+
+    if (subPath === '' || subPath === '/') {
+      if (method === 'GET') {
+        sendJson(res, 200, session.toWire())
+        return
+      }
+      if (method === 'POST') {
+        const body = parseJson(await readBody(req))
+        const updated = await session.update({
+          ...(typeof body.title === 'string' ? { title: body.title } : {}),
+          ...(Array.isArray(body.permission)
+            ? { permission: body.permission as PermissionRuleset }
+            : {}),
+        })
+        sendJson(res, 200, updated)
+        return
+      }
+      if (method === 'DELETE') {
+        sendJson(res, 200, await manager.delete(sessionId))
+        return
+      }
+    }
+
+    if (subPath === '/message' && method === 'GET') {
+      sendJson(res, 200, await session.messagesWire())
+      return
+    }
+
+    if (subPath === '/prompt_async' && method === 'POST') {
+      const body = parseJson(await readBody(req))
+      await session.prompt(promptRequestFromBody(body))
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    if (subPath === '/abort' && method === 'POST') {
+      sendJson(res, 200, await session.abort())
+      return
+    }
+
+    if (subPath === '/summarize' && method === 'POST') {
+      await session.summarize()
+      sendJson(res, 200, true)
+      return
+    }
+
+    if (subPath === '/revert' && method === 'POST') {
+      const body = parseJson(await readBody(req))
+      const revertResult = await session
+        .revert({
+          ...(typeof body.messageID === 'string' ? { messageID: body.messageID } : {}),
+        })
+        .catch((error: unknown) => {
+          return error instanceof Error ? error : new Error(String(error))
+        })
+      if (revertResult instanceof Error) {
+        sendError(res, 400, revertResult.message)
+        return
+      }
+      sendJson(res, 200, revertResult)
+      return
+    }
+
+    if (subPath === '/unrevert' && method === 'POST') {
+      sendJson(res, 200, await session.unrevert())
+      return
+    }
+
+    if (subPath === '/fork' && method === 'POST') {
+      const body = parseJson(await readBody(req))
+      const forked = session.fork({
+        ...(typeof body.messageID === 'string' ? { messageID: body.messageID } : {}),
+      })
+      sendJson(res, 200, forked.toWire())
+      return
+    }
+
+    if (subPath === '/command' && method === 'POST') {
+      // Claude Code parses slash commands directly from prompt text.
+      const body = parseJson(await readBody(req))
+      const command = typeof body.command === 'string' ? body.command : ''
+      const args = typeof body.arguments === 'string' ? body.arguments : ''
+      if (!command) {
+        sendError(res, 400, 'command is required')
+        return
+      }
+      await session.prompt({
+        parts: [{ type: 'text', text: `/${command}${args ? ` ${args}` : ''}` }],
+      })
+      sendJson(res, 200, {})
+      return
+    }
+
+    if (subPath === '/diff' && method === 'GET') {
+      sendJson(res, 200, session.toWire().summary?.diffs ?? [])
+      return
+    }
+
+    if (subPath === '/children' && method === 'GET') {
+      const children = manager.list({}).filter((candidate) => {
+        return candidate.parentID === sessionId
+      })
+      sendJson(res, 200, children)
+      return
+    }
+
+    if (subPath === '/todo' && method === 'GET') {
+      sendJson(res, 200, [])
+      return
+    }
+
+    sendError(
+      res,
+      501,
+      `Not implemented for Claude Code sessions: ${method} /session/{id}${subPath}`,
+    )
+  }
+
+  // ── Upstream proxy helpers ───────────────────────────────────
+
+  function upstreamRequestHeaders(req: http.IncomingMessage): Record<string, string> {
+    const headers: Record<string, string> = {}
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (typeof value !== 'string') {
+        continue
+      }
+      const lower = key.toLowerCase()
+      if (
+        lower === 'host' ||
+        lower === 'connection' ||
+        lower === 'content-length' ||
+        lower === 'transfer-encoding'
+      ) {
+        continue
+      }
+      headers[key] = value
+    }
+    for (const [key, value] of Object.entries(options.getUpstreamHeaders?.() ?? {})) {
+      headers[key] = value
+    }
+    return headers
+  }
+
+  async function proxyJson<T>({
+    req,
+    url,
+    method,
+  }: {
+    req: http.IncomingMessage
+    url: URL
+    method: string
+  }): Promise<{ ok: true; body: T } | { ok: false }> {
+    const upstreamBase = options.getUpstreamBaseUrl()
+    if (!upstreamBase) {
+      return { ok: false }
+    }
+    const target = `${upstreamBase}${url.pathname}${url.search}`
+    const response = await fetch(target, {
+      method,
+      headers: upstreamRequestHeaders(req),
+    }).catch(() => {
+      return null
+    })
+    if (!response || !response.ok) {
+      return { ok: false }
+    }
+    const body = (await response.json().catch(() => {
+      return null
+    })) as T | null
+    if (body === null) {
+      return { ok: false }
+    }
+    return { ok: true, body }
+  }
+
+  async function proxyPassthrough({
+    req,
+    res,
+    url,
+    method,
+  }: {
+    req: http.IncomingMessage
+    res: http.ServerResponse
+    url: URL
+    method: string
+  }): Promise<void> {
+    const upstreamBase = options.getUpstreamBaseUrl()
+    if (!upstreamBase) {
+      sendError(res, 503, 'OpenCode server is not running')
+      return
+    }
+    const parsed = new URL(upstreamBase)
+    const upstreamReq = http.request(
+      {
+        host: parsed.hostname,
+        port: parsed.port,
+        path: `${url.pathname}${url.search}`,
+        method,
+        headers: upstreamRequestHeaders(req),
+      },
+      (upstreamRes) => {
+        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
+        upstreamRes.pipe(res)
+      },
+    )
+    upstreamReq.on('error', (error) => {
+      logger.warn(`[CLAUDE ROUTER] proxy error for ${method} ${url.pathname}: ${error.message}`)
+      if (!res.headersSent) {
+        sendError(res, 502, `Upstream opencode error: ${error.message}`)
+      } else {
+        res.end()
+      }
+    })
+    req.pipe(upstreamReq)
+  }
+
+  // ── Merged SSE ───────────────────────────────────────────────
+
+  function handleGlobalEventStream(req: http.IncomingMessage, res: http.ServerResponse): void {
+    // The downstream connection only succeeds once the upstream stream is
+    // attached. This preserves the pre-router invariant "subscribed ⇒
+    // receiving opencode events": if the merged stream accepted subscribers
+    // while the upstream was down (e.g. during an opencode restart), events
+    // emitted right after the restart would be silently lost while the
+    // listener believed it was connected. A 503 here makes kimaki's global
+    // listener retry with its own backoff, exactly like connecting to a
+    // restarting opencode server directly.
+    const upstreamBase = options.getUpstreamBaseUrl()
+    if (!upstreamBase) {
+      sendError(res, 503, 'OpenCode server is not running')
+      return
+    }
+
+    let closed = false
+    let upstreamAbort: AbortController | null = null
+
+    const subscriber: EventSubscriber = (directory, event) => {
+      if (closed) {
+        return
+      }
+      const payload = JSON.stringify({ directory, payload: event })
+      res.write(`data: ${payload}\n\n`)
+    }
+
+    const cleanup = () => {
+      if (closed) {
+        return
+      }
+      closed = true
+      subscribers.delete(subscriber)
+      upstreamAbort?.abort()
+    }
+
+    const parsed = new URL(upstreamBase)
+    upstreamAbort = new AbortController()
+    const upstreamReq = http.request(
+      {
+        host: parsed.hostname,
+        port: parsed.port,
+        path: '/global/event',
+        method: 'GET',
+        headers: {
+          accept: 'text/event-stream',
+          ...(options.getUpstreamHeaders?.() ?? {}),
+        },
+        signal: upstreamAbort.signal,
+      },
+      (upstreamRes) => {
+        if (upstreamRes.statusCode !== 200) {
+          upstreamRes.resume()
+          cleanup()
+          if (!res.headersSent) {
+            sendError(
+              res,
+              503,
+              `OpenCode event stream unavailable (status ${upstreamRes.statusCode})`,
+            )
+          }
+          return
+        }
+        // Upstream attached — open the merged stream downstream.
+        res.writeHead(200, {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        })
+        res.write(':ok\n\n')
+        subscribers.add(subscriber)
+
+        upstreamRes.on('data', (chunk: Buffer) => {
+          if (!closed) {
+            res.write(chunk)
+          }
+        })
+        upstreamRes.on('end', () => {
+          // Upstream stream ended (e.g. opencode restart) — end the merged
+          // stream too; kimaki's global listener reconnects immediately.
+          cleanup()
+          res.end()
+        })
+        upstreamRes.on('error', () => {
+          cleanup()
+          res.end()
+        })
+      },
+    )
+    upstreamReq.on('error', (error) => {
+      cleanup()
+      if (!res.headersSent) {
+        sendError(res, 503, `OpenCode event stream unavailable: ${error.message}`)
+      } else {
+        res.end()
+      }
+    })
+    upstreamReq.end()
+
+    req.on('close', () => {
+      cleanup()
+    })
+  }
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to bind claude-code router port')
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`
+  logger.log(`[CLAUDE ROUTER] listening on ${baseUrl}`)
+
+  return {
+    baseUrl,
+    manager,
+    close: async () => {
+      await manager.disposeAll()
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve()
+        })
+      })
+    },
+  }
+}

--- a/cli/src/claude-code/sessions.ts
+++ b/cli/src/claude-code/sessions.ts
@@ -1,0 +1,1970 @@
+// Claude Code session manager: one live Agent SDK query per active session,
+// translated onto OpenCode's wire protocol.
+//
+// Each ClaudeCodeSession owns:
+//  - the OpenCode Session wire object (what session.get returns)
+//  - the message/part store (what session.messages returns)
+//  - an optional live query() in streaming-input mode (the running agent)
+//  - pending permission/question bridges for Discord button round-trips
+//
+// The manager keeps the registry, persists session metadata to disk so
+// threads survive bot restarts (transcripts themselves are persisted by
+// Claude Code under ~/.claude), and fans out OpenCode events to the router's
+// SSE subscribers.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  query as sdkQuery,
+  getSessionInfo,
+  getSessionMessages,
+  AbortError,
+  type Options,
+  type Query,
+  type SDKMessage,
+  type SDKUserMessage,
+  type SDKResultMessage,
+  type SDKAssistantMessage,
+  type PermissionResult,
+  type SlashCommand,
+} from '@anthropic-ai/claude-agent-sdk'
+import type {
+  Event as OpenCodeEvent,
+  Message,
+  Part,
+  PermissionRuleset,
+  QuestionAnswer,
+  QuestionInfo,
+  Session,
+  SessionStatus,
+  TextPartInput,
+  FilePartInput,
+  TextPart,
+  ToolPart,
+  ReasoningPart,
+  StepFinishPart,
+  SnapshotFileDiff,
+  AssistantMessage,
+} from '@opencode-ai/sdk/v2'
+import { createLogger, LogPrefix } from '../logger.js'
+import { getDataDir } from '../config.js'
+import { execAsync } from '../exec-async.js'
+import {
+  createClaudeEventId,
+  createClaudeMessageId,
+  createClaudePartId,
+  createClaudePermissionId,
+  createClaudeQuestionId,
+  createClaudeSessionId,
+} from './ids.js'
+import { buildAlwaysRules, describeToolPermission, evaluatePermission } from './permission-map.js'
+import {
+  asRecord,
+  buildAssistantInfo,
+  buildQuestionAnswersInput,
+  buildUserContent,
+  extractToolResults,
+  mapAskUserQuestions,
+  normalizeToolName,
+  translateAssistantBlock,
+  translateTranscriptMessages,
+  type AssistantContentBlock,
+} from './translate.js'
+import { CLAUDE_CODE_PROVIDER_ID, DEFAULT_CLAUDE_MODEL_ID, updateLiveModels } from './models.js'
+import { createKimakiMcpServer } from './kimaki-mcp.js'
+
+const logger = createLogger(LogPrefix.SESSION)
+
+const PART_FLUSH_INTERVAL_MS = 400
+
+// Idle sessions release their Claude Code subprocess after this long; the
+// next prompt resumes seamlessly from the persisted transcript (~/.claude).
+const IDLE_SUBPROCESS_REAP_MS = 10 * 60 * 1000
+
+export type ClaudeEventSink = (directory: string, event: OpenCodeEvent) => void
+
+export type QueryImpl = typeof sdkQuery
+
+export type PromptRequest = {
+  parts: Array<TextPartInput | FilePartInput>
+  model?: { providerID: string; modelID: string }
+  agent?: string
+  variant?: string
+  system?: string
+  noReply?: boolean
+}
+
+type PushQueue<T> = {
+  iterable: AsyncIterable<T>
+  push: (value: T) => void
+  end: () => void
+}
+
+function createPushQueue<T>(): PushQueue<T> {
+  const values: T[] = []
+  let notify: (() => void) | null = null
+  let ended = false
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<T>> {
+          while (true) {
+            const value = values.shift()
+            if (value !== undefined) {
+              return { value, done: false }
+            }
+            if (ended) {
+              return { value: undefined, done: true }
+            }
+            await new Promise<void>((resolve) => {
+              notify = resolve
+            })
+          }
+        },
+      }
+    },
+  }
+  return {
+    iterable,
+    push(value: T) {
+      values.push(value)
+      notify?.()
+      notify = null
+    },
+    end() {
+      ended = true
+      notify?.()
+      notify = null
+    },
+  }
+}
+
+type LiveConfig = {
+  model?: string
+  variant?: string
+  agent?: string
+  system?: string
+}
+
+type LiveQueryHandle = {
+  query: Query
+  input: PushQueue<SDKUserMessage>
+  config: LiveConfig
+  abortController: AbortController
+  done: Promise<void>
+  stderrTail: string[]
+}
+
+type PendingPermission = {
+  sessionId: string
+  resolve: (result: PermissionResult) => void
+  input: Record<string, unknown>
+  permission: string
+  always: string[]
+}
+
+type PendingQuestion = {
+  sessionId: string
+  resolve: (result: PermissionResult) => void
+  questions: QuestionInfo[]
+  originalInput: Record<string, unknown>
+}
+
+type PersistedSessionState = {
+  id: string
+  directory: string
+  sdkSessionId?: string
+  title: string
+  permission: PermissionRuleset
+  parentID?: string
+  agent?: string
+  timeCreated: number
+}
+
+type StreamingPartState = {
+  part: TextPart | ReasoningPart | ToolPart
+  rawInput?: string
+  flushTimer?: ReturnType<typeof setTimeout>
+  dirty: boolean
+}
+
+function persistenceDir(): string {
+  return path.join(getDataDir(), 'claude-code', 'sessions')
+}
+
+function persistenceFile(sessionId: string): string {
+  return path.join(persistenceDir(), `${sessionId}.json`)
+}
+
+export class ClaudeCodeSession {
+  readonly id: string
+  readonly directory: string
+  session: Session
+  private readonly manager: ClaudeCodeSessionManager
+  private messageOrder: string[] = []
+  private messages = new Map<string, { info: Message; parts: Map<string, Part> }>()
+  private status: SessionStatus = { type: 'idle' }
+  private live: LiveQueryHandle | null = null
+  private sdkSessionId: string | undefined
+  private pendingFork: { resumeSessionAt?: string } | null = null
+  private uuidByMessageId = new Map<string, string>()
+  private toolPartsByCallId = new Map<string, ToolPart>()
+  private streamingParts = new Map<string, StreamingPartState>()
+  private currentAssistantMessageId: string | null = null
+  private lastUserMessageId = ''
+  private currentModelId = DEFAULT_CLAUDE_MODEL_ID
+  private abortRequested = false
+  private lastAssistantError: SDKAssistantMessage['error'] | undefined
+  private seenSdkUuids = new Set<string>()
+  private hydrated = false
+  private disposed = false
+
+  constructor({
+    manager,
+    id,
+    directory,
+    permission,
+    title,
+    parentID,
+    sdkSessionId,
+    timeCreated,
+    agent,
+  }: {
+    manager: ClaudeCodeSessionManager
+    id: string
+    directory: string
+    permission: PermissionRuleset
+    title?: string
+    parentID?: string
+    sdkSessionId?: string
+    timeCreated?: number
+    agent?: string
+  }) {
+    this.manager = manager
+    this.id = id
+    this.directory = directory
+    this.sdkSessionId = sdkSessionId
+    const created = timeCreated ?? Date.now()
+    this.session = {
+      id,
+      slug: id,
+      projectID: CLAUDE_CODE_PROVIDER_ID,
+      directory,
+      title: title || 'New Claude Code session',
+      version: '',
+      time: { created, updated: created },
+      permission,
+      ...(parentID ? { parentID } : {}),
+      ...(agent ? { agent } : {}),
+    }
+  }
+
+  // ── Wire accessors ────────────────────────────────────────────
+
+  toWire(): Session {
+    return this.session
+  }
+
+  getStatus(): SessionStatus {
+    return this.status
+  }
+
+  async messagesWire(): Promise<Array<{ info: Message; parts: Part[] }>> {
+    await this.hydrateFromTranscript()
+    return this.messageOrder.flatMap((messageId) => {
+      const entry = this.messages.get(messageId)
+      if (!entry) {
+        return []
+      }
+      return [{ info: entry.info, parts: [...entry.parts.values()] }]
+    })
+  }
+
+  /**
+   * After a bot restart the in-memory store is empty but the Claude Code
+   * transcript persists under ~/.claude. Rebuild the wire messages once on
+   * first access so /resume and session.messages keep working.
+   */
+  private async hydrateFromTranscript(): Promise<void> {
+    if (this.hydrated || this.messages.size > 0 || !this.sdkSessionId) {
+      this.hydrated = true
+      return
+    }
+    this.hydrated = true
+    const transcript = await getSessionMessages(this.sdkSessionId, {
+      dir: this.directory,
+    }).catch((error) => {
+      logger.warn(
+        `[CLAUDE] Failed to hydrate transcript for ${this.id}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      return []
+    })
+    if (transcript.length === 0) {
+      return
+    }
+    const { messages, uuidByMessageId } = translateTranscriptMessages({
+      transcript,
+      sessionId: this.id,
+      directory: this.directory,
+      agent: this.session.agent ?? 'claude',
+    })
+    for (const entry of messages) {
+      const parts = new Map<string, Part>()
+      for (const part of entry.parts) {
+        parts.set(part.id, part)
+        if (part.type === 'tool') {
+          this.toolPartsByCallId.set(part.callID, part)
+        }
+      }
+      this.messages.set(entry.info.id, { info: entry.info, parts })
+      this.messageOrder.push(entry.info.id)
+      if (entry.info.role === 'user') {
+        this.lastUserMessageId = entry.info.id
+      }
+    }
+    for (const [messageId, uuid] of uuidByMessageId) {
+      this.uuidByMessageId.set(messageId, uuid)
+    }
+  }
+
+  // ── Event helpers ─────────────────────────────────────────────
+
+  private emit(event: OpenCodeEvent): void {
+    this.manager.emitEvent(this.directory, event)
+  }
+
+  private emitSessionUpdated(): void {
+    this.session.time.updated = Date.now()
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'session.updated',
+      properties: { sessionID: this.id, info: this.session },
+    })
+  }
+
+  private idleReapTimer: ReturnType<typeof setTimeout> | undefined
+
+  private setStatus(status: SessionStatus): void {
+    this.status = status
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'session.status',
+      properties: { sessionID: this.id, status },
+    })
+    if (this.idleReapTimer) {
+      clearTimeout(this.idleReapTimer)
+      this.idleReapTimer = undefined
+    }
+    if (status.type === 'idle') {
+      this.emit({
+        id: createClaudeEventId(),
+        type: 'session.idle',
+        properties: { sessionID: this.id },
+      })
+      this.idleReapTimer = setTimeout(() => {
+        this.idleReapTimer = undefined
+        if (this.status.type !== 'idle' || !this.live) {
+          return
+        }
+        logger.log(`[CLAUDE] Releasing idle subprocess for session ${this.id}`)
+        void this.closeLive()
+      }, IDLE_SUBPROCESS_REAP_MS)
+      this.idleReapTimer.unref?.()
+    }
+  }
+
+  private emitMessageUpdated(info: Message): void {
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'message.updated',
+      properties: { sessionID: this.id, info },
+    })
+  }
+
+  private emitPartUpdated(part: Part): void {
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'message.part.updated',
+      properties: { sessionID: this.id, part, time: Date.now() },
+    })
+  }
+
+  private storeMessage(info: Message): void {
+    if (!this.messages.has(info.id)) {
+      this.messages.set(info.id, { info, parts: new Map() })
+      this.messageOrder.push(info.id)
+    } else {
+      const existing = this.messages.get(info.id)!
+      existing.info = info
+    }
+  }
+
+  private storePart(part: Part): void {
+    const entry = this.messages.get(part.messageID)
+    if (entry) {
+      entry.parts.set(part.id, part)
+    }
+    if (part.type === 'tool') {
+      this.toolPartsByCallId.set(part.callID, part)
+    }
+  }
+
+  // ── Prompting ─────────────────────────────────────────────────
+
+  async prompt(request: PromptRequest): Promise<void> {
+    if (this.disposed) {
+      throw new Error(`Session ${this.id} has been deleted`)
+    }
+    const hasContent = request.parts.some((part) => {
+      return part.type === 'file' || part.text.trim().length > 0
+    })
+    if (!hasContent) {
+      // OpenCode uses empty prompts to nudge a blocked loop; the Claude
+      // backend resumes automatically after permission replies, so this is
+      // a no-op.
+      return
+    }
+    await this.hydrateFromTranscript()
+
+    const modelId =
+      request.model && request.model.providerID === CLAUDE_CODE_PROVIDER_ID
+        ? request.model.modelID
+        : undefined
+    if (modelId) {
+      this.currentModelId = modelId
+    }
+
+    // Kimaki channel/session agent preferences name opencode agents (build,
+    // plan, custom .md agents). Only pass an agent through when Claude Code
+    // reported it during init; unknown names would fail the whole query.
+    const knownAgents = this.manager.getAgents(this.directory)
+    const validatedAgent =
+      request.agent && knownAgents.includes(request.agent) ? request.agent : undefined
+    if (request.agent && !validatedAgent) {
+      logger.log(
+        `[CLAUDE] Ignoring agent "${request.agent}" — not a Claude Code agent in ${this.directory}`,
+      )
+    }
+
+    const desired: LiveConfig = {
+      model: this.currentModelId,
+      variant: request.variant,
+      agent: validatedAgent,
+      system: request.system,
+    }
+
+    const live = await this.ensureLive(desired)
+
+    // Record the user message in the wire store (visible prompt parts only).
+    const userMessageId = createClaudeMessageId()
+    this.lastUserMessageId = userMessageId
+    const userInfo: Message = {
+      id: userMessageId,
+      sessionID: this.id,
+      role: 'user',
+      time: { created: Date.now() },
+      agent: validatedAgent ?? this.session.agent ?? 'claude',
+      model: {
+        providerID: CLAUDE_CODE_PROVIDER_ID,
+        modelID: this.currentModelId,
+        ...(request.variant ? { variant: request.variant } : {}),
+      },
+    }
+    this.storeMessage(userInfo)
+    for (const part of request.parts) {
+      if (part.type === 'text' && part.text.trim().length === 0) {
+        continue
+      }
+      const wirePart: Part =
+        part.type === 'text'
+          ? {
+              id: createClaudePartId(),
+              sessionID: this.id,
+              messageID: userMessageId,
+              type: 'text',
+              text: part.text,
+              ...(part.synthetic ? { synthetic: true } : {}),
+              time: { start: Date.now(), end: Date.now() },
+            }
+          : {
+              id: createClaudePartId(),
+              sessionID: this.id,
+              messageID: userMessageId,
+              type: 'file',
+              mime: part.mime,
+              url: part.url,
+              ...(part.filename ? { filename: part.filename } : {}),
+            }
+      this.storePart(wirePart)
+    }
+    this.emitMessageUpdated(userInfo)
+    const userParts = this.messages.get(userMessageId)
+    if (userParts) {
+      for (const part of userParts.parts.values()) {
+        this.emitPartUpdated(part)
+      }
+    }
+
+    const content = buildUserContent({ parts: request.parts })
+    if (content.length === 0) {
+      return
+    }
+    const shouldQuery = request.noReply !== true
+    live.input.push({
+      type: 'user',
+      message: { role: 'user', content },
+      parent_tool_use_id: null,
+      ...(shouldQuery ? {} : { shouldQuery: false }),
+    })
+
+    if (shouldQuery) {
+      this.abortRequested = false
+      this.setStatus({ type: 'busy' })
+    }
+  }
+
+  /** Push a raw text command (e.g. "/compact") without a visible wire message. */
+  async pushHiddenCommand(command: string): Promise<void> {
+    const live = await this.ensureLive({
+      model: this.currentModelId,
+    })
+    live.input.push({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: command }] },
+      parent_tool_use_id: null,
+    })
+    this.abortRequested = false
+    this.setStatus({ type: 'busy' })
+  }
+
+  private async ensureLive(desired: LiveConfig): Promise<LiveQueryHandle> {
+    const existing = this.live
+    if (existing) {
+      const needsRestart =
+        (desired.agent !== undefined && desired.agent !== existing.config.agent) ||
+        (desired.variant !== undefined && desired.variant !== existing.config.variant) ||
+        (desired.system !== undefined && desired.system !== existing.config.system)
+      if (!needsRestart) {
+        if (desired.model && desired.model !== existing.config.model) {
+          existing.config.model = desired.model
+          await existing.query.setModel(desired.model).catch((error) => {
+            logger.warn(
+              `[CLAUDE] setModel(${desired.model}) failed: ${error instanceof Error ? error.message : String(error)}`,
+            )
+          })
+        }
+        return existing
+      }
+      if (this.status.type === 'busy') {
+        // Config changes can't be applied mid-turn; keep the current query.
+        logger.log(`[CLAUDE] Deferring agent/variant/system change for busy session ${this.id}`)
+        return existing
+      }
+      await this.closeLive()
+    }
+    return this.startLive(desired)
+  }
+
+  private async closeLive(): Promise<void> {
+    const live = this.live
+    if (!live) {
+      return
+    }
+    this.live = null
+    live.input.end()
+    const closeResult = await Promise.race([
+      live.done.then(() => {
+        return 'done' as const
+      }),
+      new Promise<'timeout'>((resolve) => {
+        setTimeout(() => {
+          resolve('timeout')
+        }, 3000).unref()
+      }),
+    ]).catch(() => {
+      return 'error' as const
+    })
+    if (closeResult !== 'done') {
+      live.abortController.abort()
+    }
+  }
+
+  private startLive(desired: LiveConfig): LiveQueryHandle {
+    const input = createPushQueue<SDKUserMessage>()
+    const abortController = new AbortController()
+    const stderrTail: string[] = []
+
+    const options: Options = {
+      cwd: this.directory,
+      model: desired.model ?? this.currentModelId,
+      permissionMode: 'default',
+      includePartialMessages: true,
+      enableFileCheckpointing: true,
+      settingSources: ['user', 'project', 'local'],
+      systemPrompt: {
+        type: 'preset',
+        preset: 'claude_code',
+        ...(desired.system ? { append: desired.system } : {}),
+      },
+      mcpServers: {
+        kimaki: createKimakiMcpServer({
+          sessionId: this.id,
+          directory: this.directory,
+        }),
+      },
+      abortController,
+      stderr: (data: string) => {
+        stderrTail.push(data)
+        if (stderrTail.length > 20) {
+          stderrTail.shift()
+        }
+      },
+      canUseTool: async (toolName, toolInput, callOptions) => {
+        return this.handleCanUseTool({
+          toolName,
+          input: toolInput,
+          signal: callOptions.signal,
+          toolUseID: callOptions.toolUseID,
+          blockedPath: callOptions.blockedPath,
+        })
+      },
+      ...(desired.agent ? { agent: desired.agent } : {}),
+      ...(desired.variant && isEffortLevel(desired.variant) ? { effort: desired.variant } : {}),
+      ...(this.sdkSessionId ? { resume: this.sdkSessionId } : {}),
+      ...(this.pendingFork
+        ? {
+            forkSession: true,
+            ...(this.pendingFork.resumeSessionAt
+              ? { resumeSessionAt: this.pendingFork.resumeSessionAt }
+              : {}),
+          }
+        : {}),
+    }
+    this.pendingFork = null
+
+    const q = this.manager.queryImpl({ prompt: input.iterable, options })
+    const handle: LiveQueryHandle = {
+      query: q,
+      input,
+      config: { ...desired, model: options.model },
+      abortController,
+      done: Promise.resolve(),
+      stderrTail,
+    }
+    handle.done = this.pumpQuery(handle)
+    this.live = handle
+    return handle
+  }
+
+  private async pumpQuery(handle: LiveQueryHandle): Promise<void> {
+    const pumpResult = await (async () => {
+      for await (const message of handle.query) {
+        this.handleSdkMessage(message)
+      }
+    })().catch((error: unknown) => {
+      return error
+    })
+
+    const wasCurrent = this.live === handle
+    if (wasCurrent) {
+      this.live = null
+    }
+
+    if (pumpResult instanceof Error && !(pumpResult instanceof AbortError)) {
+      logger.error(
+        `[CLAUDE] Query pump failed for ${this.id}: ${pumpResult.message}\n${handle.stderrTail.join('')}`,
+      )
+      if (wasCurrent && !this.disposed) {
+        this.emit({
+          id: createClaudeEventId(),
+          type: 'session.error',
+          properties: {
+            sessionID: this.id,
+            error: {
+              name: 'UnknownError',
+              data: {
+                message: buildQueryErrorMessage({
+                  error: pumpResult,
+                  stderrTail: handle.stderrTail,
+                }),
+              },
+            },
+          },
+        })
+      }
+    }
+    if (wasCurrent && this.status.type === 'busy' && !this.disposed) {
+      this.finalizeOpenAssistantMessage({ aborted: true })
+      this.setStatus({ type: 'idle' })
+    }
+  }
+
+  // ── SDK message handling ──────────────────────────────────────
+
+  private handleSdkMessage(message: SDKMessage): void {
+    if (message.type === 'system' && message.subtype === 'init') {
+      this.sdkSessionId = message.session_id
+      this.currentModelId = message.model
+      this.manager.recordRuntimeInfo({
+        directory: this.directory,
+        slashCommands: message.slash_commands,
+        agents: message.agents ?? [],
+      })
+      this.manager.persistSession(this)
+      void this.refreshModelCatalog()
+      return
+    }
+    if (message.type === 'stream_event') {
+      if (message.parent_tool_use_id) {
+        return
+      }
+      this.handleStreamEvent(message.event)
+      return
+    }
+    if (message.type === 'assistant') {
+      if (message.parent_tool_use_id) {
+        return
+      }
+      this.reconcileAssistantMessage(message)
+      return
+    }
+    if (message.type === 'user') {
+      const uuid = typeof message.uuid === 'string' ? message.uuid : undefined
+      if (uuid) {
+        if (this.seenSdkUuids.has(uuid)) {
+          return
+        }
+        this.seenSdkUuids.add(uuid)
+      }
+      if (message.parent_tool_use_id) {
+        return
+      }
+      for (const result of extractToolResults(message.message)) {
+        this.applyToolResult(result)
+      }
+      return
+    }
+    if (message.type === 'result') {
+      this.handleResult(message)
+      return
+    }
+    if (message.type === 'system' && message.subtype === 'compact_boundary') {
+      this.handleCompactBoundary(message.compact_metadata.trigger === 'auto')
+      return
+    }
+    if (message.type === 'system' && message.subtype === 'session_state_changed') {
+      // Safety net: authoritative idle signal in case a result was missed.
+      if (message.state === 'idle' && this.status.type === 'busy') {
+        this.setStatus({ type: 'idle' })
+      }
+      return
+    }
+  }
+
+  private async refreshModelCatalog(): Promise<void> {
+    const live = this.live
+    if (!live || this.manager.modelCatalogLoaded) {
+      return
+    }
+    const models = await live.query.supportedModels().catch((error) => {
+      logger.warn(
+        `[CLAUDE] supportedModels failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      return []
+    })
+    if (models.length > 0) {
+      // Latch only on success so a failed first attempt retries on the next
+      // session init; the static catalog covers the gap.
+      this.manager.modelCatalogLoaded = true
+    }
+    updateLiveModels(models)
+    const commands = await live.query.supportedCommands().catch(() => {
+      return [] as SlashCommand[]
+    })
+    if (commands.length > 0) {
+      this.manager.recordSlashCommandDetails(this.directory, commands)
+    }
+  }
+
+  private ensureAssistantMessage(): { info: AssistantMessage; parts: Map<string, Part> } {
+    // A queued follow-up message starts a new SDK turn without going through
+    // prompt(); mark the session busy as soon as assistant activity appears.
+    if (this.status.type !== 'busy') {
+      this.setStatus({ type: 'busy' })
+    }
+    if (this.currentAssistantMessageId) {
+      const existing = this.messages.get(this.currentAssistantMessageId)
+      if (existing && existing.info.role === 'assistant') {
+        return existing as { info: AssistantMessage; parts: Map<string, Part> }
+      }
+    }
+    const messageId = createClaudeMessageId()
+    this.currentAssistantMessageId = messageId
+    const info = buildAssistantInfo({
+      sessionId: this.id,
+      messageId,
+      parentUserMessageId: this.lastUserMessageId,
+      modelId: this.currentModelId,
+      directory: this.directory,
+      agent: this.session.agent ?? 'claude',
+      created: Date.now(),
+    })
+    this.storeMessage(info)
+    this.emitMessageUpdated(info)
+    return this.messages.get(messageId) as {
+      info: AssistantMessage
+      parts: Map<string, Part>
+    }
+  }
+
+  // Streaming events keyed by content block index within the current message.
+  private streamKey(index: number): string {
+    return `${this.currentAssistantMessageId ?? 'none'}:${index}`
+  }
+
+  private handleStreamEvent(event: Record<string, unknown> | { type: string }): void {
+    const rec = asRecord(event)
+    const type = rec.type
+    if (type === 'message_start') {
+      this.ensureAssistantMessage()
+      return
+    }
+    if (type === 'content_block_start') {
+      const index = typeof rec.index === 'number' ? rec.index : 0
+      const contentBlock = asRecord(rec.content_block)
+      const entry = this.ensureAssistantMessage()
+      const now = Date.now()
+      if (contentBlock.type === 'text') {
+        const part: TextPart = {
+          id: createClaudePartId(),
+          sessionID: this.id,
+          messageID: entry.info.id,
+          type: 'text',
+          text: '',
+          time: { start: now },
+        }
+        this.streamingParts.set(this.streamKey(index), { part, dirty: false })
+        this.storePart(part)
+        return
+      }
+      if (contentBlock.type === 'thinking' || contentBlock.type === 'redacted_thinking') {
+        const part: ReasoningPart = {
+          id: createClaudePartId(),
+          sessionID: this.id,
+          messageID: entry.info.id,
+          type: 'reasoning',
+          text: '',
+          time: { start: now },
+        }
+        this.streamingParts.set(this.streamKey(index), { part, dirty: false })
+        this.storePart(part)
+        return
+      }
+      if (contentBlock.type === 'tool_use') {
+        const part: ToolPart = {
+          id: createClaudePartId(),
+          sessionID: this.id,
+          messageID: entry.info.id,
+          type: 'tool',
+          callID: typeof contentBlock.id === 'string' ? contentBlock.id : createClaudePartId(),
+          tool: normalizeToolName(
+            typeof contentBlock.name === 'string' ? contentBlock.name : 'tool',
+          ),
+          state: { status: 'pending', input: {}, raw: '' },
+        }
+        this.streamingParts.set(this.streamKey(index), {
+          part,
+          rawInput: '',
+          dirty: false,
+        })
+        this.storePart(part)
+        this.emitPartUpdated(part)
+        return
+      }
+      return
+    }
+    if (type === 'content_block_delta') {
+      const index = typeof rec.index === 'number' ? rec.index : 0
+      const state = this.streamingParts.get(this.streamKey(index))
+      if (!state) {
+        return
+      }
+      const delta = asRecord(rec.delta)
+      if (delta.type === 'text_delta' && state.part.type === 'text') {
+        state.part.text += typeof delta.text === 'string' ? delta.text : ''
+        this.schedulePartFlush(state)
+        return
+      }
+      if (delta.type === 'thinking_delta' && state.part.type === 'reasoning') {
+        state.part.text += typeof delta.thinking === 'string' ? delta.thinking : ''
+        this.schedulePartFlush(state)
+        return
+      }
+      if (delta.type === 'input_json_delta' && state.part.type === 'tool') {
+        state.rawInput =
+          (state.rawInput ?? '') +
+          (typeof delta.partial_json === 'string' ? delta.partial_json : '')
+        return
+      }
+      return
+    }
+    if (type === 'content_block_stop') {
+      const index = typeof rec.index === 'number' ? rec.index : 0
+      const key = this.streamKey(index)
+      const state = this.streamingParts.get(key)
+      if (!state) {
+        return
+      }
+      this.streamingParts.delete(key)
+      if (state.flushTimer) {
+        clearTimeout(state.flushTimer)
+      }
+      const now = Date.now()
+      if (state.part.type === 'text' || state.part.type === 'reasoning') {
+        state.part.time = { start: state.part.time?.start ?? now, end: now }
+        this.storePart(state.part)
+        this.emitPartUpdated(state.part)
+        return
+      }
+      if (state.part.type === 'tool') {
+        const input = (() => {
+          if (!state.rawInput) {
+            return {}
+          }
+          const parsed = (() => {
+            const tryParse = () => JSON.parse(state.rawInput!) as unknown
+            return errToNull(tryParse)
+          })()
+          return asRecord(parsed)
+        })()
+        state.part.state = {
+          status: 'running',
+          input,
+          title: state.part.tool,
+          time: { start: now },
+        }
+        this.storePart(state.part)
+        this.emitPartUpdated(state.part)
+      }
+      return
+    }
+  }
+
+  private schedulePartFlush(state: StreamingPartState): void {
+    state.dirty = true
+    if (state.flushTimer) {
+      return
+    }
+    state.flushTimer = setTimeout(() => {
+      state.flushTimer = undefined
+      if (!state.dirty) {
+        return
+      }
+      state.dirty = false
+      this.storePart(state.part)
+      this.emitPartUpdated(state.part)
+    }, PART_FLUSH_INTERVAL_MS)
+    state.flushTimer.unref?.()
+  }
+
+  /**
+   * The complete assistant SDK message is authoritative: reconcile parts so
+   * missed stream deltas (or disabled partial streaming) still produce the
+   * full content.
+   */
+  private reconcileAssistantMessage(message: SDKAssistantMessage): void {
+    this.lastAssistantError = message.error
+    const entry = this.ensureAssistantMessage()
+    this.uuidByMessageId.set(entry.info.id, message.uuid)
+    const model = message.message.model
+    if (typeof model === 'string' && model.length > 0) {
+      this.currentModelId = model
+      entry.info.modelID = model
+    }
+
+    const existingParts = [...entry.parts.values()]
+    const now = Date.now()
+    for (const block of message.message.content) {
+      if (block.type === 'text' || block.type === 'thinking') {
+        const partType = block.type === 'text' ? 'text' : 'reasoning'
+        const text = block.type === 'text' ? block.text : block.thinking
+        const match = existingParts.find((part) => {
+          return (
+            part.type === partType &&
+            (part as TextPart | ReasoningPart).text.length > 0 &&
+            text.startsWith((part as TextPart | ReasoningPart).text.slice(0, 64))
+          )
+        })
+        if (match && (match.type === 'text' || match.type === 'reasoning')) {
+          if (match.text !== text) {
+            match.text = text
+            match.time = { start: match.time?.start ?? now, end: now }
+            this.storePart(match)
+            this.emitPartUpdated(match)
+          }
+          continue
+        }
+        if (text.trim().length === 0) {
+          continue
+        }
+        const part = translateAssistantBlock({
+          block,
+          sessionId: this.id,
+          messageId: entry.info.id,
+          now,
+        })
+        if (part) {
+          this.storePart(part)
+          this.emitPartUpdated(part)
+        }
+        continue
+      }
+      if (block.type === 'tool_use') {
+        const existing = this.toolPartsByCallId.get(block.id)
+        if (existing) {
+          if (existing.state.status === 'pending') {
+            existing.state = {
+              status: 'running',
+              input: asRecord(block.input),
+              title: existing.tool,
+              time: { start: now },
+            }
+            this.storePart(existing)
+            this.emitPartUpdated(existing)
+          }
+          continue
+        }
+        const part = translateAssistantBlock({
+          block: block as AssistantContentBlock,
+          sessionId: this.id,
+          messageId: entry.info.id,
+          now,
+        })
+        if (part) {
+          this.storePart(part)
+          this.emitPartUpdated(part)
+        }
+      }
+    }
+    this.emitMessageUpdated(entry.info)
+  }
+
+  private applyToolResult(result: { toolUseId: string; output: string; isError: boolean }): void {
+    const part = this.toolPartsByCallId.get(result.toolUseId)
+    if (!part) {
+      return
+    }
+    const now = Date.now()
+    const startTime = (() => {
+      if (part.state.status === 'running') {
+        return part.state.time.start
+      }
+      return now
+    })()
+    const input = part.state.input
+    if (result.isError) {
+      part.state = {
+        status: 'error',
+        input,
+        error: result.output,
+        time: { start: startTime, end: now },
+      }
+    } else {
+      part.state = {
+        status: 'completed',
+        input,
+        output: result.output,
+        title: part.tool,
+        metadata: {},
+        time: { start: startTime, end: now },
+      }
+    }
+    this.storePart(part)
+    this.emitPartUpdated(part)
+  }
+
+  private handleResult(message: SDKResultMessage): void {
+    const entry = this.currentAssistantMessageId
+      ? this.messages.get(this.currentAssistantMessageId)
+      : undefined
+
+    if (entry && entry.info.role === 'assistant') {
+      const info = entry.info
+      info.time.completed = Date.now()
+      info.cost = message.total_cost_usd
+      info.tokens = {
+        input: message.usage.input_tokens,
+        output: message.usage.output_tokens,
+        reasoning: 0,
+        cache: {
+          read: message.usage.cache_read_input_tokens ?? 0,
+          write: message.usage.cache_creation_input_tokens ?? 0,
+        },
+      }
+      if (message.subtype === 'success') {
+        info.finish = 'stop'
+      } else {
+        info.finish = 'error'
+        info.error = this.buildResultError(message)
+      }
+      // Step-finish part carries cost/tokens for kimaki's footers.
+      const stepFinish: StepFinishPart = {
+        id: createClaudePartId(),
+        sessionID: this.id,
+        messageID: info.id,
+        type: 'step-finish',
+        reason: info.finish,
+        cost: info.cost,
+        tokens: info.tokens,
+      }
+      this.storePart(stepFinish)
+      this.emitPartUpdated(stepFinish)
+      this.emitMessageUpdated(info)
+    }
+
+    this.currentAssistantMessageId = null
+    this.clearStreamingParts()
+    this.setStatus({ type: 'idle' })
+    this.manager.persistSession(this)
+    void this.emitSessionDiff()
+    void this.refreshTitle()
+  }
+
+  private buildResultError(message: SDKResultMessage): AssistantMessage['error'] {
+    const errors =
+      'errors' in message && Array.isArray(message.errors)
+        ? message.errors.filter((value): value is string => {
+            return typeof value === 'string'
+          })
+        : []
+    const detail = errors.join('; ')
+    if (this.abortRequested) {
+      return {
+        name: 'MessageAbortedError',
+        data: { message: 'Request was aborted' },
+      }
+    }
+    if (
+      this.lastAssistantError === 'authentication_failed' ||
+      this.lastAssistantError === 'oauth_org_not_allowed'
+    ) {
+      return {
+        name: 'ProviderAuthError',
+        data: {
+          providerID: CLAUDE_CODE_PROVIDER_ID,
+          message:
+            detail ||
+            'Claude Code authentication failed. Run `claude` in a terminal to log in, or set ANTHROPIC_API_KEY.',
+        },
+      }
+    }
+    return {
+      name: 'UnknownError',
+      data: {
+        message: detail || `Claude Code run failed (${message.subtype})`,
+      },
+    }
+  }
+
+  private finalizeOpenAssistantMessage({ aborted }: { aborted: boolean }): void {
+    const entry = this.currentAssistantMessageId
+      ? this.messages.get(this.currentAssistantMessageId)
+      : undefined
+    this.currentAssistantMessageId = null
+    this.clearStreamingParts()
+    if (!entry || entry.info.role !== 'assistant') {
+      return
+    }
+    const info = entry.info
+    if (typeof info.time.completed === 'number') {
+      return
+    }
+    info.time.completed = Date.now()
+    if (aborted) {
+      info.error = {
+        name: 'MessageAbortedError',
+        data: { message: 'Request was aborted' },
+      }
+    }
+    this.emitMessageUpdated(info)
+  }
+
+  private clearStreamingParts(): void {
+    for (const state of this.streamingParts.values()) {
+      if (state.flushTimer) {
+        clearTimeout(state.flushTimer)
+      }
+      if (state.dirty) {
+        this.storePart(state.part)
+        this.emitPartUpdated(state.part)
+      }
+    }
+    this.streamingParts.clear()
+  }
+
+  private handleCompactBoundary(auto: boolean): void {
+    const entry = this.ensureAssistantMessage()
+    const part: Part = {
+      id: createClaudePartId(),
+      sessionID: this.id,
+      messageID: entry.info.id,
+      type: 'compaction',
+      auto,
+    }
+    this.storePart(part)
+    this.emitPartUpdated(part)
+  }
+
+  private async emitSessionDiff(): Promise<void> {
+    const diff = await computeGitDiffSummary(this.directory)
+    if (!diff) {
+      return
+    }
+    this.session.summary = {
+      additions: diff.additions,
+      deletions: diff.deletions,
+      files: diff.files.length,
+      diffs: diff.files,
+    }
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'session.diff',
+      properties: { sessionID: this.id, diff: diff.files },
+    })
+    this.emitSessionUpdated()
+  }
+
+  /** Adopt the SDK's auto-generated summary as the session title. */
+  private async refreshTitle(): Promise<void> {
+    if (!this.sdkSessionId) {
+      return
+    }
+    const info = await getSessionInfo(this.sdkSessionId, {
+      dir: this.directory,
+    }).catch(() => {
+      return undefined
+    })
+    if (!info) {
+      return
+    }
+    const title = info.customTitle || info.summary || info.firstPrompt
+    if (title && title !== this.session.title) {
+      this.session.title = title.slice(0, 200)
+      this.manager.persistSession(this)
+      this.emitSessionUpdated()
+    }
+  }
+
+  // ── Permissions & questions ───────────────────────────────────
+
+  private handleCanUseTool({
+    toolName,
+    input,
+    signal,
+    toolUseID,
+    blockedPath,
+  }: {
+    toolName: string
+    input: Record<string, unknown>
+    signal: AbortSignal
+    toolUseID: string
+    blockedPath?: string
+  }): Promise<PermissionResult> {
+    if (toolName === 'AskUserQuestion') {
+      return this.handleAskUserQuestion({ input, signal, toolUseID })
+    }
+    const descriptor = describeToolPermission({
+      toolName,
+      input,
+      directory: this.directory,
+      blockedPath,
+    })
+    if (!descriptor) {
+      return Promise.resolve({ behavior: 'allow', updatedInput: input })
+    }
+    const rules = this.session.permission ?? []
+    const action = evaluatePermission({
+      rules,
+      permission: descriptor.permission,
+      patterns: descriptor.patterns,
+    })
+    if (action === 'allow') {
+      return Promise.resolve({ behavior: 'allow', updatedInput: input })
+    }
+    if (action === 'deny') {
+      return Promise.resolve({
+        behavior: 'deny',
+        message: `Denied by kimaki permission rules (${descriptor.permission}: ${descriptor.patterns.join(', ')})`,
+      })
+    }
+
+    const requestId = createClaudePermissionId()
+    return new Promise<PermissionResult>((resolve) => {
+      const pending: PendingPermission = {
+        sessionId: this.id,
+        resolve: (result) => {
+          this.manager.pendingPermissions.delete(requestId)
+          resolve(result)
+        },
+        input,
+        permission: descriptor.permission,
+        always: descriptor.always,
+      }
+      this.manager.pendingPermissions.set(requestId, pending)
+      signal.addEventListener('abort', () => {
+        if (this.manager.pendingPermissions.has(requestId)) {
+          this.manager.pendingPermissions.delete(requestId)
+          this.emitPermissionReplied(requestId, 'reject')
+          resolve({ behavior: 'deny', message: 'Tool call was aborted' })
+        }
+      })
+      this.emit({
+        id: createClaudeEventId(),
+        type: 'permission.asked',
+        properties: {
+          id: requestId,
+          sessionID: this.id,
+          permission: descriptor.permission,
+          patterns: descriptor.patterns,
+          metadata: descriptor.metadata,
+          always: descriptor.always,
+          ...(this.currentAssistantMessageId
+            ? {
+                tool: {
+                  messageID: this.currentAssistantMessageId,
+                  callID: toolUseID,
+                },
+              }
+            : {}),
+        },
+      })
+    })
+  }
+
+  private handleAskUserQuestion({
+    input,
+    signal,
+    toolUseID,
+  }: {
+    input: Record<string, unknown>
+    signal: AbortSignal
+    toolUseID: string
+  }): Promise<PermissionResult> {
+    const questions = mapAskUserQuestions(input)
+    if (questions.length === 0) {
+      return Promise.resolve({ behavior: 'allow', updatedInput: input })
+    }
+    const requestId = createClaudeQuestionId()
+    return new Promise<PermissionResult>((resolve) => {
+      const pending: PendingQuestion = {
+        sessionId: this.id,
+        resolve: (result) => {
+          this.manager.pendingQuestions.delete(requestId)
+          resolve(result)
+        },
+        questions,
+        originalInput: input,
+      }
+      this.manager.pendingQuestions.set(requestId, pending)
+      signal.addEventListener('abort', () => {
+        if (this.manager.pendingQuestions.has(requestId)) {
+          this.manager.pendingQuestions.delete(requestId)
+          resolve({ behavior: 'deny', message: 'Question was aborted' })
+        }
+      })
+      this.emit({
+        id: createClaudeEventId(),
+        type: 'question.asked',
+        properties: {
+          id: requestId,
+          sessionID: this.id,
+          questions,
+          ...(this.currentAssistantMessageId
+            ? {
+                tool: {
+                  messageID: this.currentAssistantMessageId,
+                  callID: toolUseID,
+                },
+              }
+            : {}),
+        },
+      })
+    })
+  }
+
+  emitPermissionReplied(requestId: string, reply: 'once' | 'always' | 'reject'): void {
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'permission.replied',
+      properties: { sessionID: this.id, requestID: requestId, reply },
+    })
+  }
+
+  replyPermission({
+    requestId,
+    reply,
+    message,
+  }: {
+    requestId: string
+    reply: 'once' | 'always' | 'reject'
+    message?: string
+  }): boolean {
+    const pending = this.manager.pendingPermissions.get(requestId)
+    if (!pending || pending.sessionId !== this.id) {
+      return false
+    }
+    if (reply === 'always') {
+      const newRules = buildAlwaysRules({
+        permission: pending.permission,
+        always: pending.always,
+      })
+      this.session.permission = [...(this.session.permission ?? []), ...newRules]
+      this.manager.persistSession(this)
+    }
+    this.emitPermissionReplied(requestId, reply)
+    if (reply === 'reject') {
+      pending.resolve({
+        behavior: 'deny',
+        message: message || 'The user denied this tool use',
+      })
+    } else {
+      pending.resolve({ behavior: 'allow', updatedInput: pending.input })
+    }
+    return true
+  }
+
+  replyQuestion({ requestId, answers }: { requestId: string; answers: QuestionAnswer[] }): boolean {
+    const pending = this.manager.pendingQuestions.get(requestId)
+    if (!pending || pending.sessionId !== this.id) {
+      return false
+    }
+    const updatedInput = buildQuestionAnswersInput({
+      originalInput: pending.originalInput,
+      questions: pending.questions,
+      answers,
+    })
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'question.replied',
+      properties: { sessionID: this.id, requestID: requestId, answers },
+    })
+    pending.resolve({ behavior: 'allow', updatedInput })
+    return true
+  }
+
+  rejectQuestion({ requestId }: { requestId: string }): boolean {
+    const pending = this.manager.pendingQuestions.get(requestId)
+    if (!pending || pending.sessionId !== this.id) {
+      return false
+    }
+    this.emit({
+      id: createClaudeEventId(),
+      type: 'question.rejected',
+      properties: { sessionID: this.id, requestID: requestId },
+    })
+    pending.resolve({
+      behavior: 'deny',
+      message: 'User dismissed the question',
+    })
+    return true
+  }
+
+  // ── Session operations ────────────────────────────────────────
+
+  async abort(): Promise<boolean> {
+    this.abortRequested = true
+    // Deny pending interactive requests first so canUseTool unblocks.
+    for (const [requestId, pending] of this.manager.pendingPermissions) {
+      if (pending.sessionId === this.id) {
+        this.manager.pendingPermissions.delete(requestId)
+        this.emitPermissionReplied(requestId, 'reject')
+        pending.resolve({ behavior: 'deny', message: 'Aborted by user', interrupt: true })
+      }
+    }
+    for (const [requestId, pending] of this.manager.pendingQuestions) {
+      if (pending.sessionId === this.id) {
+        this.manager.pendingQuestions.delete(requestId)
+        pending.resolve({ behavior: 'deny', message: 'Aborted by user', interrupt: true })
+      }
+    }
+    const live = this.live
+    if (!live) {
+      if (this.status.type === 'busy') {
+        this.setStatus({ type: 'idle' })
+      }
+      return true
+    }
+    await live.query.interrupt().catch((error) => {
+      logger.warn(
+        `[CLAUDE] interrupt failed for ${this.id}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    })
+    return true
+  }
+
+  async summarize(): Promise<void> {
+    await this.pushHiddenCommand('/compact')
+  }
+
+  async update({
+    title,
+    permission,
+  }: {
+    title?: string
+    permission?: PermissionRuleset
+  }): Promise<Session> {
+    if (title !== undefined) {
+      this.session.title = title
+      if (this.sdkSessionId) {
+        const { renameSession } = await import('@anthropic-ai/claude-agent-sdk')
+        await renameSession(this.sdkSessionId, title, { dir: this.directory }).catch(() => {
+          // Title still applies to the wire session even if the transcript
+          // rename fails (e.g. session file not written yet).
+        })
+      }
+    }
+    if (permission !== undefined) {
+      this.session.permission = permission
+    }
+    this.manager.persistSession(this)
+    this.emitSessionUpdated()
+    return this.session
+  }
+
+  async revert({ messageID }: { messageID?: string }): Promise<Session> {
+    if (!messageID) {
+      throw new Error('revert requires a messageID')
+    }
+    const uuid = this.uuidByMessageId.get(messageID)
+    if (!uuid) {
+      throw new Error('Cannot revert: message not found in this Claude Code session')
+    }
+    const live = await this.ensureLive({ model: this.currentModelId })
+    await live.query.rewindFiles(uuid)
+    this.session.revert = { messageID }
+    this.emitSessionUpdated()
+    return this.session
+  }
+
+  async unrevert(): Promise<Session> {
+    const lastMessageId = this.messageOrder[this.messageOrder.length - 1]
+    const uuid = lastMessageId ? this.uuidByMessageId.get(lastMessageId) : undefined
+    if (uuid && this.live) {
+      await this.live.query.rewindFiles(uuid).catch((error) => {
+        logger.warn(
+          `[CLAUDE] unrevert rewindFiles failed: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      })
+    }
+    delete this.session.revert
+    this.emitSessionUpdated()
+    return this.session
+  }
+
+  fork({ messageID }: { messageID?: string }): ClaudeCodeSession {
+    const forked = this.manager.create({
+      directory: this.directory,
+      permission: [...(this.session.permission ?? [])],
+      parentID: this.id,
+      title: `Fork of ${this.session.title}`,
+    })
+    forked.sdkSessionId = this.sdkSessionId
+    forked.currentModelId = this.currentModelId
+    if (messageID) {
+      const uuid = this.uuidByMessageId.get(messageID)
+      forked.pendingFork = { resumeSessionAt: uuid }
+    } else {
+      forked.pendingFork = {}
+    }
+    // Copy wire history so the forked thread renders past context.
+    let reachedCutoff = false
+    for (const originalId of this.messageOrder) {
+      if (reachedCutoff) {
+        break
+      }
+      const entry = this.messages.get(originalId)
+      if (!entry) {
+        continue
+      }
+      const clonedInfo = structuredClone(entry.info)
+      clonedInfo.sessionID = forked.id
+      forked.storeMessage(clonedInfo)
+      for (const part of entry.parts.values()) {
+        const clonedPart = structuredClone(part)
+        clonedPart.sessionID = forked.id
+        forked.storePart(clonedPart)
+      }
+      const uuid = this.uuidByMessageId.get(originalId)
+      if (uuid) {
+        forked.uuidByMessageId.set(originalId, uuid)
+      }
+      if (messageID && originalId === messageID) {
+        reachedCutoff = true
+      }
+    }
+    this.manager.persistSession(forked)
+    return forked
+  }
+
+  async dispose({ deletePersisted }: { deletePersisted: boolean }): Promise<void> {
+    this.disposed = true
+    if (this.idleReapTimer) {
+      clearTimeout(this.idleReapTimer)
+      this.idleReapTimer = undefined
+    }
+    for (const [requestId, pending] of this.manager.pendingPermissions) {
+      if (pending.sessionId === this.id) {
+        this.manager.pendingPermissions.delete(requestId)
+        pending.resolve({ behavior: 'deny', message: 'Session closed' })
+      }
+    }
+    for (const [requestId, pending] of this.manager.pendingQuestions) {
+      if (pending.sessionId === this.id) {
+        this.manager.pendingQuestions.delete(requestId)
+        pending.resolve({ behavior: 'deny', message: 'Session closed' })
+      }
+    }
+    const live = this.live
+    this.live = null
+    if (live) {
+      live.input.end()
+      live.abortController.abort()
+    }
+    if (deletePersisted) {
+      const file = persistenceFile(this.id)
+      await fs.promises.rm(file, { force: true }).catch(() => {})
+    }
+  }
+
+  toPersisted(): PersistedSessionState {
+    return {
+      id: this.id,
+      directory: this.directory,
+      sdkSessionId: this.sdkSessionId,
+      title: this.session.title,
+      permission: this.session.permission ?? [],
+      parentID: this.session.parentID,
+      agent: this.session.agent,
+      timeCreated: this.session.time.created,
+    }
+  }
+}
+
+function errToNull<T>(fn: () => T): T | null {
+  try {
+    return fn()
+  } catch {
+    return null
+  }
+}
+
+function isEffortLevel(value: string): value is 'low' | 'medium' | 'high' | 'xhigh' | 'max' {
+  return (
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh' ||
+    value === 'max'
+  )
+}
+
+function buildQueryErrorMessage({
+  error,
+  stderrTail,
+}: {
+  error: Error
+  stderrTail: string[]
+}): string {
+  const stderrText = stderrTail.join('').trim()
+  const authHint = /auth|credential|api key|login/i.test(`${error.message}\n${stderrText}`)
+    ? ' If Claude Code is not authenticated on this machine, run `claude` in a terminal to log in or set ANTHROPIC_API_KEY.'
+    : ''
+  const tail = stderrText ? `\n${stderrText.slice(-400)}` : ''
+  return `Claude Code process error: ${error.message}.${authHint}${tail}`
+}
+
+async function computeGitDiffSummary(directory: string): Promise<{
+  additions: number
+  deletions: number
+  files: SnapshotFileDiff[]
+} | null> {
+  const numstat = await execAsync('git diff --numstat HEAD', {
+    cwd: directory,
+    timeout: 5000,
+  }).catch(() => {
+    return null
+  })
+  if (!numstat) {
+    return null
+  }
+  const files: SnapshotFileDiff[] = []
+  let additions = 0
+  let deletions = 0
+  for (const line of numstat.stdout.split('\n')) {
+    const match = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line.trim())
+    if (!match) {
+      continue
+    }
+    const add = match[1] === '-' ? 0 : Number(match[1])
+    const del = match[2] === '-' ? 0 : Number(match[2])
+    additions += add
+    deletions += del
+    files.push({
+      file: match[3],
+      additions: add,
+      deletions: del,
+      status: 'modified',
+    })
+  }
+  const untracked = await execAsync('git ls-files --others --exclude-standard', {
+    cwd: directory,
+    timeout: 5000,
+  }).catch(() => {
+    return null
+  })
+  if (untracked) {
+    for (const line of untracked.stdout.split('\n')) {
+      const file = line.trim()
+      if (!file) {
+        continue
+      }
+      files.push({ file, additions: 0, deletions: 0, status: 'added' })
+    }
+  }
+  if (files.length === 0) {
+    return null
+  }
+  return { additions, deletions, files: files.slice(0, 100) }
+}
+
+export class ClaudeCodeSessionManager {
+  readonly sessions = new Map<string, ClaudeCodeSession>()
+  readonly pendingPermissions = new Map<string, PendingPermission>()
+  readonly pendingQuestions = new Map<string, PendingQuestion>()
+  emitEvent: ClaudeEventSink
+  queryImpl: QueryImpl
+  modelCatalogLoaded = false
+  private slashCommandsByDirectory = new Map<string, string[]>()
+  private slashCommandDetails = new Map<string, SlashCommand[]>()
+  private agentsByDirectory = new Map<string, string[]>()
+
+  constructor({ emitEvent, queryImpl }: { emitEvent: ClaudeEventSink; queryImpl?: QueryImpl }) {
+    this.emitEvent = emitEvent
+    this.queryImpl = queryImpl ?? sdkQuery
+  }
+
+  create({
+    directory,
+    permission,
+    title,
+    parentID,
+    agent,
+  }: {
+    directory: string
+    permission?: PermissionRuleset
+    title?: string
+    parentID?: string
+    agent?: string
+  }): ClaudeCodeSession {
+    const session = new ClaudeCodeSession({
+      manager: this,
+      id: createClaudeSessionId(),
+      directory,
+      permission: permission ?? [],
+      title,
+      parentID,
+      agent,
+    })
+    this.sessions.set(session.id, session)
+    this.persistSession(session)
+    return session
+  }
+
+  /** Look up a session, restoring persisted metadata after a restart. */
+  get(sessionId: string): ClaudeCodeSession | undefined {
+    const existing = this.sessions.get(sessionId)
+    if (existing) {
+      return existing
+    }
+    const file = persistenceFile(sessionId)
+    const raw = errToNull(() => {
+      return fs.readFileSync(file, 'utf8')
+    })
+    if (!raw) {
+      return undefined
+    }
+    const parsed = errToNull(() => {
+      return JSON.parse(raw) as PersistedSessionState
+    })
+    if (!parsed || parsed.id !== sessionId) {
+      return undefined
+    }
+    const session = new ClaudeCodeSession({
+      manager: this,
+      id: parsed.id,
+      directory: parsed.directory,
+      permission: parsed.permission,
+      title: parsed.title,
+      parentID: parsed.parentID,
+      sdkSessionId: parsed.sdkSessionId,
+      timeCreated: parsed.timeCreated,
+      agent: parsed.agent,
+    })
+    this.sessions.set(session.id, session)
+    return session
+  }
+
+  list({ directory }: { directory?: string }): Session[] {
+    this.loadAllPersisted()
+    return [...this.sessions.values()]
+      .filter((session) => {
+        return !directory || session.directory === directory
+      })
+      .map((session) => {
+        return session.toWire()
+      })
+      .sort((a, b) => {
+        return b.time.updated - a.time.updated
+      })
+  }
+
+  private allPersistedLoaded = false
+
+  private loadAllPersisted(): void {
+    if (this.allPersistedLoaded) {
+      return
+    }
+    this.allPersistedLoaded = true
+    const dir = persistenceDir()
+    const entries = errToNull(() => {
+      return fs.readdirSync(dir)
+    })
+    if (!entries) {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) {
+        continue
+      }
+      this.get(entry.slice(0, -'.json'.length))
+    }
+  }
+
+  statuses({ directory }: { directory?: string }): Record<string, SessionStatus> {
+    const result: Record<string, SessionStatus> = {}
+    for (const session of this.sessions.values()) {
+      if (directory && session.directory !== directory) {
+        continue
+      }
+      result[session.id] = session.getStatus()
+    }
+    return result
+  }
+
+  async delete(sessionId: string): Promise<boolean> {
+    const session = this.get(sessionId)
+    if (!session) {
+      return false
+    }
+    await session.dispose({ deletePersisted: true })
+    this.sessions.delete(sessionId)
+    return true
+  }
+
+  persistSession(session: ClaudeCodeSession): void {
+    const dir = persistenceDir()
+    const writeResult = errToNull(() => {
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(persistenceFile(session.id), JSON.stringify(session.toPersisted(), null, 2))
+      return true
+    })
+    if (!writeResult) {
+      logger.warn(`[CLAUDE] Failed to persist session state for ${session.id}`)
+    }
+  }
+
+  recordRuntimeInfo({
+    directory,
+    slashCommands,
+    agents,
+  }: {
+    directory: string
+    slashCommands: string[]
+    agents: string[]
+  }): void {
+    this.slashCommandsByDirectory.set(directory, slashCommands)
+    this.agentsByDirectory.set(directory, agents)
+  }
+
+  recordSlashCommandDetails(directory: string, commands: SlashCommand[]): void {
+    this.slashCommandDetails.set(directory, commands)
+  }
+
+  getSlashCommands(directory: string): SlashCommand[] {
+    const detailed = this.slashCommandDetails.get(directory)
+    if (detailed) {
+      return detailed
+    }
+    const names = this.slashCommandsByDirectory.get(directory) ?? []
+    return names.map((name) => {
+      return { name, description: '', argumentHint: '' }
+    })
+  }
+
+  getAgents(directory: string): string[] {
+    return this.agentsByDirectory.get(directory) ?? []
+  }
+
+  replyPermission({
+    requestId,
+    reply,
+    message,
+  }: {
+    requestId: string
+    reply: 'once' | 'always' | 'reject'
+    message?: string
+  }): boolean {
+    const pending = this.pendingPermissions.get(requestId)
+    if (!pending) {
+      return false
+    }
+    const session = this.sessions.get(pending.sessionId)
+    if (!session) {
+      return false
+    }
+    return session.replyPermission({ requestId, reply, message })
+  }
+
+  replyQuestion({ requestId, answers }: { requestId: string; answers: QuestionAnswer[] }): boolean {
+    const pending = this.pendingQuestions.get(requestId)
+    if (!pending) {
+      return false
+    }
+    const session = this.sessions.get(pending.sessionId)
+    if (!session) {
+      return false
+    }
+    return session.replyQuestion({ requestId, answers })
+  }
+
+  rejectQuestion({ requestId }: { requestId: string }): boolean {
+    const pending = this.pendingQuestions.get(requestId)
+    if (!pending) {
+      return false
+    }
+    const session = this.sessions.get(pending.sessionId)
+    if (!session) {
+      return false
+    }
+    return session.rejectQuestion({ requestId })
+  }
+
+  async disposeAll(): Promise<void> {
+    await Promise.all(
+      [...this.sessions.values()].map((session) => {
+        return session.dispose({ deletePersisted: false })
+      }),
+    )
+    this.sessions.clear()
+  }
+}

--- a/cli/src/claude-code/translate.test.ts
+++ b/cli/src/claude-code/translate.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from 'vitest'
+import {
+  buildQuestionAnswersInput,
+  buildUserContent,
+  extractToolResults,
+  mapAskUserQuestions,
+  normalizeToolName,
+  stringifyToolResultContent,
+  translateAssistantBlock,
+  translateTranscriptMessages,
+} from './translate.js'
+
+describe('buildUserContent', () => {
+  test('text and data-url image parts become content blocks', () => {
+    const pngData = Buffer.from('fakepng').toString('base64')
+    const content = buildUserContent({
+      parts: [
+        { type: 'text', text: 'look at this' },
+        {
+          type: 'file',
+          mime: 'image/png',
+          filename: 'shot.png',
+          url: `data:image/png;base64,${pngData}`,
+        },
+      ],
+    })
+    expect(content).toEqual([
+      { type: 'text', text: 'look at this' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: pngData },
+      },
+    ])
+  })
+
+  test('pdf becomes a document block', () => {
+    const pdfData = Buffer.from('fakepdf').toString('base64')
+    const content = buildUserContent({
+      parts: [
+        {
+          type: 'file',
+          mime: 'application/pdf',
+          url: `data:application/pdf;base64,${pdfData}`,
+        },
+      ],
+    })
+    expect(content).toEqual([
+      {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: pdfData },
+      },
+    ])
+  })
+
+  test('empty text parts are skipped', () => {
+    expect(buildUserContent({ parts: [{ type: 'text', text: '   ' }] })).toEqual([])
+  })
+})
+
+describe('tool results', () => {
+  test('extractToolResults reads tool_result blocks', () => {
+    const results = extractToolResults({
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_1',
+          content: [{ type: 'text', text: 'file contents' }],
+        },
+      ],
+    })
+    expect(results).toEqual([{ toolUseId: 'toolu_1', output: 'file contents', isError: false }])
+  })
+
+  test('stringifyToolResultContent handles strings, arrays and objects', () => {
+    expect(stringifyToolResultContent('plain')).toBe('plain')
+    expect(
+      stringifyToolResultContent([
+        { type: 'text', text: 'a' },
+        { type: 'image', source: {} },
+      ]),
+    ).toBe('a\n[image]')
+    expect(stringifyToolResultContent({ some: 'json' })).toBe('{"some":"json"}')
+  })
+})
+
+describe('mapAskUserQuestions / buildQuestionAnswersInput', () => {
+  const input = {
+    questions: [
+      {
+        question: 'Which database should we use?',
+        header: 'Database',
+        multiSelect: false,
+        options: [
+          { label: 'Postgres', description: 'Relational' },
+          { label: 'SQLite', description: 'Embedded' },
+        ],
+      },
+    ],
+  }
+
+  test('maps AskUserQuestion input onto OpenCode QuestionInfo', () => {
+    const questions = mapAskUserQuestions(input)
+    expect(questions).toHaveLength(1)
+    expect(questions[0]).toMatchObject({
+      question: 'Which database should we use?',
+      header: 'Database',
+      multiple: false,
+      options: [
+        { label: 'Postgres', description: 'Relational' },
+        { label: 'SQLite', description: 'Embedded' },
+      ],
+    })
+  })
+
+  test('builds updatedInput with answers keyed by question text', () => {
+    const questions = mapAskUserQuestions(input)
+    const updated = buildQuestionAnswersInput({
+      originalInput: input,
+      questions,
+      answers: [['Postgres']],
+    })
+    expect(updated).toEqual({
+      questions: input.questions,
+      answers: { 'Which database should we use?': 'Postgres' },
+    })
+  })
+
+  test('multi-select answers stay arrays', () => {
+    const multiInput = {
+      questions: [
+        {
+          question: 'Which features?',
+          header: 'Features',
+          multiSelect: true,
+          options: [
+            { label: 'A', description: '' },
+            { label: 'B', description: '' },
+          ],
+        },
+      ],
+    }
+    const questions = mapAskUserQuestions(multiInput)
+    const updated = buildQuestionAnswersInput({
+      originalInput: multiInput,
+      questions,
+      answers: [['A', 'B']],
+    })
+    expect(updated).toMatchObject({
+      answers: { 'Which features?': ['A', 'B'] },
+    })
+  })
+})
+
+describe('normalizeToolName', () => {
+  test('maps Claude tool names to opencode-style lowercase names', () => {
+    expect(normalizeToolName('Bash')).toBe('bash')
+    expect(normalizeToolName('MultiEdit')).toBe('edit')
+    expect(normalizeToolName('Task')).toBe('task')
+    expect(normalizeToolName('WebFetch')).toBe('webfetch')
+    expect(normalizeToolName('mcp__kimaki__kimaki_action_buttons')).toBe('kimaki_action_buttons')
+    expect(normalizeToolName('SomethingNew')).toBe('somethingnew')
+  })
+})
+
+describe('translateAssistantBlock', () => {
+  test('text block becomes a text part', () => {
+    const part = translateAssistantBlock({
+      block: { type: 'text', text: 'hello', citations: null },
+      sessionId: 'ses_claude_x',
+      messageId: 'msg_claude_x',
+      now: 123,
+    })
+    expect(part).toMatchObject({ type: 'text', text: 'hello' })
+  })
+
+  test('tool_use block becomes a running tool part', () => {
+    const part = translateAssistantBlock({
+      block: {
+        type: 'tool_use',
+        id: 'toolu_9',
+        name: 'Bash',
+        input: { command: 'ls' },
+      },
+      sessionId: 'ses_claude_x',
+      messageId: 'msg_claude_x',
+      now: 123,
+    })
+    expect(part).toMatchObject({
+      type: 'tool',
+      callID: 'toolu_9',
+      tool: 'bash',
+      state: { status: 'running', input: { command: 'ls' } },
+    })
+  })
+})
+
+describe('translateTranscriptMessages', () => {
+  test('rebuilds user/assistant messages and resolves tool results', () => {
+    const { messages } = translateTranscriptMessages({
+      transcript: [
+        {
+          type: 'user',
+          uuid: 'u1',
+          parent_tool_use_id: null,
+          message: { role: 'user', content: 'run ls please' },
+        },
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          parent_tool_use_id: null,
+          message: {
+            role: 'assistant',
+            model: 'claude-opus-4-8',
+            content: [
+              { type: 'text', text: 'Running it now' },
+              { type: 'tool_use', id: 'toolu_1', name: 'Bash', input: { command: 'ls' } },
+            ],
+          },
+        },
+        {
+          type: 'user',
+          uuid: 'u2',
+          parent_tool_use_id: null,
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'README.md' }],
+          },
+        },
+      ],
+      sessionId: 'ses_claude_t',
+      directory: '/repo',
+      agent: 'claude',
+    })
+
+    expect(messages).toHaveLength(2)
+    expect(messages[0]!.info.role).toBe('user')
+    expect(messages[1]!.info.role).toBe('assistant')
+    const toolPart = messages[1]!.parts.find((part) => {
+      return part.type === 'tool'
+    })
+    expect(toolPart).toMatchObject({
+      type: 'tool',
+      state: { status: 'completed', output: 'README.md' },
+    })
+  })
+})

--- a/cli/src/claude-code/translate.ts
+++ b/cli/src/claude-code/translate.ts
@@ -1,0 +1,554 @@
+// Translation between Claude Agent SDK messages and OpenCode wire types.
+//
+// The Claude backend speaks OpenCode's protocol to the rest of kimaki, so
+// everything the SDK emits (assistant content blocks, tool results, results)
+// must be reshaped into OpenCode Message/Part objects. Pure functions only —
+// session state lives in sessions.ts.
+
+import type {
+  AssistantMessage,
+  Message,
+  Part,
+  QuestionInfo,
+  TextPart,
+  ToolPart,
+  ReasoningPart,
+  FilePartInput,
+  TextPartInput,
+} from '@opencode-ai/sdk/v2'
+import type { SDKAssistantMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
+import { CLAUDE_CODE_PROVIDER_ID } from './models.js'
+import { createClaudeMessageId, createClaudePartId } from './ids.js'
+
+// Content block unions derived from the SDK's own message types so we don't
+// have to depend on @anthropic-ai/sdk directly.
+export type AssistantContentBlock = SDKAssistantMessage['message']['content'][number]
+export type UserMessageParam = SDKUserMessage['message']
+type UserContentBlock = Exclude<UserMessageParam['content'], string>[number]
+
+export type WireMessageWithParts = {
+  info: Message
+  parts: Part[]
+}
+
+export function buildAssistantInfo({
+  sessionId,
+  messageId,
+  parentUserMessageId,
+  modelId,
+  directory,
+  agent,
+  created,
+}: {
+  sessionId: string
+  messageId: string
+  parentUserMessageId: string
+  modelId: string
+  directory: string
+  agent: string
+  created: number
+}): AssistantMessage {
+  return {
+    id: messageId,
+    sessionID: sessionId,
+    role: 'assistant',
+    time: { created },
+    parentID: parentUserMessageId,
+    modelID: modelId,
+    providerID: CLAUDE_CODE_PROVIDER_ID,
+    mode: agent,
+    agent,
+    path: { cwd: directory, root: directory },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  }
+}
+
+export function stringifyToolResultContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (block && typeof block === 'object') {
+          const rec = block as Record<string, unknown>
+          if (rec.type === 'text' && typeof rec.text === 'string') {
+            return rec.text
+          }
+          if (rec.type === 'image') {
+            return '[image]'
+          }
+        }
+        return ''
+      })
+      .filter((text) => {
+        return text.length > 0
+      })
+      .join('\n')
+  }
+  if (content == null) {
+    return ''
+  }
+  return JSON.stringify(content)
+}
+
+export type ToolResultBlock = {
+  toolUseId: string
+  output: string
+  isError: boolean
+}
+
+/** Extract tool_result blocks from an SDK user message (tool result carrier). */
+export function extractToolResults(message: UserMessageParam): ToolResultBlock[] {
+  if (typeof message.content === 'string') {
+    return []
+  }
+  const results: ToolResultBlock[] = []
+  for (const block of message.content) {
+    if (block.type !== 'tool_result') {
+      continue
+    }
+    results.push({
+      toolUseId: block.tool_use_id,
+      output: stringifyToolResultContent(block.content),
+      isError: block.is_error === true,
+    })
+  }
+  return results
+}
+
+/**
+ * Convert OpenCode prompt parts (text + data-url file parts) into an SDK
+ * MessageParam content array. Discord images arrive as data URLs; PDFs become
+ * document blocks.
+ */
+export function buildUserContent({
+  parts,
+}: {
+  parts: Array<TextPartInput | FilePartInput>
+}): Exclude<UserMessageParam['content'], string> {
+  const content: UserContentBlock[] = []
+  for (const part of parts) {
+    if (part.type === 'text') {
+      if (part.text.trim().length === 0) {
+        continue
+      }
+      content.push({ type: 'text', text: part.text })
+      continue
+    }
+    if (part.type === 'file') {
+      const parsed = parseDataUrl(part.url)
+      if (!parsed) {
+        content.push({
+          type: 'text',
+          text: `[attachment: ${part.filename ?? part.url}]`,
+        })
+        continue
+      }
+      if (parsed.mime === 'application/pdf') {
+        content.push({
+          type: 'document',
+          source: {
+            type: 'base64',
+            media_type: 'application/pdf',
+            data: parsed.data,
+          },
+        })
+        continue
+      }
+      if (isSupportedImageMime(parsed.mime)) {
+        content.push({
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: parsed.mime,
+            data: parsed.data,
+          },
+        })
+        continue
+      }
+      content.push({
+        type: 'text',
+        text: `[unsupported attachment type ${parsed.mime}: ${part.filename ?? ''}]`,
+      })
+    }
+  }
+  return content
+}
+
+type SupportedImageMime = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
+
+function isSupportedImageMime(mime: string): mime is SupportedImageMime {
+  return (
+    mime === 'image/jpeg' || mime === 'image/png' || mime === 'image/gif' || mime === 'image/webp'
+  )
+}
+
+function parseDataUrl(url: string): { mime: string; data: string } | null {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(url)
+  if (!match) {
+    return null
+  }
+  return { mime: match[1]!, data: match[2]! }
+}
+
+/**
+ * Map AskUserQuestion tool input questions into OpenCode QuestionInfo entries
+ * (they are nearly identical by design).
+ */
+export function mapAskUserQuestions(input: Record<string, unknown>): QuestionInfo[] {
+  const rawQuestions = input.questions
+  if (!Array.isArray(rawQuestions)) {
+    return []
+  }
+  const questions: QuestionInfo[] = []
+  for (const raw of rawQuestions) {
+    if (!raw || typeof raw !== 'object') {
+      continue
+    }
+    const rec = raw as Record<string, unknown>
+    const question = typeof rec.question === 'string' ? rec.question : ''
+    const header = typeof rec.header === 'string' ? rec.header : ''
+    const optionsRaw = Array.isArray(rec.options) ? rec.options : []
+    const options = optionsRaw.flatMap((opt) => {
+      if (!opt || typeof opt !== 'object') {
+        return []
+      }
+      const optRec = opt as Record<string, unknown>
+      const label = typeof optRec.label === 'string' ? optRec.label : ''
+      if (!label) {
+        return []
+      }
+      return [
+        {
+          label,
+          description: typeof optRec.description === 'string' ? optRec.description : '',
+        },
+      ]
+    })
+    if (!question || options.length === 0) {
+      continue
+    }
+    questions.push({
+      question,
+      header: header || question.slice(0, 30),
+      options,
+      multiple: rec.multiSelect === true,
+      custom: true,
+    })
+  }
+  return questions
+}
+
+/**
+ * Build the AskUserQuestion updatedInput payload from kimaki question answers.
+ * Answer values are option labels; multi-select questions get arrays.
+ */
+export function buildQuestionAnswersInput({
+  originalInput,
+  questions,
+  answers,
+}: {
+  originalInput: Record<string, unknown>
+  questions: QuestionInfo[]
+  answers: string[][]
+}): Record<string, unknown> {
+  const answerMap: Record<string, string | string[]> = {}
+  questions.forEach((question, index) => {
+    const selected = answers[index] ?? []
+    if (selected.length === 0) {
+      return
+    }
+    answerMap[question.question] = question.multiple ? selected : (selected[0] ?? '')
+  })
+  return {
+    questions: originalInput.questions,
+    answers: answerMap,
+  }
+}
+
+export type TranslatedBlockPart = Part
+
+/**
+ * Translate a complete assistant content block into an OpenCode part.
+ * Used both for live reconciliation and for transcript hydration.
+ */
+export function translateAssistantBlock({
+  block,
+  sessionId,
+  messageId,
+  now,
+}: {
+  block: AssistantContentBlock
+  sessionId: string
+  messageId: string
+  now: number
+}): Part | null {
+  if (block.type === 'text') {
+    const part: TextPart = {
+      id: createClaudePartId(),
+      sessionID: sessionId,
+      messageID: messageId,
+      type: 'text',
+      text: block.text,
+      time: { start: now, end: now },
+    }
+    return part
+  }
+  if (block.type === 'thinking') {
+    const part: ReasoningPart = {
+      id: createClaudePartId(),
+      sessionID: sessionId,
+      messageID: messageId,
+      type: 'reasoning',
+      text: block.thinking,
+      time: { start: now, end: now },
+    }
+    return part
+  }
+  if (block.type === 'redacted_thinking') {
+    const part: ReasoningPart = {
+      id: createClaudePartId(),
+      sessionID: sessionId,
+      messageID: messageId,
+      type: 'reasoning',
+      text: '[redacted thinking]',
+      time: { start: now, end: now },
+    }
+    return part
+  }
+  if (block.type === 'tool_use') {
+    const part: ToolPart = {
+      id: createClaudePartId(),
+      sessionID: sessionId,
+      messageID: messageId,
+      type: 'tool',
+      callID: block.id,
+      tool: normalizeToolName(block.name),
+      state: {
+        status: 'running',
+        input: asRecord(block.input),
+        title: normalizeToolName(block.name),
+        time: { start: now },
+      },
+    }
+    return part
+  }
+  return null
+}
+
+/**
+ * OpenCode tool names are lowercase (bash, edit, read...). Claude tool names
+ * are TitleCase (Bash, Edit, Read...). Kimaki's formatting layer special-cases
+ * the lowercase names, so normalize the common ones and lowercase the rest.
+ */
+export function normalizeToolName(toolName: string): string {
+  const mapping: Record<string, string> = {
+    Bash: 'bash',
+    Edit: 'edit',
+    MultiEdit: 'edit',
+    Write: 'write',
+    Read: 'read',
+    Glob: 'glob',
+    Grep: 'grep',
+    Task: 'task',
+    TodoWrite: 'todowrite',
+    TodoRead: 'todoread',
+    WebFetch: 'webfetch',
+    WebSearch: 'websearch',
+    NotebookEdit: 'edit',
+    ExitPlanMode: 'plan_exit',
+    AskUserQuestion: 'question',
+    KillShell: 'bash',
+    BashOutput: 'bash',
+    SlashCommand: 'command',
+    Skill: 'skill',
+  }
+  if (mapping[toolName]) {
+    return mapping[toolName]
+  }
+  const mcpMatch = /^mcp__[^_]+__(.+)$/.exec(toolName)
+  if (mcpMatch) {
+    return mcpMatch[1]!
+  }
+  return toolName.toLowerCase()
+}
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return {}
+}
+
+/**
+ * Hydrate OpenCode wire messages from a persisted Claude Code transcript
+ * (SDK getSessionMessages output). Used after bot restarts so /resume and
+ * session.messages keep working for claude-backed threads.
+ */
+export function translateTranscriptMessages({
+  transcript,
+  sessionId,
+  directory,
+  agent,
+}: {
+  transcript: Array<{
+    type: 'user' | 'assistant' | 'system'
+    uuid: string
+    message: unknown
+    parent_tool_use_id: string | null
+  }>
+  sessionId: string
+  directory: string
+  agent: string
+}): { messages: WireMessageWithParts[]; uuidByMessageId: Map<string, string> } {
+  const messages: WireMessageWithParts[] = []
+  const uuidByMessageId = new Map<string, string>()
+  const toolPartsByCallId = new Map<string, ToolPart>()
+  let lastUserMessageId = ''
+  let modelId = ''
+  const now = Date.now()
+
+  for (const entry of transcript) {
+    if (entry.parent_tool_use_id) {
+      continue
+    }
+    const messageRecord = asRecord(entry.message)
+    if (entry.type === 'user') {
+      const content = messageRecord.content
+      // Tool-result carrier messages update existing tool parts instead of
+      // becoming visible user messages.
+      if (Array.isArray(content)) {
+        let onlyToolResults = content.length > 0
+        for (const block of content) {
+          const rec = asRecord(block)
+          if (rec.type !== 'tool_result') {
+            onlyToolResults = false
+          }
+        }
+        if (onlyToolResults) {
+          for (const block of content) {
+            const rec = asRecord(block)
+            const callId = typeof rec.tool_use_id === 'string' ? rec.tool_use_id : ''
+            const part = toolPartsByCallId.get(callId)
+            if (!part) {
+              continue
+            }
+            const output = stringifyToolResultContent(rec.content)
+            if (rec.is_error === true) {
+              part.state = {
+                status: 'error',
+                input: part.state.input,
+                error: output,
+                time: { start: now, end: now },
+              }
+            } else {
+              part.state = {
+                status: 'completed',
+                input: part.state.input,
+                output,
+                title: part.tool,
+                metadata: {},
+                time: { start: now, end: now },
+              }
+            }
+          }
+          continue
+        }
+      }
+      const text = (() => {
+        if (typeof content === 'string') {
+          return content
+        }
+        if (!Array.isArray(content)) {
+          return ''
+        }
+        return content
+          .map((block) => {
+            const rec = asRecord(block)
+            return rec.type === 'text' && typeof rec.text === 'string' ? rec.text : ''
+          })
+          .filter((value) => {
+            return value.length > 0
+          })
+          .join('\n')
+      })()
+      if (!text) {
+        continue
+      }
+      const messageId = createClaudeMessageId()
+      lastUserMessageId = messageId
+      uuidByMessageId.set(messageId, entry.uuid)
+      const textPart: TextPart = {
+        id: createClaudePartId(),
+        sessionID: sessionId,
+        messageID: messageId,
+        type: 'text',
+        text,
+        time: { start: now, end: now },
+      }
+      messages.push({
+        info: {
+          id: messageId,
+          sessionID: sessionId,
+          role: 'user',
+          time: { created: now },
+          agent,
+          model: {
+            providerID: CLAUDE_CODE_PROVIDER_ID,
+            modelID: modelId || 'claude-code',
+          },
+        },
+        parts: [textPart],
+      })
+      continue
+    }
+    if (entry.type === 'assistant') {
+      const model = typeof messageRecord.model === 'string' ? messageRecord.model : ''
+      if (model) {
+        modelId = model
+      }
+      const messageId = createClaudeMessageId()
+      uuidByMessageId.set(messageId, entry.uuid)
+      const info = buildAssistantInfo({
+        sessionId,
+        messageId,
+        parentUserMessageId: lastUserMessageId,
+        modelId: modelId || 'claude-code',
+        directory,
+        agent,
+        created: now,
+      })
+      info.time.completed = now
+      info.finish = 'stop'
+      const parts: Part[] = []
+      const content = messageRecord.content
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const part = translateAssistantBlock({
+            block: block as AssistantContentBlock,
+            sessionId,
+            messageId,
+            now,
+          })
+          if (!part) {
+            continue
+          }
+          parts.push(part)
+          if (part.type === 'tool') {
+            toolPartsByCallId.set(part.callID, part)
+          }
+        }
+      }
+      messages.push({ info, parts })
+    }
+  }
+
+  return { messages, uuidByMessageId }
+}

--- a/cli/src/database.ts
+++ b/cli/src/database.ts
@@ -279,6 +279,17 @@ export async function getGlobalModel(appId: string) {
   return row ? { modelId: row.model_id, variant: row.variant } : undefined
 }
 
+/**
+ * Global model preference without an appId, for callers that only know the
+ * channel (backend routing). Kimaki installs run a single bot per data dir,
+ * so the first row is the effective global default.
+ */
+export async function getAnyGlobalModel() {
+  const db = await getDb()
+  const row = await db.query.global_models.findFirst()
+  return row ? { modelId: row.model_id, variant: row.variant } : undefined
+}
+
 export async function setGlobalModel({ appId, modelId, variant }: { appId: string; modelId: string; variant?: string | null }) {
   const db = await getDb()
   await db.insert(schema.global_models)

--- a/cli/src/discord-bot.ts
+++ b/cli/src/discord-bot.ts
@@ -29,6 +29,7 @@ import {
 } from './database.js'
 import {
   stopOpencodeServer,
+  stopClaudeCodeRouter,
 } from './opencode.js'
 import { formatAutoWorktreeName, createWorktreeInBackground, worktreeCreatingMessage } from './commands/new-worktree.js'
 import { resolveSessionWorkingDirectory, git, isGitRepositoryRoot } from './worktrees.js'
@@ -1470,6 +1471,9 @@ export async function startDiscordBot({
       voiceLogger.log('[SHUTDOWN] Stopping OpenCode server')
       stopExternalOpencodeSessionSync()
       await stopOpencodeServer()
+
+      voiceLogger.log('[SHUTDOWN] Stopping Claude Code router')
+      await stopClaudeCodeRouter()
 
       discordLogger.log('Closing database...')
       await closeDatabase()

--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -68,6 +68,14 @@ import {
   selectResolvedCommand,
 } from './opencode-command.js'
 import { computeSkillPermission } from './skill-filter.js'
+import {
+  startClaudeCodeRouter,
+  CLAUDE_BACKEND_HEADER,
+  CLAUDE_BACKEND_VALUE,
+  type ClaudeCodeRouter,
+} from './claude-code/server.js'
+import { isClaudeCodeModel } from './claude-code/models.js'
+import { getChannelModel, getAnyGlobalModel } from './database.js'
 
 const opencodeLogger = createLogger(LogPrefix.OPENCODE)
 
@@ -297,6 +305,85 @@ let processCleanupHandlersRegistered = false
 let startingServerProcess: ChildProcess | null = null
 const clientCache = new Map<string, OpencodeClient>()
 
+// ── Claude Code backend router ───────────────────────────────────
+// A local HTTP server that speaks the opencode protocol: claude-code
+// sessions are handled in-process by the Claude Agent SDK, everything else
+// is proxied to the opencode server above. All kimaki clients point at the
+// router so both backends share one wire protocol.
+
+let claudeRouter: ClaudeCodeRouter | null = null
+let claudeRouterStarting: Promise<ClaudeCodeRouter> | null = null
+
+async function ensureClaudeRouter(): Promise<ClaudeCodeRouter> {
+  if (claudeRouter) {
+    return claudeRouter
+  }
+  if (!claudeRouterStarting) {
+    claudeRouterStarting = startClaudeCodeRouter({
+      getUpstreamBaseUrl: () => {
+        return singleServer?.baseUrl ?? null
+      },
+      getUpstreamHeaders: getOpencodeServerAuthHeaders,
+      expectedAuthorization: () => {
+        return getOpencodeServerAuthHeaders().Authorization
+      },
+    }).then(
+      (router) => {
+        claudeRouter = router
+        claudeRouterStarting = null
+        return router
+      },
+      (error: unknown) => {
+        // Don't cache the rejection — the next call retries the startup.
+        claudeRouterStarting = null
+        throw error
+      },
+    )
+  }
+  return claudeRouterStarting
+}
+
+/** The claude-code router base URL, if the router is running. */
+export function getClaudeCodeRouterBaseUrl(): string | null {
+  return claudeRouter?.baseUrl ?? null
+}
+
+export async function stopClaudeCodeRouter(): Promise<void> {
+  const router = claudeRouter
+  claudeRouter = null
+  claudeRouterStarting = null
+  if (router) {
+    await router.close().catch((error) => {
+      opencodeLogger.warn(
+        `Failed to close claude-code router: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    })
+  }
+}
+
+export type AgentBackendKind = 'opencode' | 'claude-code'
+
+/**
+ * Backend for new sessions in a channel, derived from the model preference
+ * cascade (channel override, then global default): picking a claude-code/*
+ * model in /model routes new sessions to the Claude Code backend.
+ */
+export async function resolveChannelBackend({
+  channelId,
+}: {
+  channelId?: string
+}): Promise<AgentBackendKind> {
+  const channelPreference = channelId ? await getChannelModel(channelId) : undefined
+  if (channelPreference) {
+    return isClaudeCodeModel(channelPreference.modelId) ? 'claude-code' : 'opencode'
+  }
+  const globalPreference = await getAnyGlobalModel()
+  if (globalPreference) {
+    return isClaudeCodeModel(globalPreference.modelId) ? 'claude-code' : 'opencode'
+  }
+  return 'opencode'
+}
+
 function notifyServerLifecycle(event: ServerLifecycleEvent): void {
   for (const listener of serverLifecycleListeners) {
     listener(event)
@@ -396,9 +483,18 @@ function ensureProcessCleanupHandlersRegistered(): void {
 
   opencodeLogger.log('Registering process cleanup handlers for opencode server')
 
+  // disposeAll aborts each live Claude Code subprocess synchronously before
+  // awaiting cleanup, so calling it without awaiting is safe in exit paths.
+  const killClaudeSessionsNow = () => {
+    if (claudeRouter) {
+      void claudeRouter.manager.disposeAll()
+    }
+  }
+
   process.on('exit', () => {
     killSingleServerProcessNow({ reason: 'process-exit' })
     killStartingServerProcessNow({ reason: 'process-exit' })
+    killClaudeSessionsNow()
   })
 
   // Fallback for short-lived CLI subcommands that call process.exit without
@@ -406,10 +502,12 @@ function ensureProcessCleanupHandlersRegistered(): void {
   process.on('SIGINT', () => {
     killSingleServerProcessNow({ reason: 'sigint' })
     killStartingServerProcessNow({ reason: 'sigint' })
+    killClaudeSessionsNow()
   })
   process.on('SIGTERM', () => {
     killSingleServerProcessNow({ reason: 'sigterm' })
     killStartingServerProcessNow({ reason: 'sigterm' })
+    killClaudeSessionsNow()
   })
 }
 
@@ -936,11 +1034,14 @@ async function startSingleServer({
 function getOrCreateClient({
   baseUrl,
   directory,
+  backend,
 }: {
   baseUrl: string
   directory: string
+  backend?: AgentBackendKind
 }): OpencodeClient {
-  const cached = clientCache.get(directory)
+  const cacheKey = `${backend ?? 'opencode'}:${baseUrl}:${directory}`
+  const cached = clientCache.get(cacheKey)
   if (cached) {
     return cached
   }
@@ -955,9 +1056,16 @@ function getOrCreateClient({
     baseUrl,
     directory,
     fetch: fetchWithTimeout as typeof fetch,
-    headers: getOpencodeServerAuthHeaders(),
+    headers: {
+      ...getOpencodeServerAuthHeaders(),
+      // The router creates sessions on the Claude Code backend when this
+      // header is present; every other request routes by session id.
+      ...(backend === 'claude-code'
+        ? { [CLAUDE_BACKEND_HEADER]: CLAUDE_BACKEND_VALUE }
+        : {}),
+    },
   })
-  clientCache.set(directory, client)
+  clientCache.set(cacheKey, client)
   return client
 }
 
@@ -976,7 +1084,7 @@ function getOrCreateClient({
  */
 export async function initializeOpencodeForDirectory(
   directory: string,
-  _options?: { originalRepoDirectory?: string; channelId?: string },
+  options?: { originalRepoDirectory?: string; channelId?: string },
 ): Promise<OpenCodeErrors | (() => OpencodeClient)> {
   // Verify directory exists and is accessible
   const accessCheck = errore.tryFn({
@@ -992,17 +1100,24 @@ export async function initializeOpencodeForDirectory(
   const server = await ensureSingleServer({ directory })
   if (server instanceof Error) return server
 
+  const router = await ensureClaudeRouter()
+
   if (!initializedDirectories.has(directory)) {
     initializedDirectories.add(directory)
   }
+
+  // Session-create backend is chosen by the channel's model preference;
+  // everything after creation routes by session id inside the router.
+  const backend = await resolveChannelBackend({ channelId: options?.channelId })
 
   return () => {
     if (!singleServer) {
       throw new ServerNotReadyError({ directory })
     }
     return getOrCreateClient({
-      baseUrl: singleServer.baseUrl,
+      baseUrl: router.baseUrl,
       directory,
+      ...(backend === 'claude-code' ? { backend } : {}),
     })
   }
 }
@@ -1250,6 +1365,11 @@ export function getOpencodeServerPort(_directory?: string): number | null {
 }
 
 export function getOpencodeServerBaseUrl(): string | null {
+  // Prefer the router: it serves both backends and proxies everything else
+  // to the opencode server. Falls back to the raw server URL during startup.
+  if (singleServer && claudeRouter) {
+    return claudeRouter.baseUrl
+  }
   return singleServer?.baseUrl ?? null
 }
 
@@ -1258,7 +1378,7 @@ export function getOpencodeClient(directory: string): OpencodeClient | null {
     return null
   }
   return getOrCreateClient({
-    baseUrl: singleServer.baseUrl,
+    baseUrl: claudeRouter?.baseUrl ?? singleServer.baseUrl,
     directory,
   })
 }

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -136,6 +136,8 @@ import {
   getThinkingValuesForModel,
   matchThinkingValue,
 } from '../thinking-utils.js'
+import { isClaudeCodeSessionId } from '../claude-code/ids.js'
+import { CLAUDE_CODE_PROVIDER_ID } from '../claude-code/models.js'
 import { execAsync } from '../worktrees.js'
 import {
   DiscordOperationError,
@@ -2973,9 +2975,24 @@ export class ThreadSessionRuntime {
         return
       }
 
+      // Cross-backend guard: a session created on one backend can't run a
+      // model from the other. When the preference cascade resolves to a
+      // mismatched model (e.g. a claude-code model selected mid-thread in an
+      // opencode session), drop the model and let the session keep its own
+      // default — new sessions pick the right backend from the same cascade.
+      const sessionIsClaudeCode = isClaudeCodeSessionId(session.id)
+      const modelMatchesBackend =
+        (modelField.providerID === CLAUDE_CODE_PROVIDER_ID) === sessionIsClaudeCode
+      const effectiveModelField = modelMatchesBackend ? modelField : undefined
+      if (!modelMatchesBackend) {
+        logger.log(
+          `[INGRESS] Model ${modelField.providerID}/${modelField.modelID} does not match backend of session ${session.id}; using the session's current model instead`,
+        )
+      }
+
       // Resolve thinking variant
       const thinkingValue = await (async (): Promise<string | undefined> => {
-        if (!preferredVariant) {
+        if (!preferredVariant || !effectiveModelField) {
           return undefined
         }
         const providersResponse = await getClient().provider.list({ directory: this.sdkDirectory })
@@ -2985,8 +3002,8 @@ export class ThreadSessionRuntime {
         }
         const availableValues = getThinkingValuesForModel({
           providers: providersResponse.data.all,
-          providerId: modelField.providerID,
-          modelId: modelField.modelID,
+          providerId: effectiveModelField.providerID,
+          modelId: effectiveModelField.modelID,
         })
         if (availableValues.length === 0) {
           return undefined
@@ -3081,7 +3098,7 @@ export class ThreadSessionRuntime {
           userId: this.state?.sessionUserId || input.userId,
         }),
         ...(resolvedAgent ? { agent: resolvedAgent } : {}),
-        ...(modelField ? { model: modelField } : {}),
+        ...(effectiveModelField ? { model: effectiveModelField } : {}),
         ...variantField,
         ...(input.noReply ? { noReply: true } : {}),
       }
@@ -3689,9 +3706,21 @@ export class ThreadSessionRuntime {
       return
     }
 
+    // Cross-backend guard: don't send a model that belongs to the other
+    // backend (see submitViaOpencodeQueue for details).
+    const earlySessionIsClaudeCode = isClaudeCodeSessionId(session.id)
+    const earlyModelMatchesBackend =
+      (earlyModelParam.providerID === CLAUDE_CODE_PROVIDER_ID) === earlySessionIsClaudeCode
+    const earlyEffectiveModelParam = earlyModelMatchesBackend ? earlyModelParam : undefined
+    if (!earlyModelMatchesBackend) {
+      logger.log(
+        `[DISPATCH] Model ${earlyModelParam.providerID}/${earlyModelParam.modelID} does not match backend of session ${session.id}; using the session's current model instead`,
+      )
+    }
+
     // Resolve thinking variant
     const earlyThinkingValue = await (async (): Promise<string | undefined> => {
-      if (!preferredVariant) {
+      if (!preferredVariant || !earlyEffectiveModelParam) {
         return undefined
       }
       const providersResponse = await getClient().provider.list({ directory: this.sdkDirectory })
@@ -3701,8 +3730,8 @@ export class ThreadSessionRuntime {
       }
       const availableValues = getThinkingValuesForModel({
         providers: providersResponse.data.all,
-        providerId: earlyModelParam.providerID,
-        modelId: earlyModelParam.modelID,
+        providerId: earlyEffectiveModelParam.providerID,
+        modelId: earlyEffectiveModelParam.modelID,
       })
       if (availableValues.length === 0) {
         return undefined
@@ -3832,7 +3861,11 @@ export class ThreadSessionRuntime {
           command: queuedCommand.name,
           arguments: queuedCommand.arguments + (discordTag ? `\n${discordTag}` : ''),
           agent: earlyAgentPreference,
-          model: `${earlyModelParam.providerID}/${earlyModelParam.modelID}`,
+          ...(earlyEffectiveModelParam
+            ? {
+                model: `${earlyEffectiveModelParam.providerID}/${earlyEffectiveModelParam.modelID}`,
+              }
+            : {}),
           ...variantField,
         },
         { signal: commandSignal },
@@ -3925,7 +3958,7 @@ export class ThreadSessionRuntime {
         username: this.state?.sessionUsername || input.username,
         userId: this.state?.sessionUserId || input.userId,
       }),
-      model: earlyModelParam,
+      ...(earlyEffectiveModelParam ? { model: earlyEffectiveModelParam } : {}),
       agent: earlyAgentPreference,
       ...variantField,
     }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.10
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.202
+        version: 0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@clack/prompts':
         specifier: ^1.3.0
         version: 1.5.1
@@ -706,6 +709,67 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.202':
+    resolution: {integrity: sha512-ujR3zDthDPkZs+AxW95iHpqLT5cuwGImsS3mVxLt1DlDij4qeTnihLX8+EpQTK+oNW9jjvFA86yKwa84fa1KYA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.202':
+    resolution: {integrity: sha512-s/RVSGgkVmIMfyt1ndR8braLLu82bARoijmt1kk8d4IptUZ0Sc+zNUWKoFXwR9XqDBu6rBbBF9RIzD02raT57w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.202':
+    resolution: {integrity: sha512-abSb3Gah45kUNyOeKjmQ/dd1KZ4CaQz5JAr9YQxRDXoOwx8wJVx6huBIpDxjms9wyS9X5Rqxn0Lx7zFP+wV2zQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.202':
+    resolution: {integrity: sha512-a4YtRkgGYt3ogePJDW8Ts6bNW690jb9LHyZaiWXsi+zT53xCNqJB2zKPyRc7hXWOqzIk4nCfwJpjmhLzMu3WIg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.202':
+    resolution: {integrity: sha512-fze5nAQL1ErcMCQNB10ILaWdM0QbJSaTQzBz8NVAy0FGW8ZL0t4Wf/VgFkfzXbfkaxmPuM1C27Dn5HiU7UDEHQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.202':
+    resolution: {integrity: sha512-XIvhdCWAAT4OdOA82fOJII+WH0Tf8pFckckEbJMMmOgQBKOnHT+609Pd3Ehw6zGcA9iFrhG5mY8Ncuckeo1aMw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.202':
+    resolution: {integrity: sha512-N1J0HRvC+8a69bqNY7+ENIYQzR0i7s+rOIGH5XtuLxvLqOnZO8LHxWEZOe8ezabGq5eZqphSCgL6vQnQQpNh+A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.202':
+    resolution: {integrity: sha512-ytLGEC1fjTSiVSoXukS+j9G+06Mi20NSzxxzlG6uE75SEB0+17tHdWUaHqd8PhH/6GPzcYx81czxWQl1MVbq4Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.202':
+    resolution: {integrity: sha512-LnaLxDtsZP7J6g++xRSnnpTX7CHNe4v+cvBRIlD2ar+N+xi0aqY2YDaCsxPsl+haVUB9kqlUMd0zosmwsfTGjQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.110.0':
+    resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@azure/abort-controller@1.1.0':
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
@@ -781,6 +845,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -2713,6 +2781,9 @@ packages:
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4060,6 +4131,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -4427,6 +4501,10 @@ packages:
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -5571,6 +5649,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -5685,6 +5766,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
@@ -6165,6 +6249,52 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.202':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.202(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.110.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.202
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.202
+
+  '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
   '@azure/abort-controller@1.1.0':
     dependencies:
       tslib: 2.8.1
@@ -6303,6 +6433,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
     dependencies:
@@ -7889,6 +8021,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.1':
@@ -9326,6 +9460,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -9729,6 +9865,11 @@ snapshots:
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -11309,6 +11450,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -11397,6 +11543,8 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.3.0: {}
 

--- a/website/docs.json
+++ b/website/docs.json
@@ -49,6 +49,7 @@
         "group": "Features",
         "icon": "lucide:sparkles",
         "pages": [
+          "docs/features/claude-code",
           "docs/features/queue",
           "docs/features/btw",
           "docs/features/worktrees",

--- a/website/src/docs/docs/features/claude-code.mdx
+++ b/website/src/docs/docs/features/claude-code.mdx
@@ -1,0 +1,61 @@
+---
+title: Claude Code Backend
+description: Run threads on Claude Code instead of OpenCode by picking a claude-code model, using your existing Claude subscription and .claude configuration.
+icon: lucide:sparkles
+---
+
+Kimaki can drive **Claude Code** as an alternative agent backend, powered by the official [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview). Each Discord thread becomes a real Claude Code session on your machine — the same agent you get in the `claude` terminal, with your `CLAUDE.md`, settings, skills, and subagents.
+
+## Switching a channel to Claude Code
+
+Claude Code appears as a regular provider in the model picker:
+
+1. Run **`/model`** in a channel (or thread).
+2. Pick the **Claude Code** provider.
+3. Pick a model (e.g. Claude Opus 4.8) and, optionally, an effort level.
+4. Choose the scope: this session, this channel, or global default.
+
+```diagram
+  /model ──▶ Claude Code ──▶ claude-opus-4-8 ──▶ high ──▶ channel
+                                                          │
+            new threads in this channel now run Claude Code
+```
+
+New sessions follow the model preference cascade (session → channel → global): if the effective model is a `claude-code/*` model, the thread runs on Claude Code; otherwise it runs on OpenCode. Existing threads keep their original backend — a session lives on one backend for its whole life.
+
+## Authentication
+
+Kimaki uses the same credentials as the `claude` CLI, in this order:
+
+- Your **Claude Pro/Max subscription** — run `claude` once in a terminal and log in.
+- An **`ANTHROPIC_API_KEY`** environment variable.
+
+No extra setup inside Kimaki: if Claude Code works in your terminal, it works in Discord. If authentication is missing, the first message in a Claude thread replies with an error explaining what to configure.
+
+## What works
+
+Claude Code threads support the full Kimaki feature set:
+
+- **Streaming replies** — text, thinking, and tool calls render live, exactly like OpenCode threads.
+- **Permissions** — bash/edit/web requests show the usual **Accept / Accept Always / Deny** buttons. *Accept Always* persists an allow rule for the session (e.g. `git *`).
+- **Questions** — Claude's `AskUserQuestion` renders as Discord dropdowns.
+- **Model & effort switching** — `/model` mid-thread switches between Claude models; effort levels (`low` → `max`) map to Kimaki's model variants.
+- **Queue, interrupts, btw** — messages interrupt after ~3s like always; `. queue` waits for the run to finish.
+- **Images & PDFs** — attachments are sent as native content blocks.
+- **`/compact`** — compacts the Claude session context.
+- **`/fork`**, **`/abort`**, **`/undo`** (file rewind via Claude Code checkpointing).
+- **Resume** — session transcripts persist under `~/.claude`; threads reconnect after a bot restart.
+- **Worktrees** — `/new-worktree` and `/merge-worktree` work unchanged.
+- **Diff summaries and cost footers** — per-turn diffs and token/cost usage.
+- **Discord tools** — Claude can call `kimaki_file_upload` and `kimaki_action_buttons`, served over an in-process MCP server.
+- **`CLAUDE.md` & project settings** — user, project, and local setting sources load exactly like the terminal `claude`.
+
+## What's different from OpenCode threads
+
+- **`/login` is not needed** — authentication comes from the Claude Code CLI login or the environment.
+- **Custom slash commands** from `.claude/commands` aren't registered as Discord commands yet; type them as a normal message (e.g. `/review`) and Claude Code picks them up from the prompt text.
+- **Agent selection** (`/agent`) currently applies to OpenCode threads; Claude Code subagents are used automatically by the model via its Task tool.
+
+## How it works
+
+Kimaki routes all agent traffic through a small local router that speaks the OpenCode protocol. OpenCode sessions are proxied to the `opencode` server as before; Claude Code sessions are served in-process by the Claude Agent SDK, with messages translated onto the same wire format. That is why every existing feature — formatting, permissions, the queue, diff footers — behaves identically on both backends.


### PR DESCRIPTION
## What

Adds **Claude Code** as a second agent backend alongside OpenCode, powered by the official [`@anthropic-ai/claude-agent-sdk`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) (which bundles the Claude Code binary — no separate install).

Pick a **Claude Code** model in `/model` and new sessions in that channel run on Claude Code instead of OpenCode — using the user's existing Claude Code login (Pro/Max subscription or `ANTHROPIC_API_KEY`), their `CLAUDE.md`, `.claude` settings, skills, and subagents. Existing threads keep their original backend.

## How it works

Rather than fork the 4,400-line thread runtime, this routes **all** OpenCode SDK traffic through a small local **backend router** that speaks the OpenCode v2 wire protocol:

- `ses_claude_*` sessions are served **in-process** by the Agent SDK, with SDK messages translated onto OpenCode's `Message`/`Part`/`Event` shapes.
- Everything else is **transparently proxied** to the opencode server.
- `/global/event` is a merged SSE stream (opencode events + claude events).

Because the rest of kimaki still consumes one wire protocol, every existing feature keeps working on both backends with only ~200 lines changed in existing files.

## Feature coverage for Claude threads

Streaming text/thinking/tool rendering · permission **Accept / Accept Always / Deny** buttons with persisted always-rules (OpenCode last-match-wins semantics replicated over `canUseTool`) · `AskUserQuestion` → Discord dropdowns · model + effort switching mid-thread · interrupts & the queue · images/PDFs as native content blocks · `/compact` · `/fork` · revert via file checkpointing · resume across bot restarts (transcripts persist in `~/.claude`, wire history rehydrates from them) · per-turn git diff summaries · cost/token footers · worktrees · and the `kimaki_file_upload` / `kimaki_action_buttons` tools served to Claude over an in-process MCP server. Idle sessions release their subprocess after 10 minutes and resume seamlessly.

## Files

New backend lives in `cli/src/claude-code/`:

| File | Role |
|---|---|
| `server.ts` | Backend router (OpenCode-protocol HTTP server + merged SSE + proxy) |
| `sessions.ts` | Session manager: one live `query()` per session, SDK↔OpenCode translation, permission/question bridges |
| `translate.ts` | Pure SDK-message → OpenCode wire translation + transcript hydration |
| `permission-map.ts` | Claude tool calls → OpenCode permission descriptors + ruleset evaluation |
| `models.ts` | Claude Code model catalog exposed as an OpenCode provider (effort → variants) |
| `kimaki-mcp.ts` | In-process MCP server for the Discord `kimaki_*` tools |
| `ids.ts` | Backend-tagged id helpers |

Existing files touched: `opencode.ts` (router lifecycle + backend routing), `thread-session-runtime.ts` (cross-backend model guard), `database.ts` (`getAnyGlobalModel`), `discord-bot.ts` (shutdown hook).

## Tests

`tsc` clean under strict mode. **33 new tests** pass, including a hermetic protocol e2e (`router.e2e.test.ts`) that drives the router with the **real** OpenCode SDK client and a scripted fake Agent SDK: create → prompt → events → permission round-trip → always-rule persistence → questions → abort → provider merge.

## Notes for review

- **Docs:** new *Claude Code Backend* feature page + nav entry, plus a `minor` changeset.
- **`pnpm-lock.yaml`:** purely additive (the `@anthropic-ai/*` entries only).
- **Known v1 limits** (documented): `.claude/commands` aren't registered as Discord slash commands yet (typing `/review` as a message works — Claude parses it from text); `/agent` remains OpenCode-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)