### PR TITLE
Extend interaction wait timeouts to 24 hours

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -84,7 +84,7 @@ cli
   )
   .option(
     '--permission-timeout-minutes <minutes>',
-    'Permission prompt timeout in minutes before auto-rejecting (default: 10)',
+    'Permission prompt timeout in minutes before auto-rejecting (default: 1440)',
   )
   .option(
     '--disable-sync',

--- a/cli/src/commands/ask-question.ts
+++ b/cli/src/commands/ask-question.ts
@@ -45,7 +45,7 @@ type PendingQuestionContext = {
 
 // Store pending question contexts by hash.
 // TTL prevents unbounded growth if user never answers a question.
-const QUESTION_CONTEXT_TTL_MS = 10 * 60 * 1000
+const QUESTION_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000
 export const pendingQuestionContexts = new Map<string, PendingQuestionContext>()
 
 export function areAllQuestionsAnswered({

--- a/cli/src/commands/permissions.ts
+++ b/cli/src/commands/permissions.ts
@@ -115,7 +115,7 @@ type PendingPermissionContext = {
 
 // Store pending permission contexts by hash.
 // TTL prevents unbounded growth if user never clicks a permission button.
-// Configurable via --permission-timeout-minutes CLI flag (default: 10 minutes).
+// Configurable via --permission-timeout-minutes CLI flag (default: 24 hours).
 export const pendingPermissionContexts = new Map<
   string,
   PendingPermissionContext

--- a/cli/src/ipc-tools-plugin.ts
+++ b/cli/src/ipc-tools-plugin.ts
@@ -42,7 +42,7 @@ const logger = createPluginLogger('OPENCODE')
 
 const FILE_UPLOAD_TIMEOUT_MS = 6 * 60 * 1000
 const DEFAULT_FILE_UPLOAD_MAX_FILES = 5
-const ACTION_BUTTON_TIMEOUT_MS = 30 * 1000
+const ACTION_BUTTON_TIMEOUT_MS = 24 * 60 * 60 * 1000
 
 async function loadDatabaseModule() {
   // The plugin-loading e2e test boots OpenCode directly without the bot-side

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -178,7 +178,7 @@ export const store = createStore<KimakiState>(() => ({
   disabledSkills: [],
   allowedMentions: ['users'],
   allowAllUsers: false,
-  permissionTimeoutMs: 10 * 60 * 1000,
+  permissionTimeoutMs: 24 * 60 * 60 * 1000,
   useWorktrees: false,
   autoUpgradeEnabled: true,
   syncEnabled: true,


### PR DESCRIPTION
## What

Bumps the "wait for a user click/approval" timeouts from minutes/seconds to **24 hours**, since users frequently step away and come back later to answer a question, approve a permission, or click an action button.

| Interaction | Before | After |
|---|---|---|
| Question select menu (`QUESTION_CONTEXT_TTL_MS`) | 10 min | 24 h |
| Action buttons (`ACTION_BUTTON_TIMEOUT_MS`) | 30 s | 24 h |
| Permission prompt (`permissionTimeoutMs` default) | 10 min | 24 h |

The `--permission-timeout-minutes` flag still overrides the permission default; CLI help + comments updated to match (default now 1440).

## Why

Reported in real use: questions/approvals expire before the user returns to click them. The IPC row TTL (`STALE_TTL_MS`) is already 24 h, so this aligns the interactive-wait timeouts with that intent.

## Notes

- 5 one-line changes, all type-preserving (numeric/string literals).
- `ACTION_BUTTON_TIMEOUT_MS` governs a blocking poll in the action-buttons tool; it now waits up to 24 h for a click (previously gave up at 30 s), matching the file-upload pattern.