### PR TITLE
fix: pin frozen dependency bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.15.9
 
       - uses: actions/setup-node@v4
         with:
@@ -36,7 +36,7 @@ jobs:
         run: opencode --version
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       # Submodules have dist/ gitignored so they need to be built after checkout.
       # libsqlproxy is a workspace package that also needs building (exports from dist/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "root",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "prepare": "pnpm -r --filter errore --filter libsqlproxy --filter opencode-injection-guard --filter traforo --filter fly-admin --filter profano --filter sigillo --filter discord-slack-bridge run build",
     "test": "NODE_ENV=test pnpm --filter kimaki run vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-/VTHs9J0RGLH2lU39U6Ra5aj1bwTgDrArdwh46iKBWY=
+packageExtensionsChecksum: 12a00ea3a37f088c14786963e400c96c
 
 importers:
 


### PR DESCRIPTION
## Summary
- pin the repository and CI to pnpm 9.15.9
- regenerate pnpm's package-extension checksum with that canonical version
- make CI enforce the frozen install it relies on

Closes #161

## Validation
- `corepack pnpm@9.15.9 install --frozen-lockfile --ignore-scripts`
- `../node_modules/.bin/tsc --noEmit` from `cli` (blocked by existing missing submodule build artifacts and unrelated baseline type errors)

## AI disclosure
Assisted by OpenCode using `openai/gpt-5.6-terra`.