### PR TITLE
feat: local voice transcription — zero-setup built-in whisper, service lifecycle (CLI+Discord), reply-to-retry

### DIFF
--- a/cli/src/cli-commands/whisper.ts
+++ b/cli/src/cli-commands/whisper.ts
@@ -1,137 +1,23 @@
-// Local voice-transcription service lifecycle commands.
-//
-// Kimaki can transcribe Discord voice notes through a LOCAL OpenAI-compatible
-// server instead of the paid Gemini/OpenAI cloud (set OPENAI_BASE_URL at it).
-// These commands manage that local service's lifecycle so users can spin it up
-// on demand and free the GPU when idle, without juggling separate terminals.
+// Local voice-transcription service lifecycle commands (CLI).
 //
 //   kimaki whisper start    launch the configured local transcription service
 //   kimaki whisper stop     stop it (frees GPU/RAM)
 //   kimaki whisper status   report whether it is running + healthy
 //
-// The service is generic: any command that exposes an OpenAI-compatible endpoint
-// works (e.g. a Whisper shim, speaches, faster-whisper-server, whisper.cpp).
-// Config lives at <data-dir>/whisper.json; sensible defaults require no setup
-// for the common "shim on :7070" case.
+// Thin wrapper over ../whisper-service.js, shared with the Discord `/whisper-*`
+// slash commands.
 import { goke } from 'goke'
 import { z } from 'zod'
-import * as errore from 'errore'
-import path from 'node:path'
-import fs from 'node:fs'
-import { spawn } from 'node:child_process'
 import { createLogger, LogPrefix } from '../logger.js'
-import { getDataDir } from '../config.js'
 import { EXIT_NO_RESTART } from '../cli-runner.js'
+import {
+  startWhisperService,
+  stopWhisperService,
+  getWhisperStatus,
+} from '../whisper-service.js'
 
 const cliLogger = createLogger(LogPrefix.VOICE)
 const cli = goke()
-
-class WhisperConfigError extends errore.createTaggedError({
-  name: 'WhisperConfigError',
-  message: 'Failed to $action whisper config at $path',
-}) {}
-
-class WhisperServiceError extends errore.createTaggedError({
-  name: 'WhisperServiceError',
-  message: '$reason',
-}) {}
-
-interface WhisperConfig {
-  /** Command to launch the local transcription service (run via a shell). */
-  command: string
-  /** Working directory to launch it from. Defaults to the data dir. */
-  cwd?: string
-  /** Health-check URL polled after start and by `status`. */
-  healthUrl: string
-  /** Seconds to wait for the health check to pass on start. */
-  startTimeoutSeconds: number
-}
-
-const DEFAULT_CONFIG: WhisperConfig = {
-  command: 'kimaki-whisper-shim',
-  healthUrl: 'http://localhost:7070/health',
-  startTimeoutSeconds: 60,
-}
-
-function configPath(): string {
-  return path.join(getDataDir(), 'whisper.json')
-}
-
-function pidPath(): string {
-  return path.join(getDataDir(), 'whisper.pid')
-}
-
-function loadConfig(): WhisperConfigError | WhisperConfig {
-  const file = configPath()
-  const raw = errore.try(
-    () => fs.readFileSync(file, 'utf-8'),
-    (e) => new WhisperConfigError({ action: 'read', path: file, cause: e }),
-  )
-  // No config file yet: use defaults (the common shim-on-7070 case).
-  if (raw instanceof Error) return { ...DEFAULT_CONFIG }
-
-  const parsed = errore.try(
-    () => JSON.parse(raw) as Partial<WhisperConfig>,
-    (e) => new WhisperConfigError({ action: 'parse', path: file, cause: e }),
-  )
-  if (parsed instanceof Error) return parsed
-
-  return { ...DEFAULT_CONFIG, ...parsed }
-}
-
-function saveConfig({ config }: { config: WhisperConfig }): WhisperConfigError | null {
-  const file = configPath()
-  const result = errore.try(
-    () => {
-      fs.mkdirSync(getDataDir(), { recursive: true })
-      fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
-    },
-    (e) => new WhisperConfigError({ action: 'write', path: file, cause: e }),
-  )
-  return result instanceof Error ? result : null
-}
-
-function readPid(): number | null {
-  const raw = errore.try(
-    () => fs.readFileSync(pidPath(), 'utf-8'),
-    (e) => new WhisperConfigError({ action: 'read pid for', path: pidPath(), cause: e }),
-  )
-  if (raw instanceof Error) return null
-  const pid = Number(raw.trim())
-  return Number.isInteger(pid) && pid > 0 ? pid : null
-}
-
-function isProcessAlive({ pid }: { pid: number }): boolean {
-  // signal 0 does not kill; it only checks the process exists and is signalable.
-  const result = errore.try(
-    () => process.kill(pid, 0),
-    (e) => new WhisperServiceError({ reason: `process ${pid} not signalable`, cause: e }),
-  )
-  return !(result instanceof Error)
-}
-
-async function isHealthy({ url }: { url: string }): Promise<boolean> {
-  const res = await fetch(url, {
-    signal: AbortSignal.timeout(4000),
-  }).catch((e) => new WhisperServiceError({ reason: 'health check failed', cause: e }))
-  if (res instanceof Error) return false
-  return res.ok
-}
-
-async function waitForHealthy({
-  url,
-  timeoutSeconds,
-}: {
-  url: string
-  timeoutSeconds: number
-}): Promise<boolean> {
-  const deadline = Date.now() + timeoutSeconds * 1000
-  while (Date.now() < deadline) {
-    if (await isHealthy({ url })) return true
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-  }
-  return false
-}
 
 cli
   .command('whisper start', 'Start the local voice-transcription service')
@@ -144,129 +30,46 @@ cli
   )
   .option(
     '--health-url [url]',
-    z
-      .string()
-      .optional()
-      .describe('Health-check URL (persists to whisper.json)'),
+    z.string().optional().describe('Health-check URL (persists to whisper.json)'),
   )
   .action(async (options: { command?: string; healthUrl?: string }) => {
-    const loaded = loadConfig()
-    if (loaded instanceof Error) {
-      cliLogger.error(loaded.message)
+    const result = await startWhisperService({
+      overrides: {
+        ...(options.command && { command: options.command }),
+        ...(options.healthUrl && { healthUrl: options.healthUrl }),
+      },
+    })
+    if (result instanceof Error) {
+      cliLogger.error(result.message)
       process.exit(EXIT_NO_RESTART)
     }
-
-    const config: WhisperConfig = {
-      ...loaded,
-      command: options.command ?? loaded.command,
-      healthUrl: options.healthUrl ?? loaded.healthUrl,
-    }
-
-    // Persist any overrides so the next start/stop uses the same settings.
-    if (options.command || options.healthUrl) {
-      const saved = saveConfig({ config })
-      if (saved instanceof Error) {
-        cliLogger.error(saved.message)
-        process.exit(EXIT_NO_RESTART)
-      }
-    }
-
-    // Already running? Report and exit success (idempotent start).
-    const existingPid = readPid()
-    if (existingPid !== null && isProcessAlive({ pid: existingPid })) {
-      const healthy = await isHealthy({ url: config.healthUrl })
+    if (result.status === 'already-running') {
       cliLogger.log(
-        `Whisper service already running (pid ${existingPid})${healthy ? ' and healthy' : ' (not yet healthy)'}`,
+        `Whisper service already running (pid ${result.pid})${result.healthy ? ' and healthy' : ' (not yet healthy)'}`,
       )
       process.exit(0)
     }
-
-    cliLogger.log(`Starting whisper service: ${config.command}`)
-    const child = spawn(config.command, {
-      shell: true,
-      cwd: config.cwd || getDataDir(),
-      stdio: 'ignore',
-      detached: true,
-    })
-
-    if (child.pid === undefined) {
-      cliLogger.error('Failed to spawn whisper service (no pid)')
-      process.exit(EXIT_NO_RESTART)
-    }
-    child.unref()
-
-    const saved = saveConfig({ config })
-    if (saved instanceof Error) {
-      cliLogger.warn(`Started but could not persist config: ${saved.message}`)
-    }
-    const wrotePid = errore.try(
-      () => fs.writeFileSync(pidPath(), String(child.pid)),
-      (e) => new WhisperConfigError({ action: 'write pid for', path: pidPath(), cause: e }),
-    )
-    if (wrotePid instanceof Error) {
-      cliLogger.warn(wrotePid.message)
-    }
-
-    const healthy = await waitForHealthy({
-      url: config.healthUrl,
-      timeoutSeconds: config.startTimeoutSeconds,
-    })
-    if (!healthy) {
-      cliLogger.error(
-        `Whisper service started (pid ${child.pid}) but did not become healthy within ${config.startTimeoutSeconds}s at ${config.healthUrl}. Check its logs.`,
-      )
-      process.exit(EXIT_NO_RESTART)
-    }
-
-    cliLogger.log(`Whisper service healthy (pid ${child.pid}) at ${config.healthUrl}`)
+    cliLogger.log(`Whisper service healthy (pid ${result.pid}) at ${result.healthUrl}`)
     process.exit(0)
   })
 
 cli
   .command('whisper stop', 'Stop the local voice-transcription service (frees GPU/RAM)')
   .action(async () => {
-    const pid = readPid()
-    if (pid === null) {
+    const result = stopWhisperService()
+    if (result instanceof Error) {
+      cliLogger.error(result.message)
+      process.exit(EXIT_NO_RESTART)
+    }
+    if (result.status === 'not-running') {
       cliLogger.log('No whisper service pid on record — nothing to stop')
       process.exit(0)
     }
-
-    if (!isProcessAlive({ pid })) {
-      cliLogger.log(`Whisper service (pid ${pid}) is not running — clearing stale pid`)
-      const removed = errore.try(
-        () => fs.rmSync(pidPath(), { force: true }),
-        (e) => new WhisperConfigError({ action: 'remove pid for', path: pidPath(), cause: e }),
-      )
-      if (removed instanceof Error) cliLogger.warn(removed.message)
+    if (result.status === 'stale-pid') {
+      cliLogger.log(`Whisper service (pid ${result.pid}) was not running — cleared stale pid`)
       process.exit(0)
     }
-
-    // Kill the whole process group (detached start makes the child a group
-    // leader), so a wrapper + its child service both stop. Fall back to a plain
-    // single-process kill if the group signal fails (e.g. not a group leader).
-    const killedGroup = errore.try(
-      () => process.kill(-pid, 'SIGTERM'),
-      (e) => new WhisperServiceError({ reason: `group kill failed for ${pid}`, cause: e }),
-    )
-    if (killedGroup instanceof Error) {
-      const killedSingle = errore.try(
-        () => process.kill(pid, 'SIGTERM'),
-        (e) => new WhisperServiceError({ reason: `failed to stop pid ${pid}`, cause: e }),
-      )
-      if (killedSingle instanceof Error) {
-        cliLogger.error(killedSingle.message)
-        process.exit(EXIT_NO_RESTART)
-      }
-    }
-
-    const removed = errore.try(
-      () => fs.rmSync(pidPath(), { force: true }),
-      (e) => new WhisperConfigError({ action: 'remove pid for', path: pidPath(), cause: e }),
-    )
-    if (removed instanceof Error) {
-      cliLogger.warn(removed.message)
-    }
-    cliLogger.log(`Stopped whisper service (pid ${pid})`)
+    cliLogger.log(`Stopped whisper service (pid ${result.pid})`)
     process.exit(0)
   })
 
@@ -274,33 +77,21 @@ cli
   .command('whisper status', 'Report whether the local transcription service is running')
   .option('--json', 'Output as JSON')
   .action(async (options: { json?: boolean }) => {
-    const loaded = loadConfig()
-    if (loaded instanceof Error) {
-      cliLogger.error(loaded.message)
+    const status = await getWhisperStatus()
+    if (status instanceof Error) {
+      cliLogger.error(status.message)
       process.exit(EXIT_NO_RESTART)
     }
-
-    const pid = readPid()
-    const running = pid !== null && isProcessAlive({ pid })
-    const healthy = running ? await isHealthy({ url: loaded.healthUrl }) : false
-
     if (options.json) {
-      process.stdout.write(
-        JSON.stringify(
-          { running, healthy, pid: running ? pid : null, healthUrl: loaded.healthUrl },
-          null,
-          2,
-        ) + '\n',
-      )
+      process.stdout.write(JSON.stringify(status, null, 2) + '\n')
       process.exit(0)
     }
-
-    if (!running) {
+    if (!status.running) {
       cliLogger.log('Whisper service: stopped')
       process.exit(0)
     }
     cliLogger.log(
-      `Whisper service: running (pid ${pid}) — ${healthy ? 'healthy' : 'NOT healthy'} at ${loaded.healthUrl}`,
+      `Whisper service: running (pid ${status.pid}) — ${status.healthy ? 'healthy' : 'NOT healthy'} at ${status.healthUrl}`,
     )
     process.exit(0)
   })

--- a/cli/src/cli-commands/whisper.ts
+++ b/cli/src/cli-commands/whisper.ts
@@ -1,0 +1,308 @@
+// Local voice-transcription service lifecycle commands.
+//
+// Kimaki can transcribe Discord voice notes through a LOCAL OpenAI-compatible
+// server instead of the paid Gemini/OpenAI cloud (set OPENAI_BASE_URL at it).
+// These commands manage that local service's lifecycle so users can spin it up
+// on demand and free the GPU when idle, without juggling separate terminals.
+//
+//   kimaki whisper start    launch the configured local transcription service
+//   kimaki whisper stop     stop it (frees GPU/RAM)
+//   kimaki whisper status   report whether it is running + healthy
+//
+// The service is generic: any command that exposes an OpenAI-compatible endpoint
+// works (e.g. a Whisper shim, speaches, faster-whisper-server, whisper.cpp).
+// Config lives at <data-dir>/whisper.json; sensible defaults require no setup
+// for the common "shim on :7070" case.
+import { goke } from 'goke'
+import { z } from 'zod'
+import * as errore from 'errore'
+import path from 'node:path'
+import fs from 'node:fs'
+import { spawn } from 'node:child_process'
+import { createLogger, LogPrefix } from '../logger.js'
+import { getDataDir } from '../config.js'
+import { EXIT_NO_RESTART } from '../cli-runner.js'
+
+const cliLogger = createLogger(LogPrefix.VOICE)
+const cli = goke()
+
+class WhisperConfigError extends errore.createTaggedError({
+  name: 'WhisperConfigError',
+  message: 'Failed to $action whisper config at $path',
+}) {}
+
+class WhisperServiceError extends errore.createTaggedError({
+  name: 'WhisperServiceError',
+  message: '$reason',
+}) {}
+
+interface WhisperConfig {
+  /** Command to launch the local transcription service (run via a shell). */
+  command: string
+  /** Working directory to launch it from. Defaults to the data dir. */
+  cwd?: string
+  /** Health-check URL polled after start and by `status`. */
+  healthUrl: string
+  /** Seconds to wait for the health check to pass on start. */
+  startTimeoutSeconds: number
+}
+
+const DEFAULT_CONFIG: WhisperConfig = {
+  command: 'kimaki-whisper-shim',
+  healthUrl: 'http://localhost:7070/health',
+  startTimeoutSeconds: 60,
+}
+
+function configPath(): string {
+  return path.join(getDataDir(), 'whisper.json')
+}
+
+function pidPath(): string {
+  return path.join(getDataDir(), 'whisper.pid')
+}
+
+function loadConfig(): WhisperConfigError | WhisperConfig {
+  const file = configPath()
+  const raw = errore.try(
+    () => fs.readFileSync(file, 'utf-8'),
+    (e) => new WhisperConfigError({ action: 'read', path: file, cause: e }),
+  )
+  // No config file yet: use defaults (the common shim-on-7070 case).
+  if (raw instanceof Error) return { ...DEFAULT_CONFIG }
+
+  const parsed = errore.try(
+    () => JSON.parse(raw) as Partial<WhisperConfig>,
+    (e) => new WhisperConfigError({ action: 'parse', path: file, cause: e }),
+  )
+  if (parsed instanceof Error) return parsed
+
+  return { ...DEFAULT_CONFIG, ...parsed }
+}
+
+function saveConfig({ config }: { config: WhisperConfig }): WhisperConfigError | null {
+  const file = configPath()
+  const result = errore.try(
+    () => {
+      fs.mkdirSync(getDataDir(), { recursive: true })
+      fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
+    },
+    (e) => new WhisperConfigError({ action: 'write', path: file, cause: e }),
+  )
+  return result instanceof Error ? result : null
+}
+
+function readPid(): number | null {
+  const raw = errore.try(
+    () => fs.readFileSync(pidPath(), 'utf-8'),
+    (e) => new WhisperConfigError({ action: 'read pid for', path: pidPath(), cause: e }),
+  )
+  if (raw instanceof Error) return null
+  const pid = Number(raw.trim())
+  return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+function isProcessAlive({ pid }: { pid: number }): boolean {
+  // signal 0 does not kill; it only checks the process exists and is signalable.
+  const result = errore.try(
+    () => process.kill(pid, 0),
+    (e) => new WhisperServiceError({ reason: `process ${pid} not signalable`, cause: e }),
+  )
+  return !(result instanceof Error)
+}
+
+async function isHealthy({ url }: { url: string }): Promise<boolean> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(4000),
+  }).catch((e) => new WhisperServiceError({ reason: 'health check failed', cause: e }))
+  if (res instanceof Error) return false
+  return res.ok
+}
+
+async function waitForHealthy({
+  url,
+  timeoutSeconds,
+}: {
+  url: string
+  timeoutSeconds: number
+}): Promise<boolean> {
+  const deadline = Date.now() + timeoutSeconds * 1000
+  while (Date.now() < deadline) {
+    if (await isHealthy({ url })) return true
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  return false
+}
+
+cli
+  .command('whisper start', 'Start the local voice-transcription service')
+  .option(
+    '--command [command]',
+    z
+      .string()
+      .optional()
+      .describe('Command to launch the service (persists to whisper.json)'),
+  )
+  .option(
+    '--health-url [url]',
+    z
+      .string()
+      .optional()
+      .describe('Health-check URL (persists to whisper.json)'),
+  )
+  .action(async (options: { command?: string; healthUrl?: string }) => {
+    const loaded = loadConfig()
+    if (loaded instanceof Error) {
+      cliLogger.error(loaded.message)
+      process.exit(EXIT_NO_RESTART)
+    }
+
+    const config: WhisperConfig = {
+      ...loaded,
+      command: options.command ?? loaded.command,
+      healthUrl: options.healthUrl ?? loaded.healthUrl,
+    }
+
+    // Persist any overrides so the next start/stop uses the same settings.
+    if (options.command || options.healthUrl) {
+      const saved = saveConfig({ config })
+      if (saved instanceof Error) {
+        cliLogger.error(saved.message)
+        process.exit(EXIT_NO_RESTART)
+      }
+    }
+
+    // Already running? Report and exit success (idempotent start).
+    const existingPid = readPid()
+    if (existingPid !== null && isProcessAlive({ pid: existingPid })) {
+      const healthy = await isHealthy({ url: config.healthUrl })
+      cliLogger.log(
+        `Whisper service already running (pid ${existingPid})${healthy ? ' and healthy' : ' (not yet healthy)'}`,
+      )
+      process.exit(0)
+    }
+
+    cliLogger.log(`Starting whisper service: ${config.command}`)
+    const child = spawn(config.command, {
+      shell: true,
+      cwd: config.cwd || getDataDir(),
+      stdio: 'ignore',
+      detached: true,
+    })
+
+    if (child.pid === undefined) {
+      cliLogger.error('Failed to spawn whisper service (no pid)')
+      process.exit(EXIT_NO_RESTART)
+    }
+    child.unref()
+
+    const saved = saveConfig({ config })
+    if (saved instanceof Error) {
+      cliLogger.warn(`Started but could not persist config: ${saved.message}`)
+    }
+    const wrotePid = errore.try(
+      () => fs.writeFileSync(pidPath(), String(child.pid)),
+      (e) => new WhisperConfigError({ action: 'write pid for', path: pidPath(), cause: e }),
+    )
+    if (wrotePid instanceof Error) {
+      cliLogger.warn(wrotePid.message)
+    }
+
+    const healthy = await waitForHealthy({
+      url: config.healthUrl,
+      timeoutSeconds: config.startTimeoutSeconds,
+    })
+    if (!healthy) {
+      cliLogger.error(
+        `Whisper service started (pid ${child.pid}) but did not become healthy within ${config.startTimeoutSeconds}s at ${config.healthUrl}. Check its logs.`,
+      )
+      process.exit(EXIT_NO_RESTART)
+    }
+
+    cliLogger.log(`Whisper service healthy (pid ${child.pid}) at ${config.healthUrl}`)
+    process.exit(0)
+  })
+
+cli
+  .command('whisper stop', 'Stop the local voice-transcription service (frees GPU/RAM)')
+  .action(async () => {
+    const pid = readPid()
+    if (pid === null) {
+      cliLogger.log('No whisper service pid on record — nothing to stop')
+      process.exit(0)
+    }
+
+    if (!isProcessAlive({ pid })) {
+      cliLogger.log(`Whisper service (pid ${pid}) is not running — clearing stale pid`)
+      const removed = errore.try(
+        () => fs.rmSync(pidPath(), { force: true }),
+        (e) => new WhisperConfigError({ action: 'remove pid for', path: pidPath(), cause: e }),
+      )
+      if (removed instanceof Error) cliLogger.warn(removed.message)
+      process.exit(0)
+    }
+
+    // Kill the whole process group (detached start makes the child a group
+    // leader), so a wrapper + its child service both stop. Fall back to a plain
+    // single-process kill if the group signal fails (e.g. not a group leader).
+    const killedGroup = errore.try(
+      () => process.kill(-pid, 'SIGTERM'),
+      (e) => new WhisperServiceError({ reason: `group kill failed for ${pid}`, cause: e }),
+    )
+    if (killedGroup instanceof Error) {
+      const killedSingle = errore.try(
+        () => process.kill(pid, 'SIGTERM'),
+        (e) => new WhisperServiceError({ reason: `failed to stop pid ${pid}`, cause: e }),
+      )
+      if (killedSingle instanceof Error) {
+        cliLogger.error(killedSingle.message)
+        process.exit(EXIT_NO_RESTART)
+      }
+    }
+
+    const removed = errore.try(
+      () => fs.rmSync(pidPath(), { force: true }),
+      (e) => new WhisperConfigError({ action: 'remove pid for', path: pidPath(), cause: e }),
+    )
+    if (removed instanceof Error) {
+      cliLogger.warn(removed.message)
+    }
+    cliLogger.log(`Stopped whisper service (pid ${pid})`)
+    process.exit(0)
+  })
+
+cli
+  .command('whisper status', 'Report whether the local transcription service is running')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    const loaded = loadConfig()
+    if (loaded instanceof Error) {
+      cliLogger.error(loaded.message)
+      process.exit(EXIT_NO_RESTART)
+    }
+
+    const pid = readPid()
+    const running = pid !== null && isProcessAlive({ pid })
+    const healthy = running ? await isHealthy({ url: loaded.healthUrl }) : false
+
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          { running, healthy, pid: running ? pid : null, healthUrl: loaded.healthUrl },
+          null,
+          2,
+        ) + '\n',
+      )
+      process.exit(0)
+    }
+
+    if (!running) {
+      cliLogger.log('Whisper service: stopped')
+      process.exit(0)
+    }
+    cliLogger.log(
+      `Whisper service: running (pid ${pid}) — ${healthy ? 'healthy' : 'NOT healthy'} at ${loaded.healthUrl}`,
+    )
+    process.exit(0)
+  })
+
+export default cli

--- a/cli/src/cli-commands/whisper.ts
+++ b/cli/src/cli-commands/whisper.ts
@@ -1,32 +1,120 @@
 // Local voice-transcription service lifecycle commands (CLI).
 //
-//   kimaki whisper start    launch the configured local transcription service
+//   kimaki whisper setup    interactively pick + wire a local transcription service
+//   kimaki whisper start    launch the configured service
 //   kimaki whisper stop     stop it (frees GPU/RAM)
-//   kimaki whisper status   report whether it is running + healthy
+//   kimaki whisper status   report configured / running / healthy
 //
 // Thin wrapper over ../whisper-service.js, shared with the Discord `/whisper-*`
 // slash commands.
 import { goke } from 'goke'
 import { z } from 'zod'
+import * as clack from '@clack/prompts'
 import { createLogger, LogPrefix } from '../logger.js'
 import { EXIT_NO_RESTART } from '../cli-runner.js'
 import {
   startWhisperService,
   stopWhisperService,
   getWhisperStatus,
+  setupWhisperService,
+  WHISPER_BACKEND_PRESETS,
 } from '../whisper-service.js'
 
 const cliLogger = createLogger(LogPrefix.VOICE)
 const cli = goke()
 
 cli
+  .command('whisper setup', 'Pick and wire a local voice-transcription service')
+  .option(
+    '--command [command]',
+    z.string().optional().describe('Launch command (skips the interactive picker)'),
+  )
+  .option(
+    '--health-url [url]',
+    z.string().optional().describe('Health-check URL for the service'),
+  )
+  .action(async (options: { command?: string; healthUrl?: string }) => {
+    // Non-interactive path: both flags provided (or a TTY-less shell).
+    const nonInteractive = !process.stdin.isTTY
+
+    const chosen = await (async (): Promise<{ command: string; healthUrl: string } | null> => {
+      if (options.command) {
+        return {
+          command: options.command,
+          healthUrl: options.healthUrl ?? 'http://localhost:7070/health',
+        }
+      }
+      if (nonInteractive) {
+        cliLogger.error(
+          'kimaki whisper setup needs a TTY, or pass --command <cmd> [--health-url <url>].',
+        )
+        cliLogger.error(
+          'Presets: ' +
+            WHISPER_BACKEND_PRESETS.map((p) => `${p.id} (${p.requires})`).join('; '),
+        )
+        process.exit(EXIT_NO_RESTART)
+      }
+
+      const pick = await clack.select({
+        message: 'Which local transcription backend do you want Kimaki to manage?',
+        options: [
+          ...WHISPER_BACKEND_PRESETS.map((p) => ({
+            value: p.id,
+            label: p.label,
+            hint: `requires ${p.requires}`,
+          })),
+          { value: 'custom', label: 'Custom command', hint: 'paste your own' },
+        ],
+      })
+      if (clack.isCancel(pick)) return null
+
+      if (pick === 'custom') {
+        const cmd = await clack.text({
+          message: 'Command to launch the service',
+          placeholder: 'e.g. uvicorn ... --port 8000 ...',
+        })
+        if (clack.isCancel(cmd)) return null
+        const url = await clack.text({
+          message: 'Health-check URL',
+          initialValue: 'http://localhost:8000/health',
+        })
+        if (clack.isCancel(url)) return null
+        return { command: cmd, healthUrl: url }
+      }
+
+      const preset = WHISPER_BACKEND_PRESETS.find((p) => p.id === pick)!
+      return { command: preset.command, healthUrl: preset.healthUrl }
+    })()
+
+    if (chosen === null) {
+      cliLogger.log('Setup cancelled')
+      process.exit(0)
+    }
+
+    const saved = setupWhisperService({
+      command: chosen.command,
+      healthUrl: chosen.healthUrl,
+    })
+    if (saved instanceof Error) {
+      cliLogger.error(saved.message)
+      process.exit(EXIT_NO_RESTART)
+    }
+
+    cliLogger.log(`Configured whisper service: ${saved.command}`)
+    cliLogger.log(`Health URL: ${saved.healthUrl}`)
+    cliLogger.log('')
+    cliLogger.log('Next steps:')
+    cliLogger.log('  1. Ensure the backend it launches is installed (see the presets/docs).')
+    cliLogger.log('  2. Point Kimaki at it:  OPENAI_BASE_URL=<your /v1 base>  (and any dummy OPENAI_API_KEY)')
+    cliLogger.log('  3. Start it:  kimaki whisper start   (or /whisper-start in Discord)')
+    process.exit(0)
+  })
+
+cli
   .command('whisper start', 'Start the local voice-transcription service')
   .option(
     '--command [command]',
-    z
-      .string()
-      .optional()
-      .describe('Command to launch the service (persists to whisper.json)'),
+    z.string().optional().describe('Command to launch the service (persists to whisper.json)'),
   )
   .option(
     '--health-url [url]',
@@ -84,6 +172,10 @@ cli
     }
     if (options.json) {
       process.stdout.write(JSON.stringify(status, null, 2) + '\n')
+      process.exit(0)
+    }
+    if (!status.configured) {
+      cliLogger.log('Whisper service: not configured — run `kimaki whisper setup`')
       process.exit(0)
     }
     if (!status.running) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -25,6 +25,7 @@ import sendCommands from './cli-commands/send.js'
 import sessionCommands from './cli-commands/session.js'
 import taskCommands from './cli-commands/task.js'
 import userCommands from './cli-commands/user.js'
+import whisperCommands from './cli-commands/whisper.js'
 import {
   EXIT_NO_RESTART,
   printDiscordInstallUrlAndExit,
@@ -373,6 +374,7 @@ cli.use(projectCommands)
 cli.use(userCommands)
 cli.use(sessionCommands)
 cli.use(maintenanceCommands)
+cli.use(whisperCommands)
 
 cli.version(getCurrentVersion())
 cli.help()

--- a/cli/src/commands/whisper.ts
+++ b/cli/src/commands/whisper.ts
@@ -20,7 +20,9 @@ export async function handleWhisperStartCommand({
   const result = await startWhisperService()
   if (result instanceof Error) {
     logger.error(`whisper start failed: ${result.message}`)
-    await command.editReply(`⚠️ Failed to start whisper service: ${result.message}`)
+    await command.editReply(
+      `⚠️ ${result.message}`,
+    )
     return
   }
   if (result.status === 'already-running') {
@@ -61,6 +63,12 @@ export async function handleWhisperStatusCommand({
   if (status instanceof Error) {
     logger.error(`whisper status failed: ${status.message}`)
     await command.editReply(`⚠️ Failed to read whisper status: ${status.message}`)
+    return
+  }
+  if (!status.configured) {
+    await command.editReply(
+      '🎤 Whisper service: **not configured** — run `kimaki whisper setup` in a terminal on the host first.',
+    )
     return
   }
   if (!status.running) {

--- a/cli/src/commands/whisper.ts
+++ b/cli/src/commands/whisper.ts
@@ -1,0 +1,73 @@
+// /whisper-start, /whisper-stop, /whisper-status Discord slash commands.
+// Control the local voice-transcription service from Discord (e.g. from a phone),
+// mirroring the `kimaki whisper` CLI commands. Shares logic via whisper-service.js.
+import { MessageFlags } from 'discord.js'
+import type { CommandContext } from './types.js'
+import { SILENT_MESSAGE_FLAGS } from '../discord-utils.js'
+import { createLogger, LogPrefix } from '../logger.js'
+import {
+  startWhisperService,
+  stopWhisperService,
+  getWhisperStatus,
+} from '../whisper-service.js'
+
+const logger = createLogger(LogPrefix.VOICE)
+
+export async function handleWhisperStartCommand({
+  command,
+}: CommandContext): Promise<void> {
+  await command.deferReply({ flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS })
+  const result = await startWhisperService()
+  if (result instanceof Error) {
+    logger.error(`whisper start failed: ${result.message}`)
+    await command.editReply(`⚠️ Failed to start whisper service: ${result.message}`)
+    return
+  }
+  if (result.status === 'already-running') {
+    await command.editReply(
+      `🎤 Whisper service already running (pid ${result.pid})${result.healthy ? ' and healthy' : ' — not yet healthy'}`,
+    )
+    return
+  }
+  await command.editReply(`🎤 Whisper service started (pid ${result.pid}) and healthy`)
+}
+
+export async function handleWhisperStopCommand({
+  command,
+}: CommandContext): Promise<void> {
+  await command.deferReply({ flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS })
+  const result = stopWhisperService()
+  if (result instanceof Error) {
+    logger.error(`whisper stop failed: ${result.message}`)
+    await command.editReply(`⚠️ Failed to stop whisper service: ${result.message}`)
+    return
+  }
+  if (result.status === 'not-running') {
+    await command.editReply('Whisper service is not running — nothing to stop')
+    return
+  }
+  if (result.status === 'stale-pid') {
+    await command.editReply(`Whisper service (pid ${result.pid}) was not running — cleared stale pid`)
+    return
+  }
+  await command.editReply(`🛑 Stopped whisper service (pid ${result.pid}) — GPU/RAM freed`)
+}
+
+export async function handleWhisperStatusCommand({
+  command,
+}: CommandContext): Promise<void> {
+  await command.deferReply({ flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS })
+  const status = await getWhisperStatus()
+  if (status instanceof Error) {
+    logger.error(`whisper status failed: ${status.message}`)
+    await command.editReply(`⚠️ Failed to read whisper status: ${status.message}`)
+    return
+  }
+  if (!status.running) {
+    await command.editReply('🎤 Whisper service: **stopped**')
+    return
+  }
+  await command.editReply(
+    `🎤 Whisper service: **running** (pid ${status.pid}) — ${status.healthy ? 'healthy ✅' : 'NOT healthy ⚠️'} at ${status.healthUrl}`,
+  )
+}

--- a/cli/src/commands/whisper.ts
+++ b/cli/src/commands/whisper.ts
@@ -16,6 +16,8 @@ import {
 import {
   getLocalWhisperModelById,
   prepareLocalWhisperModel,
+  detectWhisperEnvironment,
+  recommendLocalWhisperModel,
 } from '../whisper-local.js'
 
 const logger = createLogger(LogPrefix.VOICE)
@@ -44,10 +46,19 @@ export async function handleWhisperSetupCommand({
       return
     }
 
-    const model = getLocalWhisperModelById(modelChoice)
+    // 'auto' resolves to the best tier for this machine's RAM/CPU.
+    const autoPick = modelChoice === 'auto'
+      ? recommendLocalWhisperModel(await detectWhisperEnvironment())
+      : null
+    const model = autoPick?.model ?? getLocalWhisperModelById(modelChoice)
     if (!model) {
       await command.editReply(`⚠️ Unknown model: ${modelChoice}`)
       return
+    }
+    if (autoPick) {
+      await command.editReply(
+        `🎤 Auto-selected **${model.label}** for this machine — ${autoPick.reason}.`,
+      )
     }
 
     await command.editReply(
@@ -110,9 +121,25 @@ export async function handleWhisperSetupCommand({
   }
 
   if (lines.length === 0) {
-    await command.editReply(
-      'Nothing to configure. Pass `backend` (or a custom `command`) to set the managed service, and/or `transcription-url` to route voice notes to a local OpenAI-compatible endpoint.',
-    )
+    // Bare invocation: report the environment and recommend a model, so a
+    // non-technical user learns exactly what to pick without leaving Discord.
+    const env = await detectWhisperEnvironment()
+    const rec = recommendLocalWhisperModel(env)
+    const report = [
+      '🎤 **Local transcription setup**',
+      '',
+      `**This machine:** ${env.platform}/${env.arch}, ${env.cpuCores} cores, ${env.totalMemGb} GB RAM${env.nvidiaGpu ? `, ${env.nvidiaGpu}` : ''}${env.appleSilicon ? ' (Apple Silicon)' : ''}`,
+      `**Recommended:** \`${rec.model.label}\` (${rec.model.approxSize} one-time download) — ${rec.reason}.`,
+      '',
+      `Run \`/whisper-setup model: Auto\` to set it up — Kimaki downloads and runs everything automatically. No keys, services, or URLs needed; audio never leaves this machine.`,
+      ...(env.nvidiaGpu
+        ? [
+            '',
+            `💡 With your ${env.nvidiaGpu}, the advanced \`backend\` options can run even larger GPU-accelerated models (e.g. faster-whisper large-v3) — for technical users.`,
+          ]
+        : []),
+    ]
+    await command.editReply(report.join('\n'))
     return
   }
 

--- a/cli/src/commands/whisper.ts
+++ b/cli/src/commands/whisper.ts
@@ -5,7 +5,7 @@ import { MessageFlags } from 'discord.js'
 import type { CommandContext } from './types.js'
 import { SILENT_MESSAGE_FLAGS } from '../discord-utils.js'
 import { createLogger, LogPrefix } from '../logger.js'
-import { setOpenAIBaseUrl } from '../database.js'
+import { setOpenAIBaseUrl, setLocalWhisperModel } from '../database.js'
 import {
   startWhisperService,
   stopWhisperService,
@@ -13,6 +13,10 @@ import {
   setupWhisperService,
   WHISPER_BACKEND_PRESETS,
 } from '../whisper-service.js'
+import {
+  getLocalWhisperModelById,
+  prepareLocalWhisperModel,
+} from '../whisper-local.js'
 
 const logger = createLogger(LogPrefix.VOICE)
 
@@ -22,10 +26,61 @@ export async function handleWhisperSetupCommand({
 }: CommandContext): Promise<void> {
   await command.deferReply({ flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS })
 
+  const modelChoice = command.options.getString('model')
   const backend = command.options.getString('backend')
   const customCommand = command.options.getString('command')
   const healthUrlOption = command.options.getString('health-url')
   const transcriptionUrl = command.options.getString('transcription-url')
+
+  // ── Zero-setup path: built-in local model (recommended for most users) ──
+  // Downloads and runs an ONNX whisper model in-process; nothing to install
+  // or configure. Everything else in this command is the advanced path.
+  if (modelChoice) {
+    if (modelChoice === 'off') {
+      await setLocalWhisperModel(appId, null)
+      await command.editReply(
+        '🎤 Built-in local transcription **disabled**. Voice notes use your cloud key / configured service again.',
+      )
+      return
+    }
+
+    const model = getLocalWhisperModelById(modelChoice)
+    if (!model) {
+      await command.editReply(`⚠️ Unknown model: ${modelChoice}`)
+      return
+    }
+
+    await command.editReply(
+      `🎤 Setting up built-in transcription — **${model.label}** (one-time download ${model.approxSize})…`,
+    )
+
+    let lastEdit = 0
+    const prepared = await prepareLocalWhisperModel({
+      modelId: model.id,
+      onProgress: (message) => {
+        // Throttle Discord edits to avoid rate limits during multi-file downloads.
+        const now = Date.now()
+        if (now - lastEdit < 2500) return
+        lastEdit = now
+        void command
+          .editReply(`🎤 Setting up **${model.label}**… ${message}`)
+          .catch(() => {})
+      },
+    })
+    if (prepared instanceof Error) {
+      logger.error(`local whisper setup failed: ${prepared.message}`)
+      await command.editReply(
+        `⚠️ Setup failed: ${prepared.message}\nNothing was changed — try again, or use a cloud key via /transcription-key.`,
+      )
+      return
+    }
+
+    await setLocalWhisperModel(appId, model.id)
+    await command.editReply(
+      `✅ Built-in local transcription ready — **${model.label}**.\nSend a voice note to try it. No API keys, services, or URLs needed; audio never leaves this machine.`,
+    )
+    return
+  }
 
   const preset = backend && backend !== 'custom'
     ? WHISPER_BACKEND_PRESETS.find((p) => p.id === backend)

--- a/cli/src/commands/whisper.ts
+++ b/cli/src/commands/whisper.ts
@@ -5,13 +5,66 @@ import { MessageFlags } from 'discord.js'
 import type { CommandContext } from './types.js'
 import { SILENT_MESSAGE_FLAGS } from '../discord-utils.js'
 import { createLogger, LogPrefix } from '../logger.js'
+import { setOpenAIBaseUrl } from '../database.js'
 import {
   startWhisperService,
   stopWhisperService,
   getWhisperStatus,
+  setupWhisperService,
+  WHISPER_BACKEND_PRESETS,
 } from '../whisper-service.js'
 
 const logger = createLogger(LogPrefix.VOICE)
+
+export async function handleWhisperSetupCommand({
+  command,
+  appId,
+}: CommandContext): Promise<void> {
+  await command.deferReply({ flags: MessageFlags.Ephemeral | SILENT_MESSAGE_FLAGS })
+
+  const backend = command.options.getString('backend')
+  const customCommand = command.options.getString('command')
+  const healthUrlOption = command.options.getString('health-url')
+  const transcriptionUrl = command.options.getString('transcription-url')
+
+  const preset = backend && backend !== 'custom'
+    ? WHISPER_BACKEND_PRESETS.find((p) => p.id === backend)
+    : undefined
+
+  const launchCommand = customCommand ?? preset?.command
+  const healthUrl = healthUrlOption ?? preset?.healthUrl ?? 'http://localhost:7070/health'
+
+  const lines: string[] = []
+
+  if (launchCommand) {
+    const saved = setupWhisperService({ command: launchCommand, healthUrl })
+    if (saved instanceof Error) {
+      logger.error(`whisper setup failed: ${saved.message}`)
+      await command.editReply(`⚠️ Failed to save whisper config: ${saved.message}`)
+      return
+    }
+    lines.push(`🎤 Whisper service configured:`)
+    lines.push(`- **Launch command:** \`${saved.command}\``)
+    lines.push(`- **Health URL:** ${saved.healthUrl}`)
+    if (preset) lines.push(`- **Requires:** ${preset.requires}`)
+  }
+
+  if (transcriptionUrl) {
+    await setOpenAIBaseUrl(appId, transcriptionUrl)
+    lines.push(`- **Transcription URL:** ${transcriptionUrl} (voice notes now route here — no env vars needed)`)
+  }
+
+  if (lines.length === 0) {
+    await command.editReply(
+      'Nothing to configure. Pass `backend` (or a custom `command`) to set the managed service, and/or `transcription-url` to route voice notes to a local OpenAI-compatible endpoint.',
+    )
+    return
+  }
+
+  lines.push('')
+  lines.push(launchCommand ? 'Start it with `/whisper-start`.' : 'Send a voice note to test.')
+  await command.editReply(lines.join('\n'))
+}
 
 export async function handleWhisperStartCommand({
   command,

--- a/cli/src/database.ts
+++ b/cli/src/database.ts
@@ -736,11 +736,30 @@ export async function setOpenAIApiKey(appId: string, apiKey: string) {
     .onConflictDoUpdate({ target: schema.bot_api_keys.app_id, set: { openai_api_key: apiKey } })
 }
 
-export async function getTranscriptionApiKey(appId: string): Promise<{ provider: 'openai' | 'gemini'; apiKey: string } | null> {
+export async function setOpenAIBaseUrl(appId: string, baseUrl: string | null) {
+  const db = await getDb()
+  await db.insert(schema.bot_api_keys)
+    .values({ app_id: appId, openai_base_url: baseUrl })
+    .onConflictDoUpdate({ target: schema.bot_api_keys.app_id, set: { openai_base_url: baseUrl } })
+}
+
+export async function getTranscriptionApiKey(appId: string): Promise<{ provider: 'openai' | 'gemini'; apiKey: string; baseUrl?: string } | null> {
   const db = await getDb()
   const row = await db.query.bot_api_keys.findFirst({ where: { app_id: appId } })
   if (!row) return null
-  if (row.openai_api_key) return { provider: 'openai', apiKey: row.openai_api_key }
+  if (row.openai_api_key) {
+    return {
+      provider: 'openai',
+      apiKey: row.openai_api_key,
+      ...(row.openai_base_url && { baseUrl: row.openai_base_url }),
+    }
+  }
+  // A stored base URL implies a local OpenAI-compatible service that usually
+  // needs no real key — allow transcription with a placeholder key so pure
+  // Discord onboarding (no env vars) works.
+  if (row.openai_base_url) {
+    return { provider: 'openai', apiKey: 'local', baseUrl: row.openai_base_url }
+  }
   if (row.gemini_api_key) return { provider: 'gemini', apiKey: row.gemini_api_key }
   return null
 }

--- a/cli/src/database.ts
+++ b/cli/src/database.ts
@@ -736,6 +736,19 @@ export async function setOpenAIApiKey(appId: string, apiKey: string) {
     .onConflictDoUpdate({ target: schema.bot_api_keys.app_id, set: { openai_api_key: apiKey } })
 }
 
+export async function getLocalWhisperModel(appId: string): Promise<string | null> {
+  const db = await getDb()
+  const row = await db.query.bot_api_keys.findFirst({ where: { app_id: appId } })
+  return row?.transcription_local_model ?? null
+}
+
+export async function setLocalWhisperModel(appId: string, modelId: string | null) {
+  const db = await getDb()
+  await db.insert(schema.bot_api_keys)
+    .values({ app_id: appId, transcription_local_model: modelId })
+    .onConflictDoUpdate({ target: schema.bot_api_keys.app_id, set: { transcription_local_model: modelId } })
+}
+
 export async function setOpenAIBaseUrl(appId: string, baseUrl: string | null) {
   const db = await getDb()
   await db.insert(schema.bot_api_keys)

--- a/cli/src/db.ts
+++ b/cli/src/db.ts
@@ -152,6 +152,7 @@ async function migrateSchema({
     'ALTER TABLE global_models ADD COLUMN variant TEXT',
     'ALTER TABLE bot_api_keys ADD COLUMN openai_api_key TEXT',
     'ALTER TABLE bot_api_keys ADD COLUMN openai_base_url TEXT',
+    'ALTER TABLE bot_api_keys ADD COLUMN transcription_local_model TEXT',
     "ALTER TABLE bot_tokens ADD COLUMN bot_mode TEXT DEFAULT 'self_hosted'",
     'ALTER TABLE bot_tokens ADD COLUMN client_id TEXT',
     'ALTER TABLE bot_tokens ADD COLUMN client_secret TEXT',

--- a/cli/src/db.ts
+++ b/cli/src/db.ts
@@ -151,6 +151,7 @@ async function migrateSchema({
     'ALTER TABLE session_models ADD COLUMN variant TEXT',
     'ALTER TABLE global_models ADD COLUMN variant TEXT',
     'ALTER TABLE bot_api_keys ADD COLUMN openai_api_key TEXT',
+    'ALTER TABLE bot_api_keys ADD COLUMN openai_base_url TEXT',
     "ALTER TABLE bot_tokens ADD COLUMN bot_mode TEXT DEFAULT 'self_hosted'",
     'ALTER TABLE bot_tokens ADD COLUMN client_id TEXT',
     'ALTER TABLE bot_tokens ADD COLUMN client_secret TEXT',

--- a/cli/src/discord-command-registration.ts
+++ b/cli/src/discord-command-registration.ts
@@ -463,12 +463,24 @@ export async function registerCommands({
     new SlashCommandBuilder()
       .setName('whisper-setup')
       .setDescription(
-        truncateCommandDescription('Configure a local voice-transcription service (backend, launch command, routing)'),
+        truncateCommandDescription('Set up local voice transcription — pick a model and Kimaki handles the rest'),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('model')
+          .setDescription('Built-in local model — downloads and runs automatically, zero setup (recommended)')
+          .setRequired(false)
+          .addChoices(
+            { name: 'Fast — quickest, ~110 MB download', value: 'fast' },
+            { name: 'Balanced — recommended, ~200 MB download', value: 'balanced' },
+            { name: 'Accurate — best quality, ~600 MB download', value: 'accurate' },
+            { name: 'Off — go back to cloud transcription', value: 'off' },
+          ),
       )
       .addStringOption((option) =>
         option
           .setName('backend')
-          .setDescription('Which local transcription backend to manage')
+          .setDescription('Advanced: manage a self-hosted transcription backend instead')
           .setRequired(false)
           .addChoices(
             { name: 'Kimaki Whisper shim (chat-audio bridge)', value: 'shim' },

--- a/cli/src/discord-command-registration.ts
+++ b/cli/src/discord-command-registration.ts
@@ -471,9 +471,11 @@ export async function registerCommands({
           .setDescription('Built-in local model — downloads and runs automatically, zero setup (recommended)')
           .setRequired(false)
           .addChoices(
+            { name: 'Auto — pick the best model for this machine (recommended)', value: 'auto' },
             { name: 'Fast — quickest, ~110 MB download', value: 'fast' },
-            { name: 'Balanced — recommended, ~200 MB download', value: 'balanced' },
-            { name: 'Accurate — best quality, ~600 MB download', value: 'accurate' },
+            { name: 'Balanced — good accuracy, ~200 MB download', value: 'balanced' },
+            { name: 'Accurate — better accuracy, ~600 MB download', value: 'accurate' },
+            { name: 'Best — large-v3-turbo, ~1 GB, needs 16 GB+ RAM', value: 'best' },
             { name: 'Off — go back to cloud transcription', value: 'off' },
           ),
       )

--- a/cli/src/discord-command-registration.ts
+++ b/cli/src/discord-command-registration.ts
@@ -460,6 +460,21 @@ export async function registerCommands({
       )
       .setDMPermission(false)
       .toJSON(),
+    new SlashCommandBuilder()
+      .setName('whisper-start')
+      .setDescription(truncateCommandDescription('Start the local voice-transcription service'))
+      .setDMPermission(false)
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName('whisper-stop')
+      .setDescription(truncateCommandDescription('Stop the local voice-transcription service (frees GPU/RAM)'))
+      .setDMPermission(false)
+      .toJSON(),
+    new SlashCommandBuilder()
+      .setName('whisper-status')
+      .setDescription(truncateCommandDescription('Report whether the local voice-transcription service is running'))
+      .setDMPermission(false)
+      .toJSON(),
   ]
 
   // Dynamic commands are registered in priority order:

--- a/cli/src/discord-command-registration.ts
+++ b/cli/src/discord-command-registration.ts
@@ -461,6 +461,43 @@ export async function registerCommands({
       .setDMPermission(false)
       .toJSON(),
     new SlashCommandBuilder()
+      .setName('whisper-setup')
+      .setDescription(
+        truncateCommandDescription('Configure a local voice-transcription service (backend, launch command, routing)'),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('backend')
+          .setDescription('Which local transcription backend to manage')
+          .setRequired(false)
+          .addChoices(
+            { name: 'Kimaki Whisper shim (chat-audio bridge)', value: 'shim' },
+            { name: 'speaches (faster-whisper, GPU)', value: 'speaches' },
+            { name: 'whisper.cpp server (Metal/CPU)', value: 'whisper-cpp' },
+            { name: 'Custom command', value: 'custom' },
+          ),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('command')
+          .setDescription('Custom launch command (required when backend is Custom)')
+          .setRequired(false),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('health-url')
+          .setDescription('Health-check URL for the service (default per backend)')
+          .setRequired(false),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('transcription-url')
+          .setDescription('OpenAI-compatible /v1 base URL to route voice notes to (stored, no env vars needed)')
+          .setRequired(false),
+      )
+      .setDMPermission(false)
+      .toJSON(),
+    new SlashCommandBuilder()
       .setName('whisper-start')
       .setDescription(truncateCommandDescription('Start the local voice-transcription service'))
       .setDMPermission(false)

--- a/cli/src/interaction-handler.ts
+++ b/cli/src/interaction-handler.ts
@@ -105,6 +105,11 @@ import { handleUpgradeAndRestartCommand } from './commands/upgrade.js'
 import { handleMcpCommand, handleMcpSelectMenu } from './commands/mcp.js'
 import { handleScreenshareCommand } from './commands/screenshare.js'
 import { handleVscodeCommand } from './commands/vscode.js'
+import {
+  handleWhisperStartCommand,
+  handleWhisperStopCommand,
+  handleWhisperStatusCommand,
+} from './commands/whisper.js'
 import { handleModelVariantSelectMenu } from './commands/model.js'
 import {
   handleModelVariantCommand,
@@ -440,6 +445,18 @@ export function registerInteractionHandler({
 
             case 'vscode':
               await handleVscodeCommand({ command: interaction, appId })
+              return
+
+            case 'whisper-start':
+              await handleWhisperStartCommand({ command: interaction, appId })
+              return
+
+            case 'whisper-stop':
+              await handleWhisperStopCommand({ command: interaction, appId })
+              return
+
+            case 'whisper-status':
+              await handleWhisperStatusCommand({ command: interaction, appId })
               return
           }
 

--- a/cli/src/interaction-handler.ts
+++ b/cli/src/interaction-handler.ts
@@ -106,6 +106,7 @@ import { handleMcpCommand, handleMcpSelectMenu } from './commands/mcp.js'
 import { handleScreenshareCommand } from './commands/screenshare.js'
 import { handleVscodeCommand } from './commands/vscode.js'
 import {
+  handleWhisperSetupCommand,
   handleWhisperStartCommand,
   handleWhisperStopCommand,
   handleWhisperStatusCommand,
@@ -445,6 +446,19 @@ export function registerInteractionHandler({
 
             case 'vscode':
               await handleVscodeCommand({ command: interaction, appId })
+              return
+
+            case 'whisper-setup':
+              // Setup writes the shell command the host will later execute on
+              // /whisper-start — admin-only, same gate as transcription-key.
+              if (!hasKimakiAdminPermission(interaction.member, interaction.guild)) {
+                await interaction.reply({
+                  content: `Only server admins or users with the **Kimaki** role can configure the transcription service.`,
+                  flags: MessageFlags.Ephemeral,
+                })
+                return
+              }
+              await handleWhisperSetupCommand({ command: interaction, appId })
               return
 
             case 'whisper-start':

--- a/cli/src/message-preprocessing.ts
+++ b/cli/src/message-preprocessing.ts
@@ -32,6 +32,46 @@ const voiceLogger = createLogger(LogPrefix.VOICE)
 export const VOICE_MESSAGE_TRANSCRIPTION_PREFIX =
   'Voice message transcription from Discord user:\n'
 
+// A short trigger a user replies to a voice note with, to re-transcribe it
+// (e.g. after the transcription service was offline when it was first sent).
+// Discord attachment URLs expire, but fetchReference() returns a fresh message
+// with a newly-signed URL, so the original audio is always recoverable.
+const RETRANSCRIBE_TRIGGER =
+  /^\s*(?:re-?transcribe|retry(?:\s+transcription)?|transcribe(?:\s+(?:this|that|again))?)\s*$/i
+
+/**
+ * If `message` is a reply whose parent has a voice attachment AND its text is a
+ * re-transcribe trigger, fetch the parent (fresh signed URL) and return it so the
+ * caller can re-run transcription on the original audio. Returns null otherwise.
+ */
+async function getVoiceNoteToRetranscribe({
+  message,
+  text,
+}: {
+  message: Message
+  text: string
+}): Promise<Message | null> {
+  if (!message.reference?.messageId) return null
+  if (!RETRANSCRIBE_TRIGGER.test(text)) return null
+
+  const referenced = await message
+    .fetchReference()
+    .catch((e) => new DiscordOperationError({ operation: 'fetchReference', cause: e }))
+  if (referenced instanceof Error) {
+    voiceLogger.warn(
+      `[RETRANSCRIBE] Failed to fetch replied message ${message.reference.messageId}: ${referenced.message}`,
+    )
+    return null
+  }
+
+  const hasVoice = Array.from(referenced.attachments.values()).some((attachment) =>
+    isVoiceAttachment(attachment),
+  )
+  if (!hasVoice) return null
+
+  return referenced
+}
+
 /** Fetch available agents from OpenCode for voice transcription agent selection. */
 async function fetchAvailableAgents(
   getClient: Awaited<ReturnType<typeof initializeOpencodeForDirectory>>,
@@ -237,8 +277,18 @@ export async function preprocessExistingThreadMessage({
     }
   }
 
-  const voiceResult = await processVoiceAttachment({
+  // Reply-to-retry: if the user replied to an existing voice note with a
+  // re-transcribe trigger, transcribe THAT message's audio (re-fetched with a
+  // fresh signed URL) instead of the reply itself. Recovers voice notes that
+  // were missed while the transcription service was offline.
+  const retranscribeTarget = await getVoiceNoteToRetranscribe({
     message,
+    text: messageContent,
+  })
+  const voiceSourceMessage = retranscribeTarget ?? message
+
+  const voiceResult = await processVoiceAttachment({
+    message: voiceSourceMessage,
     thread,
     projectDirectory,
     appId,
@@ -248,6 +298,14 @@ export async function preprocessExistingThreadMessage({
   })
   if (voiceResult) {
     messageContent = `${VOICE_MESSAGE_TRANSCRIPTION_PREFIX}${voiceResult.transcription}`
+  }
+
+  // A retry request's own text ("retranscribe") is just the trigger, not a
+  // prompt — if the re-transcription itself failed, drop it rather than sending
+  // the trigger word to the model.
+  const isRetryRequest = retranscribeTarget !== null
+  if (isRetryRequest && !voiceResult) {
+    return { prompt: '', mode: 'opencode', skip: true }
   }
 
   // Voice transcription failed and no text — drop silently

--- a/cli/src/schema.sql
+++ b/cli/src/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS `bot_api_keys` (
 	`gemini_api_key` text,
 	`openai_api_key` text,
 	`openai_base_url` text,
+	`transcription_local_model` text,
 	`xai_api_key` text,
 	`created_at` datetime DEFAULT CURRENT_TIMESTAMP,
 	CONSTRAINT `fk_bot_api_keys_app_id_bot_tokens_app_id_fk` FOREIGN KEY (`app_id`) REFERENCES `bot_tokens`(`app_id`) ON UPDATE CASCADE

--- a/cli/src/schema.sql
+++ b/cli/src/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `bot_api_keys` (
 	`app_id` text PRIMARY KEY,
 	`gemini_api_key` text,
 	`openai_api_key` text,
+	`openai_base_url` text,
 	`xai_api_key` text,
 	`created_at` datetime DEFAULT CURRENT_TIMESTAMP,
 	CONSTRAINT `fk_bot_api_keys_app_id_bot_tokens_app_id_fk` FOREIGN KEY (`app_id`) REFERENCES `bot_tokens`(`app_id`) ON UPDATE CASCADE

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -81,6 +81,8 @@ export const bot_api_keys = sqliteCore.sqliteTable('bot_api_keys', {
   openai_api_key: sqliteCore.text('openai_api_key'),
   /** Custom OpenAI-compatible base URL for voice transcription (e.g. a local Whisper service). */
   openai_base_url: sqliteCore.text('openai_base_url'),
+  /** Built-in local whisper model id (fast/balanced/accurate). Takes priority over cloud transcription. */
+  transcription_local_model: sqliteCore.text('transcription_local_model'),
   xai_api_key: sqliteCore.text('xai_api_key'),
   created_at: datetime('created_at').default(orm.sql`CURRENT_TIMESTAMP`),
 })

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -79,6 +79,8 @@ export const bot_api_keys = sqliteCore.sqliteTable('bot_api_keys', {
   app_id: sqliteCore.text('app_id').primaryKey().notNull().references(() => bot_tokens.app_id, { onUpdate: 'cascade' }),
   gemini_api_key: sqliteCore.text('gemini_api_key'),
   openai_api_key: sqliteCore.text('openai_api_key'),
+  /** Custom OpenAI-compatible base URL for voice transcription (e.g. a local Whisper service). */
+  openai_base_url: sqliteCore.text('openai_base_url'),
   xai_api_key: sqliteCore.text('xai_api_key'),
   created_at: datetime('created_at').default(orm.sql`CURRENT_TIMESTAMP`),
 })

--- a/cli/src/voice-handler.ts
+++ b/cli/src/voice-handler.ts
@@ -30,9 +30,11 @@ import {
   getGeminiApiKey,
   getTranscriptionApiKey,
   getBotTokenWithMode,
+  getLocalWhisperModel,
   findTextChannelByVoiceChannel,
 } from './database.js'
 import { transcribeViaKimakiGateway } from './cloudflare-transcription.js'
+import { transcribeLocalWhisper } from './whisper-local.js'
 import {
   sendThreadMessage,
   escapeDiscordFormatting,
@@ -605,6 +607,10 @@ export async function processVoiceAttachment({
     }
   }
 
+  // Built-in local whisper model takes priority: no API key, service, or URL
+  // needed — the model runs in-process (configured via /whisper-setup).
+  const localWhisperModel = appId ? await getLocalWhisperModel(appId) : null
+
   // Resolve transcription API key: prefer OpenAI, fall back to Gemini, then env vars.
   let transcriptionApiKey: string | undefined
   let transcriptionProvider: 'openai' | 'gemini' | undefined
@@ -630,9 +636,10 @@ export async function processVoiceAttachment({
   // via the kimaki.dev Whisper fallback before we bother the user with the
   // "add API key" dialog. This fallback has no tool-calling, so it can't
   // detect queueMessage/agent hints spoken in the voice message the way the
-  // OpenAI/Gemini path can.
+  // OpenAI/Gemini path can. Skipped when a built-in local model is configured —
+  // that path needs neither keys nor network.
   let gatewayTranscription: string | undefined
-  if (!transcriptionApiKey) {
+  if (!transcriptionApiKey && !localWhisperModel) {
     const botRow = await getBotTokenWithMode().catch(() => undefined)
     if (botRow?.mode === 'gateway' && botRow.clientId && botRow.clientSecret) {
       const result = await transcribeViaKimakiGateway({
@@ -649,7 +656,8 @@ export async function processVoiceAttachment({
     }
   }
 
-  if (!transcriptionApiKey && !gatewayTranscription) {
+  // A configured local model needs no API key at all — skip the key prompt.
+  if (!transcriptionApiKey && !gatewayTranscription && !localWhisperModel) {
     if (!appId) {
       await sendThreadMessage(
         thread,
@@ -668,19 +676,25 @@ export async function processVoiceAttachment({
     transcriptionProvider = requested.provider
   }
 
-  const transcription = gatewayTranscription
-    ? { transcription: gatewayTranscription, queueMessage: false, agent: undefined }
-    : await transcribeAudio({
+  const transcription = localWhisperModel
+    ? await transcribeLocalWhisper({
         audio: audioBuffer,
-        prompt: transcriptionPrompt,
-        apiKey: transcriptionApiKey!,
-        provider: transcriptionProvider!,
-        baseURL: transcriptionBaseUrl,
-        mediaType: audioAttachment.contentType || undefined,
-        currentSessionContext,
-        lastSessionContext,
-        agents,
+        mediaType: audioAttachment.contentType || 'audio/ogg',
+        modelId: localWhisperModel,
       })
+    : gatewayTranscription
+      ? { transcription: gatewayTranscription, queueMessage: false, agent: undefined }
+      : await transcribeAudio({
+          audio: audioBuffer,
+          prompt: transcriptionPrompt,
+          apiKey: transcriptionApiKey!,
+          provider: transcriptionProvider!,
+          baseURL: transcriptionBaseUrl,
+          mediaType: audioAttachment.contentType || undefined,
+          currentSessionContext,
+          lastSessionContext,
+          agents,
+        })
 
   if (transcription instanceof Error) {
     const errMsg = errore.matchError(transcription, {
@@ -690,6 +704,7 @@ export async function processVoiceAttachment({
       EmptyTranscriptionError: (e) => e.message,
       NoResponseContentError: (e) => e.message,
       NoToolResponseError: (e) => e.message,
+      LocalWhisperError: (e) => e.message,
       Error: (e) => e.message,
     })
     voiceLogger.error(`Transcription failed:`, transcription)

--- a/cli/src/voice-handler.ts
+++ b/cli/src/voice-handler.ts
@@ -608,11 +608,13 @@ export async function processVoiceAttachment({
   // Resolve transcription API key: prefer OpenAI, fall back to Gemini, then env vars.
   let transcriptionApiKey: string | undefined
   let transcriptionProvider: 'openai' | 'gemini' | undefined
+  let transcriptionBaseUrl: string | undefined
   if (appId) {
     const stored = await getTranscriptionApiKey(appId)
     if (stored) {
       transcriptionApiKey = stored.apiKey
       transcriptionProvider = stored.provider
+      transcriptionBaseUrl = stored.baseUrl
     }
   }
   if (!transcriptionApiKey && process.env.OPENAI_API_KEY) {
@@ -673,6 +675,7 @@ export async function processVoiceAttachment({
         prompt: transcriptionPrompt,
         apiKey: transcriptionApiKey!,
         provider: transcriptionProvider!,
+        baseURL: transcriptionBaseUrl,
         mediaType: audioAttachment.contentType || undefined,
         currentSessionContext,
         lastSessionContext,

--- a/cli/src/voice.ts
+++ b/cli/src/voice.ts
@@ -443,15 +443,18 @@ export type TranscriptionProvider = 'openai' | 'gemini'
 export function createTranscriptionModel({
   apiKey,
   provider,
+  baseURL,
 }: {
   apiKey: string
   provider?: TranscriptionProvider
+  /** Custom OpenAI-compatible base URL (e.g. a local Whisper service). OpenAI provider only. */
+  baseURL?: string
 }): LanguageModelV3 {
   const resolvedProvider: TranscriptionProvider =
     provider || (apiKey.startsWith('sk-') ? 'openai' : 'gemini')
 
   if (resolvedProvider === 'openai') {
-    const openai = createOpenAI({ apiKey })
+    const openai = createOpenAI({ apiKey, ...(baseURL && { baseURL }) })
     return openai.chat('gpt-audio')
   }
 
@@ -467,6 +470,7 @@ export async function transcribeAudio({
   apiKey: apiKeyParam,
   model,
   provider,
+  baseURL,
   mediaType: mediaTypeParam,
   currentSessionContext,
   lastSessionContext,
@@ -479,6 +483,8 @@ export async function transcribeAudio({
   apiKey?: string
   model?: LanguageModelV3
   provider?: TranscriptionProvider
+  /** Custom OpenAI-compatible base URL (e.g. a local Whisper service). */
+  baseURL?: string
   /** MIME type of the audio data (e.g. 'audio/ogg'). Defaults to 'audio/mpeg'. */
   mediaType?: string
   currentSessionContext?: string
@@ -504,7 +510,7 @@ export async function transcribeAudio({
   })()
 
   const languageModel: LanguageModelV3 =
-    model || createTranscriptionModel({ apiKey: apiKey!, provider: resolvedProvider })
+    model || createTranscriptionModel({ apiKey: apiKey!, provider: resolvedProvider, baseURL })
 
   // Convert audio to Buffer for potential format conversion
   const audioBuffer: Buffer = (() => {

--- a/cli/src/whisper-local.ts
+++ b/cli/src/whisper-local.ts
@@ -13,6 +13,7 @@
 import * as errore from 'errore'
 import path from 'node:path'
 import fs from 'node:fs'
+import os from 'node:os'
 import { spawn } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { getDataDir } from './config.js'
@@ -45,7 +46,7 @@ export const LOCAL_WHISPER_MODELS: LocalWhisperModel[] = [
   {
     id: 'balanced',
     hfModel: 'onnx-community/whisper-base',
-    label: 'Balanced (recommended)',
+    label: 'Balanced',
     approxSize: '~200 MB',
   },
   {
@@ -54,7 +55,91 @@ export const LOCAL_WHISPER_MODELS: LocalWhisperModel[] = [
     label: 'Accurate',
     approxSize: '~600 MB',
   },
+  {
+    id: 'best',
+    hfModel: 'onnx-community/whisper-large-v3-turbo',
+    label: 'Best (large-v3-turbo)',
+    approxSize: '~1 GB',
+  },
 ]
+
+export interface WhisperEnvironment {
+  platform: NodeJS.Platform
+  arch: string
+  cpuCores: number
+  totalMemGb: number
+  nvidiaGpu: string | null
+  appleSilicon: boolean
+}
+
+/** Detect the host environment to drive model recommendations. */
+export async function detectWhisperEnvironment(): Promise<WhisperEnvironment> {
+  const nvidiaGpu = await new Promise<string | null>((resolve) => {
+    const child = spawn('nvidia-smi', ['--query-gpu=name', '--format=csv,noheader'], {
+      shell: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    let out = ''
+    const timer = setTimeout(() => {
+      child.kill()
+      resolve(null)
+    }, 3000)
+    child.stdout?.on('data', (chunk: Buffer) => {
+      out += chunk.toString()
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve(null)
+    })
+    child.on('exit', (code) => {
+      clearTimeout(timer)
+      const name = out.split('\n')[0]?.trim()
+      resolve(code === 0 && name ? name : null)
+    })
+  })
+
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    cpuCores: os.cpus().length,
+    totalMemGb: Math.round(os.totalmem() / 1e9),
+    nvidiaGpu,
+    appleSilicon: process.platform === 'darwin' && process.arch === 'arm64',
+  }
+}
+
+/**
+ * Recommend a built-in model tier for the detected environment. Conservative on
+ * RAM: the loaded model roughly doubles its download size in memory, and the
+ * bot + inference must not push a small machine into swap.
+ */
+export function recommendLocalWhisperModel(env: WhisperEnvironment): {
+  model: LocalWhisperModel
+  reason: string
+} {
+  if (env.totalMemGb >= 16 && env.cpuCores >= 8) {
+    return {
+      model: getLocalWhisperModelById('best')!,
+      reason: `${env.cpuCores} cores + ${env.totalMemGb} GB RAM handle the large-v3-turbo model comfortably`,
+    }
+  }
+  if (env.totalMemGb >= 8) {
+    return {
+      model: getLocalWhisperModelById('accurate')!,
+      reason: `${env.totalMemGb} GB RAM fits the Accurate model without memory pressure`,
+    }
+  }
+  if (env.totalMemGb >= 4) {
+    return {
+      model: getLocalWhisperModelById('balanced')!,
+      reason: `${env.totalMemGb} GB RAM suits the Balanced model`,
+    }
+  }
+  return {
+    model: getLocalWhisperModelById('fast')!,
+    reason: `limited RAM (${env.totalMemGb} GB) — Fast keeps transcription snappy without swapping`,
+  }
+}
 
 export function getLocalWhisperModelById(id: string): LocalWhisperModel | undefined {
   return LOCAL_WHISPER_MODELS.find((m) => m.id === id)

--- a/cli/src/whisper-local.ts
+++ b/cli/src/whisper-local.ts
@@ -1,0 +1,293 @@
+// Built-in local voice transcription — zero-setup path for non-technical users.
+//
+// Instead of requiring a self-hosted Whisper backend (Python/CUDA/ports/URLs),
+// Kimaki can download and run an ONNX Whisper model IN-PROCESS on the CPU via
+// @huggingface/transformers (pure Node, no Python). `/whisper-setup model:...`
+// installs the runtime + downloads the model automatically; voice notes then
+// transcribe locally with nothing else to configure.
+//
+// The inference runtime (~onnxruntime) is heavy, so it is NOT a kimaki
+// dependency: it is npm-installed on demand into <data-dir>/whisper-runtime the
+// first time a local model is selected, keeping the base install lean. Models
+// are cached under <data-dir>/whisper-runtime/models by the HF hub cache.
+import * as errore from 'errore'
+import path from 'node:path'
+import fs from 'node:fs'
+import { spawn } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { getDataDir } from './config.js'
+import { convertOggToWav, convertM4aToWav, normalizeAudioMediaType } from './voice.js'
+import type { TranscriptionResult } from './voice.js'
+import { createLogger, LogPrefix } from './logger.js'
+
+const logger = createLogger(LogPrefix.VOICE)
+
+export class LocalWhisperError extends errore.createTaggedError({
+  name: 'LocalWhisperError',
+  message: '$reason',
+}) {}
+
+export interface LocalWhisperModel {
+  id: string
+  hfModel: string
+  label: string
+  /** Approximate one-time download size shown to the user. */
+  approxSize: string
+}
+
+export const LOCAL_WHISPER_MODELS: LocalWhisperModel[] = [
+  {
+    id: 'fast',
+    hfModel: 'onnx-community/whisper-tiny',
+    label: 'Fast',
+    approxSize: '~110 MB',
+  },
+  {
+    id: 'balanced',
+    hfModel: 'onnx-community/whisper-base',
+    label: 'Balanced (recommended)',
+    approxSize: '~200 MB',
+  },
+  {
+    id: 'accurate',
+    hfModel: 'onnx-community/whisper-small',
+    label: 'Accurate',
+    approxSize: '~600 MB',
+  },
+]
+
+export function getLocalWhisperModelById(id: string): LocalWhisperModel | undefined {
+  return LOCAL_WHISPER_MODELS.find((m) => m.id === id)
+}
+
+function runtimeDir(): string {
+  return path.join(getDataDir(), 'whisper-runtime')
+}
+
+function modelsCacheDir(): string {
+  return path.join(runtimeDir(), 'models')
+}
+
+export function isLocalWhisperRuntimeInstalled(): boolean {
+  return fs.existsSync(
+    path.join(runtimeDir(), 'node_modules', '@huggingface', 'transformers', 'package.json'),
+  )
+}
+
+/**
+ * npm-install the inference runtime into <data-dir>/whisper-runtime (one-time).
+ * Kept out of kimaki's own dependencies because onnxruntime is large.
+ */
+export async function installLocalWhisperRuntime(): Promise<LocalWhisperError | null> {
+  if (isLocalWhisperRuntimeInstalled()) return null
+
+  const dir = runtimeDir()
+  const prepared = errore.try(
+    () => {
+      fs.mkdirSync(dir, { recursive: true })
+      const pkgPath = path.join(dir, 'package.json')
+      if (!fs.existsSync(pkgPath)) {
+        fs.writeFileSync(
+          pkgPath,
+          JSON.stringify({ name: 'kimaki-whisper-runtime', private: true }, null, 2) + '\n',
+        )
+      }
+    },
+    (e) => new LocalWhisperError({ reason: `failed to prepare runtime dir: ${String(e)}`, cause: e }),
+  )
+  if (prepared instanceof Error) return prepared
+
+  logger.log('Installing local whisper runtime (@huggingface/transformers)...')
+  const exitError = await new Promise<Error | null>((resolve) => {
+    const child = spawn('npm', ['install', '--no-audit', '--no-fund', '@huggingface/transformers@^3'], {
+      cwd: dir,
+      shell: true,
+      stdio: 'ignore',
+    })
+    child.on('error', (e) => resolve(e))
+    child.on('exit', (code) => resolve(code === 0 ? null : new Error(`npm install exited with code ${code}`)))
+  })
+  if (exitError) {
+    return new LocalWhisperError({
+      reason: `runtime install failed: ${exitError.message}`,
+      cause: exitError,
+    })
+  }
+  if (!isLocalWhisperRuntimeInstalled()) {
+    return new LocalWhisperError({ reason: 'runtime install completed but package not found' })
+  }
+  return null
+}
+
+// The ASR pipeline is cached per model so the (RAM-resident) weights load once.
+let cachedPipeline: { hfModel: string; asr: (audio: Float32Array, options?: object) => Promise<unknown> } | null = null
+
+async function getPipeline({
+  hfModel,
+  onProgress,
+}: {
+  hfModel: string
+  onProgress?: (message: string) => void
+}): Promise<LocalWhisperError | ((audio: Float32Array, options?: object) => Promise<unknown>)> {
+  if (cachedPipeline?.hfModel === hfModel) return cachedPipeline.asr
+
+  // Import the package's NODE entry (dist/transformers.node.mjs) — the default
+  // web bundle lacks the onnxruntime-node binding and cannot run inference.
+  const entry = path.join(
+    runtimeDir(),
+    'node_modules',
+    '@huggingface',
+    'transformers',
+    'dist',
+    'transformers.node.mjs',
+  )
+  if (!fs.existsSync(entry)) {
+    return new LocalWhisperError({
+      reason: 'local whisper runtime is not installed — run /whisper-setup again',
+    })
+  }
+
+  const transformers = await import(pathToFileURL(entry).href).catch(
+    (e) => new LocalWhisperError({ reason: `failed to load runtime: ${String(e)}`, cause: e }),
+  )
+  if (transformers instanceof LocalWhisperError) return transformers
+
+  const { pipeline, env } = transformers as {
+    pipeline: (task: string, model: string, options?: object) => Promise<(audio: Float32Array, options?: object) => Promise<unknown>>
+    env: { cacheDir: string }
+  }
+  env.cacheDir = modelsCacheDir()
+
+  logger.log(`Loading local whisper model ${hfModel} (downloads on first use)...`)
+  const seenFiles = new Set<string>()
+  const asr = await pipeline('automatic-speech-recognition', hfModel, {
+    dtype: 'q8',
+    progress_callback: (progress: { status?: string; file?: string }) => {
+      if (progress.status === 'download' && progress.file && !seenFiles.has(progress.file)) {
+        seenFiles.add(progress.file)
+        onProgress?.(`Downloading model file: ${progress.file}`)
+      }
+    },
+  }).catch((e) => new LocalWhisperError({ reason: `failed to load model ${hfModel}: ${String(e)}`, cause: e }))
+  if (asr instanceof Error) return asr
+
+  cachedPipeline = { hfModel, asr }
+  return asr
+}
+
+/**
+ * Pre-download the model + verify the pipeline loads, so setup can report
+ * "ready" before the first voice note arrives.
+ */
+export async function prepareLocalWhisperModel({
+  modelId,
+  onProgress,
+}: {
+  modelId: string
+  onProgress?: (message: string) => void
+}): Promise<LocalWhisperError | null> {
+  const model = getLocalWhisperModelById(modelId)
+  if (!model) return new LocalWhisperError({ reason: `unknown local model: ${modelId}` })
+
+  const installed = await installLocalWhisperRuntime()
+  if (installed instanceof Error) return installed
+
+  const asr = await getPipeline({ hfModel: model.hfModel, onProgress })
+  if (asr instanceof Error) return asr
+  return null
+}
+
+/** Convert our 48 kHz mono 16-bit WAV (from prism decode) to 16 kHz Float32. */
+function wav48kMonoToFloat32At16k(wav: Buffer): Float32Array {
+  const pcm = wav.subarray(44)
+  const sampleCount = Math.floor(pcm.length / 2)
+  const out = new Float32Array(Math.floor(sampleCount / 3))
+  for (let i = 0; i < out.length; i++) {
+    const base = i * 6
+    const a = pcm.readInt16LE(base)
+    const b = pcm.readInt16LE(base + 2)
+    const c = pcm.readInt16LE(base + 4)
+    out[i] = (a + b + c) / (3 * 32768)
+  }
+  return out
+}
+
+// Mirrors the queue-detection behaviour the cloud transcription performs via
+// its tool schema, using deterministic string matching instead of a model.
+const QUEUE_PHRASES = [
+  'queue this message',
+  'queue this',
+  'add this to the queue',
+  'add to the queue',
+  'queue it',
+]
+
+function detectQueueIntent(text: string): { transcription: string; queueMessage: boolean } {
+  const lower = text.toLowerCase()
+  for (const phrase of QUEUE_PHRASES) {
+    const idx = lower.indexOf(phrase)
+    if (idx === -1) continue
+    const stripped = (text.slice(0, idx) + text.slice(idx + phrase.length))
+      .replace(/^[\s.,;:!?-]+/, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+    return { transcription: stripped.length > 0 ? stripped : text, queueMessage: true }
+  }
+  return { transcription: text, queueMessage: false }
+}
+
+/**
+ * Transcribe a Discord voice note in-process with the configured local model.
+ * Accepts OGG/Opus (native decode, no ffmpeg) and M4A (needs ffmpeg on PATH).
+ */
+export async function transcribeLocalWhisper({
+  audio,
+  mediaType,
+  modelId,
+}: {
+  audio: Buffer
+  mediaType: string
+  modelId: string
+}): Promise<LocalWhisperError | TranscriptionResult> {
+  const model = getLocalWhisperModelById(modelId)
+  if (!model) return new LocalWhisperError({ reason: `unknown local model: ${modelId}` })
+
+  const normalized = normalizeAudioMediaType(mediaType || 'audio/ogg')
+  const wav = await (async (): Promise<Error | Buffer> => {
+    if (normalized === 'audio/ogg' || normalized === 'audio/opus') {
+      return convertOggToWav(audio)
+    }
+    if (normalized === 'audio/mp4') {
+      return convertM4aToWav(audio)
+    }
+    return new LocalWhisperError({
+      reason: `unsupported audio type for local transcription: ${normalized}`,
+    })
+  })()
+  if (wav instanceof Error) {
+    return new LocalWhisperError({ reason: `audio decode failed: ${wav.message}`, cause: wav })
+  }
+
+  const float32 = wav48kMonoToFloat32At16k(wav)
+  if (float32.length === 0) {
+    return new LocalWhisperError({ reason: 'decoded audio is empty' })
+  }
+
+  const asr = await getPipeline({ hfModel: model.hfModel })
+  if (asr instanceof Error) return asr
+
+  const started = Date.now()
+  // chunking handles voice notes longer than whisper's native 30s window
+  const output = await asr(float32, { chunk_length_s: 30, stride_length_s: 5 }).catch(
+    (e) => new LocalWhisperError({ reason: `inference failed: ${String(e)}`, cause: e }),
+  )
+  if (output instanceof LocalWhisperError) return output
+
+  const text = (output as { text?: string })?.text?.trim() ?? ''
+  logger.log(
+    `Local whisper (${model.hfModel}) transcribed ${float32.length / 16000}s of audio in ${Date.now() - started}ms`,
+  )
+  if (!text) return { transcription: '[inaudible audio]', queueMessage: false }
+
+  return { ...detectQueueIntent(text) }
+}

--- a/cli/src/whisper-service.ts
+++ b/cli/src/whisper-service.ts
@@ -25,8 +25,17 @@ export class WhisperServiceError extends errore.createTaggedError({
   message: '$reason',
 }) {}
 
+export class WhisperNotConfiguredError extends errore.createTaggedError({
+  name: 'WhisperNotConfiguredError',
+  message:
+    'No local transcription service is configured. Run `kimaki whisper setup` to pick and wire a Whisper backend first.',
+}) {}
+
 export interface WhisperConfig {
-  /** Command to launch the local transcription service (run via a shell). */
+  /**
+   * Command to launch the local transcription service (run via a shell).
+   * Empty until the user configures a real service via `kimaki whisper setup`.
+   */
   command: string
   /** Working directory to launch it from. Defaults to the data dir. */
   cwd?: string
@@ -36,10 +45,19 @@ export interface WhisperConfig {
   startTimeoutSeconds: number
 }
 
+// No default launch command: there is no transcription service bundled with
+// Kimaki (a Whisper backend needs Python + CUDA/Metal + a multi-GB model that
+// cannot ship in an npm package). The user picks and wires one via
+// `kimaki whisper setup`. Until then, `command` is empty and start/status
+// report "not configured" with guidance rather than spawning a missing binary.
 export const DEFAULT_WHISPER_CONFIG: WhisperConfig = {
-  command: 'kimaki-whisper-shim',
+  command: '',
   healthUrl: 'http://localhost:7070/health',
   startTimeoutSeconds: 60,
+}
+
+export function isWhisperConfigured(config: WhisperConfig): boolean {
+  return config.command.trim().length > 0
 }
 
 export function whisperConfigPath(): string {
@@ -127,6 +145,7 @@ async function waitForHealthy({
 }
 
 export interface WhisperStatus {
+  configured: boolean
   running: boolean
   healthy: boolean
   pid: number | null
@@ -137,11 +156,18 @@ export async function getWhisperStatus(): Promise<WhisperConfigError | WhisperSt
   const config = loadWhisperConfig()
   if (config instanceof Error) return config
 
+  const configured = isWhisperConfigured(config)
   const pid = readPid()
   const running = pid !== null && isProcessAlive({ pid })
   const healthy = running ? await isWhisperHealthy({ url: config.healthUrl }) : false
 
-  return { running, healthy, pid: running ? pid : null, healthUrl: config.healthUrl }
+  return {
+    configured,
+    running,
+    healthy,
+    pid: running ? pid : null,
+    healthUrl: config.healthUrl,
+  }
 }
 
 export type WhisperStartResult =
@@ -152,7 +178,12 @@ export async function startWhisperService({
   overrides,
 }: {
   overrides?: Partial<Pick<WhisperConfig, 'command' | 'healthUrl'>>
-} = {}): Promise<WhisperConfigError | WhisperServiceError | WhisperStartResult> {
+} = {}): Promise<
+  | WhisperConfigError
+  | WhisperServiceError
+  | WhisperNotConfiguredError
+  | WhisperStartResult
+> {
   const loaded = loadWhisperConfig()
   if (loaded instanceof Error) return loaded
 
@@ -161,6 +192,8 @@ export async function startWhisperService({
     command: overrides?.command ?? loaded.command,
     healthUrl: overrides?.healthUrl ?? loaded.healthUrl,
   }
+
+  if (!isWhisperConfigured(config)) return new WhisperNotConfiguredError({})
 
   // Idempotent start: if already running, report and return.
   const existingPid = readPid()
@@ -200,6 +233,62 @@ export async function startWhisperService({
   }
 
   return { status: 'started', pid: child.pid, healthUrl: config.healthUrl }
+}
+
+// Known backend presets surfaced by `kimaki whisper setup`. Each is a command
+// the user can run to serve an OpenAI-compatible transcription endpoint. These
+// are guidance only — the user must have the backend installed. `custom` lets
+// the user paste any command.
+export interface WhisperBackendPreset {
+  id: string
+  label: string
+  command: string
+  healthUrl: string
+  /** One-line note about what the user must install for this preset. */
+  requires: string
+}
+
+export const WHISPER_BACKEND_PRESETS: WhisperBackendPreset[] = [
+  {
+    id: 'shim',
+    label: 'Kimaki Whisper shim (bridges chat-audio → a Whisper backend)',
+    command: 'kimaki-whisper-shim',
+    healthUrl: 'http://localhost:7070/health',
+    requires:
+      'the kimaki-whisper-shim on PATH, plus a Whisper backend it points at (see docs)',
+  },
+  {
+    id: 'speaches',
+    label: 'speaches (faster-whisper, GPU) — direct OpenAI-compatible server',
+    command:
+      'uvicorn --factory --host 0.0.0.0 --port 8000 speaches.main:create_app',
+    healthUrl: 'http://localhost:8000/health',
+    requires: 'speaches installed (uv/pip) with its venv active',
+  },
+  {
+    id: 'whisper-cpp',
+    label: 'whisper.cpp server (Metal/CPU) — direct OpenAI-compatible server',
+    command:
+      'whisper-server -m ~/whisper-models/ggml-large-v3.bin --host 0.0.0.0 --port 8000 --inference-path /v1/audio/transcriptions',
+    healthUrl: 'http://localhost:8000/health',
+    requires: 'whisper.cpp installed and a ggml model downloaded',
+  },
+]
+
+export function setupWhisperService({
+  command,
+  healthUrl,
+}: {
+  command: string
+  healthUrl: string
+}): WhisperConfigError | WhisperConfig {
+  const loaded = loadWhisperConfig()
+  if (loaded instanceof Error) return loaded
+
+  const config: WhisperConfig = { ...loaded, command, healthUrl }
+  const saved = saveWhisperConfig({ config })
+  if (saved instanceof Error) return saved
+  return config
 }
 
 export type WhisperStopResult =

--- a/cli/src/whisper-service.ts
+++ b/cli/src/whisper-service.ts
@@ -1,0 +1,242 @@
+// Core lifecycle logic for a local voice-transcription service, shared by the
+// `kimaki whisper` CLI commands and the Discord `/whisper-*` slash commands.
+//
+// Kimaki can transcribe Discord voice notes through a LOCAL OpenAI-compatible
+// server instead of the paid Gemini/OpenAI cloud (point OPENAI_BASE_URL at it).
+// This module manages that service's lifecycle so users can spin it up on demand
+// and free the GPU when idle, without juggling separate terminals.
+//
+// The service is generic: any command exposing an OpenAI-compatible endpoint
+// works (a Whisper shim, speaches, faster-whisper-server, whisper.cpp). Config
+// lives at <data-dir>/whisper.json; the PID is tracked at <data-dir>/whisper.pid.
+import * as errore from 'errore'
+import path from 'node:path'
+import fs from 'node:fs'
+import { spawn } from 'node:child_process'
+import { getDataDir } from './config.js'
+
+export class WhisperConfigError extends errore.createTaggedError({
+  name: 'WhisperConfigError',
+  message: 'Failed to $action whisper config at $path',
+}) {}
+
+export class WhisperServiceError extends errore.createTaggedError({
+  name: 'WhisperServiceError',
+  message: '$reason',
+}) {}
+
+export interface WhisperConfig {
+  /** Command to launch the local transcription service (run via a shell). */
+  command: string
+  /** Working directory to launch it from. Defaults to the data dir. */
+  cwd?: string
+  /** Health-check URL polled after start and by `status`. */
+  healthUrl: string
+  /** Seconds to wait for the health check to pass on start. */
+  startTimeoutSeconds: number
+}
+
+export const DEFAULT_WHISPER_CONFIG: WhisperConfig = {
+  command: 'kimaki-whisper-shim',
+  healthUrl: 'http://localhost:7070/health',
+  startTimeoutSeconds: 60,
+}
+
+export function whisperConfigPath(): string {
+  return path.join(getDataDir(), 'whisper.json')
+}
+
+function whisperPidPath(): string {
+  return path.join(getDataDir(), 'whisper.pid')
+}
+
+export function loadWhisperConfig(): WhisperConfigError | WhisperConfig {
+  const file = whisperConfigPath()
+  const raw = errore.try(
+    () => fs.readFileSync(file, 'utf-8'),
+    (e) => new WhisperConfigError({ action: 'read', path: file, cause: e }),
+  )
+  // No config file yet: use defaults (the common shim-on-7070 case).
+  if (raw instanceof Error) return { ...DEFAULT_WHISPER_CONFIG }
+
+  const parsed = errore.try(
+    () => JSON.parse(raw) as Partial<WhisperConfig>,
+    (e) => new WhisperConfigError({ action: 'parse', path: file, cause: e }),
+  )
+  if (parsed instanceof Error) return parsed
+
+  return { ...DEFAULT_WHISPER_CONFIG, ...parsed }
+}
+
+export function saveWhisperConfig({
+  config,
+}: {
+  config: WhisperConfig
+}): WhisperConfigError | null {
+  const file = whisperConfigPath()
+  const result = errore.try(
+    () => {
+      fs.mkdirSync(getDataDir(), { recursive: true })
+      fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
+    },
+    (e) => new WhisperConfigError({ action: 'write', path: file, cause: e }),
+  )
+  return result instanceof Error ? result : null
+}
+
+function readPid(): number | null {
+  const raw = errore.try(
+    () => fs.readFileSync(whisperPidPath(), 'utf-8'),
+    (e) => new WhisperConfigError({ action: 'read pid for', path: whisperPidPath(), cause: e }),
+  )
+  if (raw instanceof Error) return null
+  const pid = Number(raw.trim())
+  return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+function isProcessAlive({ pid }: { pid: number }): boolean {
+  // signal 0 does not kill; it only checks the process exists and is signalable.
+  const result = errore.try(
+    () => process.kill(pid, 0),
+    (e) => new WhisperServiceError({ reason: `process ${pid} not signalable`, cause: e }),
+  )
+  return !(result instanceof Error)
+}
+
+export async function isWhisperHealthy({ url }: { url: string }): Promise<boolean> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(4000),
+  }).catch((e) => new WhisperServiceError({ reason: 'health check failed', cause: e }))
+  if (res instanceof Error) return false
+  return res.ok
+}
+
+async function waitForHealthy({
+  url,
+  timeoutSeconds,
+}: {
+  url: string
+  timeoutSeconds: number
+}): Promise<boolean> {
+  const deadline = Date.now() + timeoutSeconds * 1000
+  while (Date.now() < deadline) {
+    if (await isWhisperHealthy({ url })) return true
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  return false
+}
+
+export interface WhisperStatus {
+  running: boolean
+  healthy: boolean
+  pid: number | null
+  healthUrl: string
+}
+
+export async function getWhisperStatus(): Promise<WhisperConfigError | WhisperStatus> {
+  const config = loadWhisperConfig()
+  if (config instanceof Error) return config
+
+  const pid = readPid()
+  const running = pid !== null && isProcessAlive({ pid })
+  const healthy = running ? await isWhisperHealthy({ url: config.healthUrl }) : false
+
+  return { running, healthy, pid: running ? pid : null, healthUrl: config.healthUrl }
+}
+
+export type WhisperStartResult =
+  | { status: 'already-running'; pid: number; healthy: boolean }
+  | { status: 'started'; pid: number; healthUrl: string }
+
+export async function startWhisperService({
+  overrides,
+}: {
+  overrides?: Partial<Pick<WhisperConfig, 'command' | 'healthUrl'>>
+} = {}): Promise<WhisperConfigError | WhisperServiceError | WhisperStartResult> {
+  const loaded = loadWhisperConfig()
+  if (loaded instanceof Error) return loaded
+
+  const config: WhisperConfig = {
+    ...loaded,
+    command: overrides?.command ?? loaded.command,
+    healthUrl: overrides?.healthUrl ?? loaded.healthUrl,
+  }
+
+  // Idempotent start: if already running, report and return.
+  const existingPid = readPid()
+  if (existingPid !== null && isProcessAlive({ pid: existingPid })) {
+    const healthy = await isWhisperHealthy({ url: config.healthUrl })
+    return { status: 'already-running', pid: existingPid, healthy }
+  }
+
+  const child = spawn(config.command, {
+    shell: true,
+    cwd: config.cwd || getDataDir(),
+    stdio: 'ignore',
+    detached: true,
+  })
+  if (child.pid === undefined) {
+    return new WhisperServiceError({ reason: 'failed to spawn whisper service (no pid)' })
+  }
+  child.unref()
+
+  const saved = saveWhisperConfig({ config })
+  if (saved instanceof Error) return saved
+
+  const wrotePid = errore.try(
+    () => fs.writeFileSync(whisperPidPath(), String(child.pid)),
+    (e) => new WhisperConfigError({ action: 'write pid for', path: whisperPidPath(), cause: e }),
+  )
+  if (wrotePid instanceof Error) return wrotePid
+
+  const healthy = await waitForHealthy({
+    url: config.healthUrl,
+    timeoutSeconds: config.startTimeoutSeconds,
+  })
+  if (!healthy) {
+    return new WhisperServiceError({
+      reason: `service started (pid ${child.pid}) but did not become healthy within ${config.startTimeoutSeconds}s at ${config.healthUrl}`,
+    })
+  }
+
+  return { status: 'started', pid: child.pid, healthUrl: config.healthUrl }
+}
+
+export type WhisperStopResult =
+  | { status: 'not-running' }
+  | { status: 'stale-pid'; pid: number }
+  | { status: 'stopped'; pid: number }
+
+export function stopWhisperService(): WhisperServiceError | WhisperStopResult {
+  const pid = readPid()
+  if (pid === null) return { status: 'not-running' }
+
+  const clearPid = () =>
+    errore.try(
+      () => fs.rmSync(whisperPidPath(), { force: true }),
+      (e) => new WhisperConfigError({ action: 'remove pid for', path: whisperPidPath(), cause: e }),
+    )
+
+  if (!isProcessAlive({ pid })) {
+    clearPid()
+    return { status: 'stale-pid', pid }
+  }
+
+  // Kill the whole process group (detached start makes the child a group
+  // leader), so a wrapper + its child service both stop. Fall back to a plain
+  // single-process kill if the group signal fails.
+  const killedGroup = errore.try(
+    () => process.kill(-pid, 'SIGTERM'),
+    (e) => new WhisperServiceError({ reason: `group kill failed for ${pid}`, cause: e }),
+  )
+  if (killedGroup instanceof Error) {
+    const killedSingle = errore.try(
+      () => process.kill(pid, 'SIGTERM'),
+      (e) => new WhisperServiceError({ reason: `failed to stop pid ${pid}`, cause: e }),
+    )
+    if (killedSingle instanceof Error) return killedSingle
+  }
+
+  clearPid()
+  return { status: 'stopped', pid }
+}


### PR DESCRIPTION
## Summary

Local voice-note transcription as a first-class, **zero-setup** Kimaki feature — from one-command onboarding for non-technical users to full lifecycle management for self-hosters, plus recovery of missed voice notes.

### 1. Built-in local whisper — zero setup (the headline)

```
/whisper-setup  model: Balanced
```

That's the entire onboarding. Kimaki npm-installs an ONNX inference runtime into `<data-dir>/whisper-runtime` (on demand — **not** a kimaki dependency, keeping the base install lean), downloads the chosen Whisper model with progress streamed into the ephemeral reply, and stores the choice in the DB. Voice notes then transcribe **in-process on the CPU**: no terminal, no Python, no API keys, no services, no ports, no URLs. Audio never leaves the machine.

- Models sized for CPU: Fast (~110 MB) / Balanced (~200 MB, recommended) / Accurate (~600 MB); `Off` reverts to cloud.
- OGG/Opus decodes natively via the existing prism-media chain (no ffmpeg for the Discord case), 48k→16k resample, chunked inference for >30 s notes.
- Measured: 11 s of Discord-format opus → **~470 ms** on CPU (tiny).
- Local model takes priority and needs **no API key**; existing cloud keys/env fallbacks unchanged.

### 2. Self-hosted service management (advanced path)

For GPU users running their own backend (Whisper shim, speaches, faster-whisper, whisper.cpp):

- **CLI:** `kimaki whisper setup|start|stop|status` — `setup` is an interactive backend picker; `start`/`stop` manage the process (group SIGTERM, PID tracking, health polling) so the GPU can be freed on demand; unconfigured state gives guidance instead of failing cryptically.
- **Discord:** `/whisper-setup` (admin-gated — it sets a shell command the host executes), `/whisper-start`, `/whisper-stop`, `/whisper-status`.
- `transcription-url` option stores an OpenAI-compatible base URL in the DB (`bot_api_keys.openai_base_url`) so routing needs no env vars; `voice.ts` honors stored base URLs, with a placeholder key for keyless local services.

### 3. Reply-to-retry re-transcription

Voice notes that failed (e.g. service offline) were previously dropped with no recovery. Now replying `retranscribe` / `transcribe this` / `retry` to a voice note re-fetches the message (fresh signed CDN URL) and re-runs transcription on the original audio — no re-recording.

## Schema

Two nullable columns on `bot_api_keys` via the existing idempotent ALTER migration list: `openai_base_url`, `transcription_local_model`.

## Verification

- `pnpm tsc` + `lintcn` clean for all changed files (pre-existing `discord-digital-twin` errors untouched).
- Zero-setup path verified end-to-end on a real machine: runtime self-install → model download → Discord-format OGG transcribed correctly (JFK sample, word-perfect).
- Lifecycle commands validated live on a real Discord guild managing a real GPU-backed service (see PR comment with the full test table).

Happy to split this into smaller PRs, rename commands, or add vitest coverage if preferred.
