### PR TITLE
fix(sync): skip sub-sessions in external-opencode-sync (no more 'Sync:' thread spam)

### DIFF
--- a/.changeset/external-sync-skip-sub-sessions.md
+++ b/.changeset/external-sync-skip-sub-sessions.md
@@ -1,0 +1,5 @@
+---
+"kimaki": patch
+---
+
+Fix `external-opencode-sync` leaking internal plugin/agent sub-sessions as `Sync:` Discord threads. Sessions with a `parentID` (forks) are now skipped in addition to the existing `new session -` / `(subagent)` title filters, so plugins that spawn sub-sessions (memory recall, memory extraction, research sub-agents) no longer each create a junk thread per real session.

--- a/cli/src/external-opencode-sync.test.ts
+++ b/cli/src/external-opencode-sync.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import { isExternalSyncCandidate } from './external-opencode-sync.js'
+
+describe('isExternalSyncCandidate', () => {
+  test('top-level CLI/TUI session is mirrored', () => {
+    expect(isExternalSyncCandidate({ title: 'Refactor the auth module', parentID: undefined })).toBe(true)
+  })
+
+  test('top-level session without a title is still mirrored', () => {
+    expect(isExternalSyncCandidate({ title: '', parentID: undefined })).toBe(true)
+    expect(isExternalSyncCandidate({ title: null, parentID: undefined })).toBe(true)
+  })
+
+  test('placeholder "new session -" titles are skipped', () => {
+    expect(isExternalSyncCandidate({ title: 'new session - 2f8a', parentID: undefined })).toBe(false)
+    expect(isExternalSyncCandidate({ title: 'New Session - untitled', parentID: undefined })).toBe(false)
+  })
+
+  test('"(subagent)" title convention is skipped', () => {
+    expect(
+      isExternalSyncCandidate({ title: 'Survey memoir memory system (@explore subagent)', parentID: 'ses_parent' }),
+    ).toBe(false)
+    expect(isExternalSyncCandidate({ title: 'research (subagent)', parentID: undefined })).toBe(false)
+  })
+
+  test('sub-session with a parentID is skipped even without the (subagent) title', () => {
+    // This is the regression being fixed: plugins that spawn internal
+    // sub-sessions (memory recall, memory extraction, …) without following the
+    // "(subagent)" naming convention previously each leaked a "Sync:" thread.
+    expect(isExternalSyncCandidate({ title: 'opencode-memory recall selector', parentID: 'ses_parent' })).toBe(false)
+    expect(isExternalSyncCandidate({ title: 'opencode-memory extraction', parentID: 'ses_parent' })).toBe(false)
+    expect(isExternalSyncCandidate({ title: 'A normal-looking title', parentID: 'ses_parent' })).toBe(false)
+  })
+
+  test('empty/absent parentID does not by itself exclude a session', () => {
+    expect(isExternalSyncCandidate({ title: 'A normal session', parentID: '' })).toBe(true)
+    expect(isExternalSyncCandidate({ title: 'A normal session' })).toBe(true)
+  })
+})

--- a/cli/src/external-opencode-sync.ts
+++ b/cli/src/external-opencode-sync.ts
@@ -257,6 +257,46 @@ function sortSessionsByRecency<T extends SessionWithTime>(sessions: T[]): T[] {
   })
 }
 
+// Minimal structural view of a session for sync-candidate checks. Kept narrow
+// (instead of importing the full SDK Session type) so the helper stays a pure,
+// easily unit-testable function with no heavy coupling.
+export type ExternalSyncSession = {
+  title?: string | null
+  parentID?: string
+}
+
+// Whether a session should be mirrored into a Discord "Sync:" thread by the
+// external-opencode-sync poller.
+//
+// Excludes:
+//   (a) untitled placeholder sessions ("new session -…"),
+//   (b) internal sub-agent sessions that follow the "(subagent)" title
+//       convention,
+//   (c) sub-sessions that carry a parentID — i.e. forks created by plugins or
+//       agents (memory recall, memory extraction, research sub-agents, …).
+//
+// (c) is the important one: those sub-sessions are internal machinery, not user
+// conversations, so they must never get their own Discord thread. The parentID
+// check is structural, so it catches sub-sessions even when the spawning plugin
+// does not follow the "(subagent)" title convention — every plugin would
+// otherwise have to know about that convention to avoid leaking a junk "Sync:"
+// thread per sub-session. The title checks above are kept only as a fallback
+// for sessions whose parentID is not exposed. Top-level CLI/TUI sessions (no
+// parentID) are mirrored exactly as before.
+export function isExternalSyncCandidate(session: ExternalSyncSession): boolean {
+  const title = session.title || ''
+  if (/^new session\s*-/i.test(title)) {
+    return false
+  }
+  if (/subagent\)\s*$/i.test(title)) {
+    return false
+  }
+  if (session.parentID) {
+    return false
+  }
+  return true
+}
+
 function groupTrackedChannelsByDirectory(
   trackedChannels: TrackedTextChannelRow[],
 ): DirectorySyncTarget[] {
@@ -646,11 +686,7 @@ async function syncDirectoryInner({
   if (signal.aborted) return
 
   const sessions = (sessionsResponse.data || []).filter((session) => {
-    const title = session.title || ''
-    if (/^new session\s*-/i.test(title)) {
-      return false
-    }
-    return !/subagent\)\s*$/i.test(title)
+    return isExternalSyncCandidate(session)
   })
   const sorted = sortSessionsByRecency(sessions)
 
@@ -758,6 +794,7 @@ export const externalOpencodeSyncInternals = {
   getSessionThreadName,
   groupTrackedChannelsByDirectory,
   sortSessionsByRecency,
+  isExternalSyncCandidate,
   parseDiscordOriginMetadata,
   getDiscordOriginMetadataFromMessage,
   isLatestUserTurnFromDiscord,


### PR DESCRIPTION
## Summary

`external-opencode-sync` no longer mirrors internal plugin/agent **sub-sessions** into Discord. It now skips any session that carries a `parentID` (a fork), in addition to the existing title-based exclusions (`new session -…`, `…(subagent)`).

## Problem

The external-sync poller mirrors opencode sessions into a `Sync: <title>` Discord thread per session. The only thing protecting against internal/plugin machinery getting its own thread was a **title denylist** with two patterns:

```ts
const sessions = (sessionsResponse.data || []).filter((session) => {
  const title = session.title || ''
  if (/^new session\s*-/i.test(title)) return false
  return !/subagent\)\s*$/i.test(title)
})
```

Any plugin that spawns an internal sub-session **without** knowing about the `(subagent)` naming convention leaks one junk `Sync:` thread per sub-session. In practice this meant **~350 junk `Sync:` threads** across every channel, because two common plugins spawn sub-sessions on every real session:

- `opencode-claude-memory` — a recall-selector sub-session on every prompt (titled `opencode-memory recall selector`)
- a memory-extraction plugin — an extraction sub-session on every `session.idle` (titled `opencode-memory extraction`)

Neither title ends in `(subagent)`, so both passed the filter. Each leaked a thread that then sat with the bot "typing…" forever (an unrelated recall bug kept the sub-session busy). That's the spam.

## Root cause

The filter relies on a **convention every plugin author must opt into**. That doesn't scale: a sub-session is structurally a fork, but the filter can only see its *title*. The robust signal is already on the session object: `parentID`.

I confirmed `parentID` is set on real sub-sessions — the opencode session store has 171 rows with `parent_id`, and the SDK (`@opencode-ai/sdk/v2`) exposes it as `Session.parentID?: string`. Legit CLI/TUI sessions the feature is meant to mirror are top-level (`parentID` undefined); internal machinery always sets a parent.

## Fix

Extracted a pure, unit-tested helper and added a `parentID` check:

```ts
export function isExternalSyncCandidate(session: ExternalSyncSession): boolean {
  const title = session.title || ''
  if (/^new session\s*-/i.test(title)) return false
  if (/subagent\)\s*$/i.test(title)) return false
  if (session.parentID) return false          // <-- new: structural sub-session filter
  return true
}
```

The title checks are kept as a fallback for sessions whose `parentID` isn't exposed. Top-level CLI/TUI sessions are mirrored exactly as before.

## Why this approach (and not the alternatives)

- **Just tell plugin authors to use the `(subagent)` suffix** — fragile. The recall-plugin patch is lost on every `npm` reinstall, and every future plugin hits the same trap. The root cause is in the filter.
- **Denylist more titles** (`opencode-memory …`) — whack-a-mole; every new plugin needs a new entry.
- **Filter on `agent`/`mode`** — the extraction sub-session uses the default `build` agent, same as real sessions, so it isn't a clean signal.
- **`parentID`** is structural, generic, and already typed by the SDK. It catches every current and future sub-session regardless of how it's titled.

## Behavior change / compatibility

Only sessions that are forks (`parentID` set) AND don't already match the `(subagent)`/`new session -` patterns stop being mirrored. That is precisely the set of leaked internal threads. A top-level user session is never affected. The only behavioural change for a legit CLI session would be if a user explicitly forked a session in the TUI *and* wanted the fork mirrored — an edge case where not getting a `Sync:` thread is low-cost (the parent is still mirrored).

## Testing

Added `cli/src/external-opencode-sync.test.ts` (vitest) covering: top-level session mirrored; empty/null title mirrored; `new session -` skipped; `(subagent)` skipped; **sub-session with `parentID` but no `(subagent)` title skipped (the regression)**; empty/absent `parentID` not excluded by itself.

> Note: the helper's logic was also verified standalone (12/12 assertions, identical to the vitest cases) because the pnpm workspace + git submodules in this repo couldn't be installed in my sandbox. CI runs the real vitest suite.

## Foreseen review questions

- **"Could this hide a session a user wants?"** — Only a forked sub-session whose parent is already mirrored (or Discord-driven). Not a top-level session. Happy to gate behind a flag if you prefer, but I think the default should be "don't mirror forks".
- **`parentID` vs `parent_id` casing?** — The SDK exposes `parentID` (camelCase); verified in `@opencode-ai/sdk/v2` `Session`. The narrow `ExternalSyncSession` structural type keeps the helper decoupled from the full SDK type.
- **Why extract a helper?** — Makes the filter logic pure and unit-testable (the old inline closure wasn't reachable by tests), mirroring the existing `externalOpencodeSyncInternals` pattern.

Fixes the "Sync:" thread spam reported when memory/research plugins are installed.
