### PR TITLE
fix(session): scope global OpenCode events before enqueueing them

### DIFF
--- a/.changeset/demux-global-events-before-queue.md
+++ b/.changeset/demux-global-events-before-queue.md
@@ -1,0 +1,11 @@
+---
+'kimaki': patch
+---
+
+Prevent active OpenCode sessions from blocking unrelated Discord threads.
+
+Global OpenCode events are now filtered by session before entering each
+thread's serialized action queue. Previously, every event from every active
+session was queued and buffered by every thread runtime, allowing a busy
+session to create a growing backlog that stopped other threads from replying
+while their typing indicators remained active.

--- a/cli/src/session-handler/event-routing.test.ts
+++ b/cli/src/session-handler/event-routing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+import { shouldRouteEventToRuntime } from './event-routing.js'
+
+describe('shouldRouteEventToRuntime', () => {
+  test('routes events for the active session', () => {
+    expect(
+      shouldRouteEventToRuntime({
+        eventType: 'message.part.updated',
+        eventSessionId: 'ses_active',
+        toastSessionId: undefined,
+        activeSessionId: 'ses_active',
+        isSubtaskSession: false,
+      }),
+    ).toBe(true)
+  })
+
+  test('drops foreign session events before they enter the runtime queue', () => {
+    expect(
+      shouldRouteEventToRuntime({
+        eventType: 'message.part.updated',
+        eventSessionId: 'ses_foreign',
+        toastSessionId: undefined,
+        activeSessionId: 'ses_active',
+        isSubtaskSession: false,
+      }),
+    ).toBe(false)
+  })
+
+  test('routes subtask session events', () => {
+    expect(
+      shouldRouteEventToRuntime({
+        eventType: 'message.part.updated',
+        eventSessionId: 'ses_subtask',
+        toastSessionId: undefined,
+        activeSessionId: 'ses_active',
+        isSubtaskSession: true,
+      }),
+    ).toBe(true)
+  })
+
+  test('routes global toasts but drops toasts scoped to another session', () => {
+    expect(
+      shouldRouteEventToRuntime({
+        eventType: 'tui.toast.show',
+        eventSessionId: undefined,
+        toastSessionId: undefined,
+        activeSessionId: 'ses_active',
+        isSubtaskSession: false,
+      }),
+    ).toBe(true)
+    expect(
+      shouldRouteEventToRuntime({
+        eventType: 'tui.toast.show',
+        eventSessionId: undefined,
+        toastSessionId: 'ses_foreign',
+        activeSessionId: 'ses_active',
+        isSubtaskSession: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/cli/src/session-handler/event-routing.ts
+++ b/cli/src/session-handler/event-routing.ts
@@ -1,0 +1,20 @@
+export function shouldRouteEventToRuntime({
+  eventType,
+  eventSessionId,
+  toastSessionId,
+  activeSessionId,
+  isSubtaskSession,
+}: {
+  eventType: string
+  eventSessionId: string | undefined
+  toastSessionId: string | undefined
+  activeSessionId: string | undefined
+  isSubtaskSession: boolean
+}): boolean {
+  if (eventType === 'tui.toast.show') {
+    if (!toastSessionId) return true
+    return toastSessionId === activeSessionId || isSubtaskSession
+  }
+  if (!eventSessionId) return true
+  return eventSessionId === activeSessionId || isSubtaskSession
+}

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -36,6 +36,7 @@ import {
   unregisterEventListener,
   waitForGlobalEventListener,
 } from './global-event-listener.js'
+import { shouldRouteEventToRuntime } from './event-routing.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import {
   sendThreadMessage,
@@ -764,6 +765,10 @@ export class ThreadSessionRuntime {
     // directory are demuxed and dispatched through our action queue.
     registerEventListener(this.threadId, (event) => {
       if (this.disposed) return
+      // Filter BEFORE enqueueing: the global listener broadcasts every event to
+      // every registered runtime, so queueing first lets one busy session build
+      // a backlog in unrelated threads' serialized queues.
+      if (!this.shouldRouteEvent(event)) return
       void this.dispatchAction(async () => {
         await this.sentPartIdsBootstrap
         await this.handleEvent(event)
@@ -1014,6 +1019,28 @@ export class ThreadSessionRuntime {
       events: this.eventBuffer,
       sessionId,
       upToIndex: normalizedIndex,
+    })
+  }
+
+  /**
+   * Whether a global-listener event belongs to this runtime. Used both before
+   * enqueueing (to keep other sessions' traffic out of this thread's queue)
+   * and again after dequeue (session ownership can change while queued).
+   */
+  private shouldRouteEvent(event: OpenCodeEvent): boolean {
+    const eventSessionId = getOpencodeEventSessionId(event)
+    const toastSessionId = event.type === 'tui.toast.show'
+      ? extractToastSessionId({ message: event.properties.message })
+      : undefined
+    const scopedSessionId = toastSessionId ?? eventSessionId
+    return shouldRouteEventToRuntime({
+      eventType: event.type,
+      eventSessionId,
+      toastSessionId,
+      activeSessionId: this.state?.sessionId,
+      isSubtaskSession: scopedSessionId
+        ? Boolean(this.getSubtaskInfoForSession(scopedSessionId))
+        : false,
     })
   }
 
@@ -1405,20 +1432,11 @@ export class ThreadSessionRuntime {
       )
     }
 
-    const isGlobalEvent = event.type === 'tui.toast.show'
-    const isScopedToastEvent = Boolean(toastSessionId)
-
-    // Drop events that don't match current session (stale events from
-    // previous sessions), unless it's a global event or a subtask session.
-    if (!isGlobalEvent && eventSessionId && eventSessionId !== sessionId) {
-      if (!this.getSubtaskInfoForSession(eventSessionId)) {
-        return // stale event from previous session
-      }
-    }
-    if (isScopedToastEvent && toastSessionId !== sessionId) {
-      if (!this.getSubtaskInfoForSession(toastSessionId!)) {
-        return
-      }
+    // Re-check routing: session ownership can change while an event waits in
+    // the action queue (e.g. the thread switched sessions), so an event that
+    // was routable at enqueue time may be stale by the time it is processed.
+    if (!this.shouldRouteEvent(event)) {
+      return
     }
 
     if (isOpencodeSessionEventLogEnabled()) {


### PR DESCRIPTION
Fixes #180.

## Problem

The global SSE listener broadcasts every event to every registered thread runtime. Each runtime enqueued **all** of them into its serialized action queue and only filtered by session inside `handleEvent` — after the event was already queued and buffered.

Work therefore scales as `events × registered runtimes`. One chatty session pushes thousands of irrelevant actions into unrelated threads' queues, so those threads' own messages sit behind a growing backlog while the typing indicator stays active.

## Change

- **Filter before `dispatchAction`** — other sessions' traffic never enters this thread's queue.
- **Re-check after dequeue** — a thread's session can change while an event waits, so an event that was routable at enqueue time may be stale when processed.
- Routing logic extracted to a pure `shouldRouteEventToRuntime()` in `event-routing.ts` so it's unit-testable.
- Global toasts and subtask-session events are delivered exactly as before.

## Verification

- 4 new regression tests in `event-routing.test.ts` — all passing
- No new type errors introduced

> Note: `pnpm tsc` on current `main` fails with `Cannot find module '../analytics.js'` (imported at `thread-session-runtime.ts:106`, but `cli/src/analytics.ts` isn't in the repo). That's pre-existing and unrelated — filed separately. This branch adds no new errors beyond it.

Happy to adjust naming or split the helper differently.



## Update: reproduces on 0.25.0

The unfiltered fanout path survives two minor versions past the original report. Verified in the **published** `kimaki@0.25.0` dist:

```js
// 0.25.0  dist/session-handler/thread-session-runtime.js:412
registerEventListener(this.threadId, (event) => {
    if (this.disposed) return;
    void this.dispatchAction(async () => {   // still unfiltered
        await this.sentPartIdsBootstrap;
        await this.handleEvent(event);
    });
});
```

(Was line 391 in 0.23.1 — same shape, so this fix is still current.)