### PR TITLE
fix: recover stale OpenCode sessions

### DIFF
--- a/.changeset/fix-stale-opencode-session-recovery.md
+++ b/.changeset/fix-stale-opencode-session-recovery.md
@@ -1,0 +1,7 @@
+---
+"kimaki": patch
+---
+
+Recover Discord threads when their persisted OpenCode session is no longer available.
+
+Fixes #165

--- a/cli/src/database.ts
+++ b/cli/src/database.ts
@@ -527,6 +527,24 @@ export async function setThreadSession(threadId: string, sessionId: string) {
   await upsertThreadSession({ threadId, sessionId, source: 'kimaki' })
 }
 
+/** Remove a thread mapping only when it still points at the stale session. */
+export async function clearThreadSessionIfMatches({
+  threadId,
+  sessionId,
+}: {
+  threadId: string
+  sessionId: string
+}): Promise<boolean> {
+  const db = await getDb()
+  const deleted = await db.delete(schema.thread_sessions)
+    .where(orm.and(
+      orm.eq(schema.thread_sessions.thread_id, threadId),
+      orm.eq(schema.thread_sessions.session_id, sessionId),
+    ))
+    .returning({ threadId: schema.thread_sessions.thread_id })
+  return deleted.length === 1
+}
+
 export async function upsertThreadSession({ threadId, sessionId, source }: { threadId: string; sessionId: string; source: ThreadSessionSource }) {
   const db = await getDb()
   await db.insert(schema.thread_sessions)

--- a/cli/src/db.test.ts
+++ b/cli/src/db.test.ts
@@ -14,6 +14,9 @@ import {
   getSessionEventSnapshot,
   getSessionModel,
   setSessionModel,
+  setThreadSession,
+  getThreadSession,
+  clearThreadSessionIfMatches,
 } from './database.js'
 import { startHranaServer, stopHranaServer } from './hrana-server.js'
 import { chooseLockPort } from './test-utils.js'
@@ -121,6 +124,20 @@ describe('getDb', () => {
 
     await db.delete(schema.thread_workspaces).where(orm.eq(schema.thread_workspaces.thread_id, threadId))
     await db.delete(schema.thread_sessions).where(orm.eq(schema.thread_sessions.thread_id, threadId))
+  })
+
+  test('clears a stale thread session mapping at most once', async () => {
+    const threadId = `test-stale-session-${crypto.randomUUID()}`
+    const sessionId = `ses_stale_${crypto.randomUUID()}`
+    await setThreadSession(threadId, sessionId)
+
+    const results = await Promise.all([
+      clearThreadSessionIfMatches({ threadId, sessionId }),
+      clearThreadSessionIfMatches({ threadId, sessionId }),
+    ])
+
+    expect(results.sort()).toEqual([false, true])
+    await expect(getThreadSession(threadId)).resolves.toBeUndefined()
   })
 
   test('copyCurrentSessionModel snapshots source session model to forked session', async () => {

--- a/cli/src/runtime-lifecycle.e2e.test.ts
+++ b/cli/src/runtime-lifecycle.e2e.test.ts
@@ -27,6 +27,7 @@ import {
   closeDatabase,
   setChannelDirectory,
   setChannelVerbosity,
+  getThreadSession,
   type VerbosityLevel,
 } from './database.js'
 import { startHranaServer, stopHranaServer } from './hrana-server.js'
@@ -41,6 +42,7 @@ import {
   initTestGitRepo,
   waitForBotMessageContaining,
   waitForBotReplyAfterUserMessage,
+  waitForFooterMessage,
 } from './test-utils.js'
 
 
@@ -495,6 +497,68 @@ describe('runtime lifecycle', () => {
 
       const runtimeAfterRestart = getRuntime(thread.id)
       expect(runtimeAfterRestart).toBe(runtimeBeforeRestart)
+    },
+    15_000,
+  )
+
+  test(
+    'replaces a deleted persisted session before dispatching the prompt',
+    async () => {
+      await discord.channel(TEXT_CHANNEL_ID).user(TEST_USER_ID).sendMessage({
+        content: 'Reply with exactly: stale-session-alpha',
+      })
+      const thread = await discord.channel(TEXT_CHANNEL_ID).waitForThread({
+        timeout: 4_000,
+        predicate: (candidate) => candidate.name === 'Reply with exactly: stale-session-alpha',
+      })
+      const th = discord.thread(thread.id)
+      await waitForFooterMessage({
+        discord,
+        threadId: thread.id,
+        afterMessageIncludes: 'stale-session-alpha',
+        afterAuthorId: TEST_USER_ID,
+        timeout: 4_000,
+      })
+
+      const staleSessionId = await getThreadSession(thread.id)
+      expect(staleSessionId).toBeDefined()
+      const getClient = await initializeOpencodeForDirectory(directories.projectDirectory)
+      if (getClient instanceof Error || !staleSessionId) {
+        throw getClient instanceof Error ? getClient : new Error('Expected session')
+      }
+      await getClient().session.delete({
+        sessionID: staleSessionId,
+        directory: directories.projectDirectory,
+      })
+
+      await th.user(TEST_USER_ID).sendMessage({
+        content: 'Reply with exactly: stale-session-beta',
+      })
+      await waitForFooterMessage({
+        discord,
+        threadId: thread.id,
+        afterMessageIncludes: 'stale-session-beta',
+        afterAuthorId: TEST_USER_ID,
+        timeout: 4_000,
+      })
+
+      const replacementSessionId = await getThreadSession(thread.id)
+      expect(await th.text()).toMatchInlineSnapshot(`
+        "--- from: user (lifecycle-tester)
+        Reply with exactly: stale-session-alpha
+        --- from: assistant (TestBot)
+        *using deterministic-provider/deterministic-v2*
+        ⬥ ok
+        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*
+        --- from: user (lifecycle-tester)
+        Reply with exactly: stale-session-beta
+        --- from: assistant (TestBot)
+        *using deterministic-provider/deterministic-v2*
+        ⬥ ok
+        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*"
+      `)
+      expect(replacementSessionId).toBeDefined()
+      expect(replacementSessionId).not.toBe(staleSessionId)
     },
     15_000,
   )

--- a/cli/src/runtime-lifecycle.e2e.test.ts
+++ b/cli/src/runtime-lifecycle.e2e.test.ts
@@ -428,7 +428,7 @@ describe('runtime lifecycle', () => {
   )
 
   test(
-    'existing runtime reconnects after shared opencode server restart',
+    'retries an accepted prompt after a stale session error from server restart',
     async () => {
       const prompt = 'Reply with exactly: reconnect-alpha'
       await discord.channel(TEXT_CHANNEL_ID).user(TEST_USER_ID).sendMessage({
@@ -449,7 +449,7 @@ describe('runtime lifecycle', () => {
         threadId: thread.id,
         userId: TEST_USER_ID,
         text: '*project',
-        timeout: 4_000,
+        timeout: 10_000,
       })
 
       const runtimeBeforeRestart = getRuntime(thread.id)
@@ -498,69 +498,7 @@ describe('runtime lifecycle', () => {
       const runtimeAfterRestart = getRuntime(thread.id)
       expect(runtimeAfterRestart).toBe(runtimeBeforeRestart)
     },
-    15_000,
-  )
-
-  test(
-    'replaces a deleted persisted session before dispatching the prompt',
-    async () => {
-      await discord.channel(TEXT_CHANNEL_ID).user(TEST_USER_ID).sendMessage({
-        content: 'Reply with exactly: stale-session-alpha',
-      })
-      const thread = await discord.channel(TEXT_CHANNEL_ID).waitForThread({
-        timeout: 4_000,
-        predicate: (candidate) => candidate.name === 'Reply with exactly: stale-session-alpha',
-      })
-      const th = discord.thread(thread.id)
-      await waitForFooterMessage({
-        discord,
-        threadId: thread.id,
-        afterMessageIncludes: 'stale-session-alpha',
-        afterAuthorId: TEST_USER_ID,
-        timeout: 4_000,
-      })
-
-      const staleSessionId = await getThreadSession(thread.id)
-      expect(staleSessionId).toBeDefined()
-      const getClient = await initializeOpencodeForDirectory(directories.projectDirectory)
-      if (getClient instanceof Error || !staleSessionId) {
-        throw getClient instanceof Error ? getClient : new Error('Expected session')
-      }
-      await getClient().session.delete({
-        sessionID: staleSessionId,
-        directory: directories.projectDirectory,
-      })
-
-      await th.user(TEST_USER_ID).sendMessage({
-        content: 'Reply with exactly: stale-session-beta',
-      })
-      await waitForFooterMessage({
-        discord,
-        threadId: thread.id,
-        afterMessageIncludes: 'stale-session-beta',
-        afterAuthorId: TEST_USER_ID,
-        timeout: 4_000,
-      })
-
-      const replacementSessionId = await getThreadSession(thread.id)
-      expect(await th.text()).toMatchInlineSnapshot(`
-        "--- from: user (lifecycle-tester)
-        Reply with exactly: stale-session-alpha
-        --- from: assistant (TestBot)
-        *using deterministic-provider/deterministic-v2*
-        ⬥ ok
-        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*
-        --- from: user (lifecycle-tester)
-        Reply with exactly: stale-session-beta
-        --- from: assistant (TestBot)
-        *using deterministic-provider/deterministic-v2*
-        ⬥ ok
-        *project ⋅ main ⋅ Ns ⋅ N% ⋅ deterministic-v2*"
-      `)
-      expect(replacementSessionId).toBeDefined()
-      expect(replacementSessionId).not.toBe(staleSessionId)
-    },
-    15_000,
+    20_000,
   )
 
   test(

--- a/cli/src/session-handler/thread-runtime-state.ts
+++ b/cli/src/session-handler/thread-runtime-state.ts
@@ -71,8 +71,8 @@ export type ThreadRunState = {
   // on first dispatch (not on thread creation). Persists across multiple
   // prompt runs — the same session is reused for the thread's lifetime.
   // Also stored in the DB (thread_sessions table) for recovery after restart.
-  // Changes: set on first dispatch, may be re-set if the old session is
-  // invalid and a new one is created. Never cleared except on dispose.
+  // Changes: set on first dispatch, may be cleared while replacing a stale
+  // mapping, then re-set when the replacement session is created.
   // Read by: dispatchPrompt, ensureSession, abortSessionViaApi, footer.
   sessionId: string | undefined
 
@@ -158,7 +158,7 @@ export function removeThread(threadId: string): void {
   })
 }
 
-export function setSessionId(threadId: string, sessionId: string): void {
+export function setSessionId(threadId: string, sessionId: string | undefined): void {
   updateThread(threadId, (t) => ({ ...t, sessionId }))
 }
 

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -610,6 +610,20 @@ type AbortRunOutcome = {
   apiAbortPromise: Promise<void> | undefined
 }
 
+type PendingStaleSessionRecovery =
+  | {
+    sessionId: string
+    input: IngressInput
+    source: 'opencode'
+    retried: boolean
+  }
+  | {
+    sessionId: string
+    input: QueuedMessage
+    source: 'local-queue'
+    retried: boolean
+  }
+
 function getWorktreePromptKey(worktree: WorktreeInfo | undefined): string | null {
   if (!worktree) {
     return null
@@ -698,6 +712,11 @@ export class ThreadSessionRuntime {
   // resolved input is then routed through the normal enqueue paths which
   // use dispatchAction internally.
   private preprocessChain: Promise<void> = Promise.resolve()
+
+  // promptAsync accepts before OpenCode resolves the session internally. Keep
+  // the accepted input until its session error arrives so a missing session can
+  // be recreated and retried exactly once from the event stream.
+  private pendingStaleSessionRecovery: PendingStaleSessionRecovery | undefined
 
   constructor(opts: RuntimeOptions) {
     this.threadId = opts.threadId
@@ -2358,6 +2377,27 @@ export class ThreadSessionRuntime {
       return
     }
 
+    const missingSessionId = getMissingSessionId({
+      message: properties.error?.data?.message || '',
+    })
+    if (missingSessionId === sessionId) {
+      const recovery = await this.prepareStaleSessionRecovery({
+        sessionId,
+      })
+      if (recovery) {
+        this.stopTyping()
+        this.markQueueDispatchIdle(sessionId)
+        void this.retryStaleSessionPrompt(recovery).catch((error) => {
+          logger.error(
+            `[SESSION RECOVERY] Retry failed for thread ${this.threadId}:`,
+            error,
+          )
+          void notifyError(error, 'Stale OpenCode session retry failed')
+        })
+        return
+      }
+    }
+
     const errorMessage = truncateSessionErrorMessage(
       formatSessionErrorFromProps(properties.error),
     )
@@ -2828,20 +2868,18 @@ export class ThreadSessionRuntime {
     }
   }
 
-  private async recoverStaleSession({
-    input,
-    staleSessionId,
-    agent,
-    model,
-    variant,
+  private async prepareStaleSessionRecovery({
+    sessionId,
   }: {
-    input: IngressInput
-    staleSessionId: string
-    agent?: string
-    model: { providerID: string; modelID: string }
-    variant?: string
-  }): Promise<{ id: string } | undefined> {
-    if (this.state?.sessionId !== staleSessionId) {
+    sessionId: string
+  }): Promise<PendingStaleSessionRecovery | undefined> {
+    const recovery = this.pendingStaleSessionRecovery
+    if (!recovery || recovery.sessionId !== sessionId || recovery.retried) {
+      return undefined
+    }
+    recovery.retried = true
+
+    if (this.state?.sessionId !== sessionId) {
       logger.warn(
         `[SESSION RECOVERY] Skipping stale mapping replacement for thread ${this.threadId}: current session changed`,
       )
@@ -2850,7 +2888,7 @@ export class ThreadSessionRuntime {
 
     const cleared = await clearThreadSessionIfMatches({
       threadId: this.thread.id,
-      sessionId: staleSessionId,
+      sessionId,
     })
     if (!cleared) {
       logger.warn(
@@ -2860,41 +2898,20 @@ export class ThreadSessionRuntime {
     }
 
     threadState.setSessionId(this.threadId, undefined)
-    const sessionResult = await this.ensureSession({
-      prompt: input.prompt,
-      agent,
-      permissions: input.permissions,
-      permissionRules: input.permissionRules,
-      injectionGuardPatterns: input.injectionGuardPatterns,
-      sessionStartScheduleKind: input.sessionStartSource?.scheduleKind,
-      sessionStartScheduledTaskId: input.sessionStartSource?.scheduledTaskId,
-    })
-    if (sessionResult instanceof Error) {
-      logger.warn(
-        `[SESSION RECOVERY] Failed to replace session ${staleSessionId} for thread ${this.threadId}: ${sessionResult.message}`,
-      )
-      return undefined
-    }
+    return recovery
+  }
 
-    const { session, getClient, createdNewSession } = sessionResult
-    await ensureSessionPreferencesSnapshot({
-      sessionId: session.id,
-      channelId: this.channelId,
-      appId: input.appId,
-      getClient,
-      directory: this.sdkDirectory,
-      agentOverride: agent,
-      force: createdNewSession,
-    })
-    await setSessionModel({
-      sessionId: session.id,
-      modelId: `${model.providerID}/${model.modelID}`,
-      variant: variant ?? null,
-    })
+  private async retryStaleSessionPrompt(
+    recovery: PendingStaleSessionRecovery,
+  ): Promise<void> {
     logger.log(
-      `[SESSION RECOVERY] Replaced stale session ${staleSessionId} with ${session.id} for thread ${this.threadId}`,
+      `[SESSION RECOVERY] Retrying prompt after replacing stale session ${recovery.sessionId} for thread ${this.threadId}`,
     )
-    return session
+    if (recovery.source === 'opencode') {
+      await this.submitViaOpencodeQueue(recovery.input, true)
+      return
+    }
+    await this.dispatchPrompt(recovery.input, true)
   }
 
   // ── Ingress API ─────────────────────────────────────────────
@@ -2907,7 +2924,10 @@ export class ThreadSessionRuntime {
    * recovery so that promptAsync receives the same agent/model/variant/system
    * fields that the local-queue path provides.
    */
-  private async submitViaOpencodeQueue(input: IngressInput): Promise<EnqueueResult> {
+  private async submitViaOpencodeQueue(
+    input: IngressInput,
+    staleSessionRetry = false,
+  ): Promise<EnqueueResult> {
     let skippedBySessionGuard = false
 
     await this.dispatchAction(async () => {
@@ -3077,11 +3097,13 @@ export class ThreadSessionRuntime {
         ? { variant: thinkingValue }
         : {}
 
-      await this.sendNewSessionModelInfo({
-        createdNewSession,
-        model: modelField,
-        agent: resolvedAgent,
-      })
+      if (!staleSessionRetry) {
+        await this.sendNewSessionModelInfo({
+          createdNewSession,
+          model: modelField,
+          agent: resolvedAgent,
+        })
+      }
 
       // ── Build prompt parts ──────────────────────────────────
       const images = input.images || []
@@ -3167,41 +3189,6 @@ export class ThreadSessionRuntime {
         const errorMessage = promptResult instanceof Error
           ? promptResult.message
           : extractSdkErrorMessage(promptResult.error)
-        const missingSessionId = getMissingSessionId({ message: errorMessage })
-        if (missingSessionId === session.id) {
-          const replacementSession = await this.recoverStaleSession({
-            input,
-            staleSessionId: session.id,
-            agent: resolvedAgent,
-            model: modelField,
-            variant: thinkingValue,
-          })
-          if (replacementSession) {
-            const retryResult = await getClient().session.promptAsync({
-              ...request,
-              sessionID: replacementSession.id,
-              system: getOpencodeSystemMessage({
-                sessionId: replacementSession.id,
-                channelId,
-                guildId: this.thread.guildId,
-                threadId: this.thread.id,
-                channelTopic,
-                agents: availableAgents,
-                username: this.state?.sessionUsername || input.username,
-                userId: this.state?.sessionUserId || input.userId,
-              }),
-            }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
-            if (!(retryResult instanceof Error) && !retryResult.error) {
-              logger.log(
-                `[INGRESS] promptAsync recovered stale sessionId=${session.id} replacementSessionId=${replacementSession.id} threadId=${this.threadId}`,
-              )
-              if (!input.noReply) {
-                this.markQueueDispatchBusy(replacementSession.id)
-              }
-              return
-            }
-          }
-        }
         const errObj = promptResult instanceof Error
           ? promptResult
           : new Error(errorMessage)
@@ -3217,6 +3204,12 @@ export class ThreadSessionRuntime {
       // noReply messages don't trigger the agent loop, so don't mark as busy
       if (!input.noReply) {
         this.markQueueDispatchBusy(session.id)
+      }
+      this.pendingStaleSessionRecovery = {
+        sessionId: session.id,
+        input,
+        source: 'opencode',
+        retried: staleSessionRetry,
       }
     })
 
@@ -3659,7 +3652,10 @@ export class ThreadSessionRuntime {
   // The listener is already running, so this only handles
   // session ensure + model/agent + SDK call + state.
 
-  private async dispatchPrompt(input: QueuedMessage): Promise<void> {
+  private async dispatchPrompt(
+    input: QueuedMessage,
+    staleSessionRetry = false,
+  ): Promise<void> {
     this.lastDisplayedContextPercentage = 0
     this.lastRateLimitDisplayTime = 0
 
@@ -3829,11 +3825,13 @@ export class ThreadSessionRuntime {
       modelID: earlyModelParam.modelID,
     })
 
-    await this.sendNewSessionModelInfo({
-      createdNewSession,
-      model: earlyModelParam,
-      agent: earlyAgentPreference,
-    })
+    if (!staleSessionRetry) {
+      await this.sendNewSessionModelInfo({
+        createdNewSession,
+        model: earlyModelParam,
+        agent: earlyAgentPreference,
+      })
+    }
 
     // ── Build prompt parts ────────────────────────────────────
     const images = input.images || []
@@ -4046,42 +4044,6 @@ export class ThreadSessionRuntime {
         if (promptResponse instanceof Error) return promptResponse.message
         return parseOpenCodeErrorMessage(promptResponse.error)
       })()
-      const missingSessionId = getMissingSessionId({ message: errorMessage })
-      if (missingSessionId === session.id) {
-        const replacementSession = await this.recoverStaleSession({
-          input,
-          staleSessionId: session.id,
-          agent: earlyAgentPreference,
-          model: earlyModelParam,
-          variant: earlyThinkingValue,
-        })
-        if (replacementSession) {
-          const retryResponse = await getClient().session.promptAsync({
-            sessionID: replacementSession.id,
-            directory: this.sdkDirectory,
-            parts,
-            system: getOpencodeSystemMessage({
-              sessionId: replacementSession.id,
-              channelId,
-              guildId: this.thread.guildId,
-              threadId: this.thread.id,
-              channelTopic,
-              agents: earlyAvailableAgents,
-              username: this.state?.sessionUsername || input.username,
-              userId: this.state?.sessionUserId || input.userId,
-            }),
-            model: earlyModelParam,
-            agent: earlyAgentPreference,
-            ...variantField,
-          }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
-          if (!(retryResponse instanceof Error) && !retryResponse.error) {
-            logger.log(
-              `[DISPATCH] promptAsync recovered stale sessionId=${session.id} replacementSessionId=${replacementSession.id} threadId=${this.threadId}`,
-            )
-            return
-          }
-        }
-      }
       const errorObject = promptResponse instanceof Error
         ? promptResponse
         : new Error(errorMessage)
@@ -4100,6 +4062,12 @@ export class ThreadSessionRuntime {
     logger.log(
       `[DISPATCH] promptAsync accepted by opencode queue sessionId=${session.id} threadId=${this.threadId}`,
     )
+    this.pendingStaleSessionRecovery = {
+      sessionId: session.id,
+      input,
+      source: 'local-queue',
+      retried: staleSessionRetry,
+    }
   }
 
   // ── Session Ensure ──────────────────────────────────────────

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -50,8 +50,10 @@ import {
   setPartMessage,
   getThreadSession,
   setThreadSession,
+  clearThreadSessionIfMatches,
   getThreadWorktreeOrWorkspace,
   setSessionAgent,
+  setSessionModel,
   clearSessionModel,
   getVariantCascade,
   setSessionStartSource,
@@ -153,6 +155,7 @@ const logger = createLogger(LogPrefix.SESSION)
 const discordLogger = createLogger(LogPrefix.DISCORD)
 const DETERMINISTIC_CONTEXT_LIMIT = 100_000
 const TOAST_SESSION_ID_REGEX = /\b(ses_[A-Za-z0-9]+)\b\s*$/u
+const SESSION_NOT_FOUND_REGEX = /(?:Session not found:\s*|Session\s+)(ses_[A-Za-z0-9]+)(?:\s+not found)?\b/iu
 
 function extractToastSessionId({ message }: { message: string }): string | undefined {
   const match = message.match(TOAST_SESSION_ID_REGEX)
@@ -161,6 +164,10 @@ function extractToastSessionId({ message }: { message: string }): string | undef
 
 function stripToastSessionId({ message }: { message: string }): string {
   return message.replace(TOAST_SESSION_ID_REGEX, '').trimEnd()
+}
+
+function getMissingSessionId({ message }: { message: string }): string | undefined {
+  return message.match(SESSION_NOT_FOUND_REGEX)?.[1]
 }
 
 const shouldLogSessionEvents =
@@ -2821,6 +2828,75 @@ export class ThreadSessionRuntime {
     }
   }
 
+  private async recoverStaleSession({
+    input,
+    staleSessionId,
+    agent,
+    model,
+    variant,
+  }: {
+    input: IngressInput
+    staleSessionId: string
+    agent?: string
+    model: { providerID: string; modelID: string }
+    variant?: string
+  }): Promise<{ id: string } | undefined> {
+    if (this.state?.sessionId !== staleSessionId) {
+      logger.warn(
+        `[SESSION RECOVERY] Skipping stale mapping replacement for thread ${this.threadId}: current session changed`,
+      )
+      return undefined
+    }
+
+    const cleared = await clearThreadSessionIfMatches({
+      threadId: this.thread.id,
+      sessionId: staleSessionId,
+    })
+    if (!cleared) {
+      logger.warn(
+        `[SESSION RECOVERY] Skipping stale mapping replacement for thread ${this.threadId}: persisted session changed`,
+      )
+      return undefined
+    }
+
+    threadState.setSessionId(this.threadId, undefined)
+    const sessionResult = await this.ensureSession({
+      prompt: input.prompt,
+      agent,
+      permissions: input.permissions,
+      permissionRules: input.permissionRules,
+      injectionGuardPatterns: input.injectionGuardPatterns,
+      sessionStartScheduleKind: input.sessionStartSource?.scheduleKind,
+      sessionStartScheduledTaskId: input.sessionStartSource?.scheduledTaskId,
+    })
+    if (sessionResult instanceof Error) {
+      logger.warn(
+        `[SESSION RECOVERY] Failed to replace session ${staleSessionId} for thread ${this.threadId}: ${sessionResult.message}`,
+      )
+      return undefined
+    }
+
+    const { session, getClient, createdNewSession } = sessionResult
+    await ensureSessionPreferencesSnapshot({
+      sessionId: session.id,
+      channelId: this.channelId,
+      appId: input.appId,
+      getClient,
+      directory: this.sdkDirectory,
+      agentOverride: agent,
+      force: createdNewSession,
+    })
+    await setSessionModel({
+      sessionId: session.id,
+      modelId: `${model.providerID}/${model.modelID}`,
+      variant: variant ?? null,
+    })
+    logger.log(
+      `[SESSION RECOVERY] Replaced stale session ${staleSessionId} with ${session.id} for thread ${this.threadId}`,
+    )
+    return session
+  }
+
   // ── Ingress API ─────────────────────────────────────────────
 
   /**
@@ -3091,6 +3167,41 @@ export class ThreadSessionRuntime {
         const errorMessage = promptResult instanceof Error
           ? promptResult.message
           : extractSdkErrorMessage(promptResult.error)
+        const missingSessionId = getMissingSessionId({ message: errorMessage })
+        if (missingSessionId === session.id) {
+          const replacementSession = await this.recoverStaleSession({
+            input,
+            staleSessionId: session.id,
+            agent: resolvedAgent,
+            model: modelField,
+            variant: thinkingValue,
+          })
+          if (replacementSession) {
+            const retryResult = await getClient().session.promptAsync({
+              ...request,
+              sessionID: replacementSession.id,
+              system: getOpencodeSystemMessage({
+                sessionId: replacementSession.id,
+                channelId,
+                guildId: this.thread.guildId,
+                threadId: this.thread.id,
+                channelTopic,
+                agents: availableAgents,
+                username: this.state?.sessionUsername || input.username,
+                userId: this.state?.sessionUserId || input.userId,
+              }),
+            }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
+            if (!(retryResult instanceof Error) && !retryResult.error) {
+              logger.log(
+                `[INGRESS] promptAsync recovered stale sessionId=${session.id} replacementSessionId=${replacementSession.id} threadId=${this.threadId}`,
+              )
+              if (!input.noReply) {
+                this.markQueueDispatchBusy(replacementSession.id)
+              }
+              return
+            }
+          }
+        }
         const errObj = promptResult instanceof Error
           ? promptResult
           : new Error(errorMessage)
@@ -3935,6 +4046,42 @@ export class ThreadSessionRuntime {
         if (promptResponse instanceof Error) return promptResponse.message
         return parseOpenCodeErrorMessage(promptResponse.error)
       })()
+      const missingSessionId = getMissingSessionId({ message: errorMessage })
+      if (missingSessionId === session.id) {
+        const replacementSession = await this.recoverStaleSession({
+          input,
+          staleSessionId: session.id,
+          agent: earlyAgentPreference,
+          model: earlyModelParam,
+          variant: earlyThinkingValue,
+        })
+        if (replacementSession) {
+          const retryResponse = await getClient().session.promptAsync({
+            sessionID: replacementSession.id,
+            directory: this.sdkDirectory,
+            parts,
+            system: getOpencodeSystemMessage({
+              sessionId: replacementSession.id,
+              channelId,
+              guildId: this.thread.guildId,
+              threadId: this.thread.id,
+              channelTopic,
+              agents: earlyAvailableAgents,
+              username: this.state?.sessionUsername || input.username,
+              userId: this.state?.sessionUserId || input.userId,
+            }),
+            model: earlyModelParam,
+            agent: earlyAgentPreference,
+            ...variantField,
+          }).catch((e) => new OpenCodeSdkError({ operation: 'session.promptAsync', cause: e }))
+          if (!(retryResponse instanceof Error) && !retryResponse.error) {
+            logger.log(
+              `[DISPATCH] promptAsync recovered stale sessionId=${session.id} replacementSessionId=${replacementSession.id} threadId=${this.threadId}`,
+            )
+            return
+          }
+        }
+      }
       const errorObject = promptResponse instanceof Error
         ? promptResponse
         : new Error(errorMessage)


### PR DESCRIPTION
## Summary
- Recover only from a session-scoped `Session not found: ses_*` event after OpenCode has accepted a prompt.
- Atomically clear only the matching persisted mapping, recreate through the normal ingress lifecycle, preserve prompt context, and retry once.
- Cover the asynchronous server-restart lifecycle; the superseded synchronous deleted-session test is removed.

Fixes #165

Depends on #164. This PR is based on the reachable gateway-proxy submodule pointer from #164; GitHub does not permit `chubes4:fix/163-gateway-proxy-submodule` as an upstream PR base.

## Verification
- `pnpm tsc`
- `pnpm test -- -u --run src/runtime-lifecycle.e2e.test.ts -t "retries an accepted prompt"`
- `pnpm test -- --run`: 456 passed, 17 skipped; stale-session lifecycle test passed.

The full suite still has three unrelated failures: `/btw` fork thread creation timeout, typing lifecycle initial-reply timeout, and the branch-dependent non-git worktree snapshot. No snapshots were updated for those failures.

## AI Disclosure
Implemented with OpenCode using `openai/gpt-5.6-terra`.