### PR TITLE
feat: add session housekeeping command

### DIFF
--- a/.changeset/add-housekeeping-command.md
+++ b/.changeset/add-housekeeping-command.md
@@ -1,0 +1,5 @@
+---
+"kimaki": minor
+---
+
+Add a dry-run `kimaki housekeeping` command that can archive inactive Discord threads and explicitly purge aged persisted session events.

--- a/cli/src/cli-commands/maintenance.ts
+++ b/cli/src/cli-commands/maintenance.ts
@@ -11,10 +11,34 @@ import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { spawn, execSync } from 'node:child_process'
 import { createLogger, LogPrefix, initLogFile } from '../logger.js'
-import { createDiscordClient, initDatabase, getChannelDirectory, initializeOpencodeForDirectory, createProjectChannels } from '../discord-bot.js'
-import { getBotTokenWithMode, getThreadSession, getThreadIdBySessionId, getSessionEventSnapshot, createScheduledTask, listScheduledTasks, cancelScheduledTask, getScheduledTask, updateScheduledTask, getSessionStartSourcesBySessionIds, deleteChannelDirectoryById, findChannelsByDirectory } from '../database.js'
+import {
+  createDiscordClient,
+  initDatabase,
+  getChannelDirectory,
+  initializeOpencodeForDirectory,
+  createProjectChannels,
+} from '../discord-bot.js'
+import {
+  getBotTokenWithMode,
+  getThreadSession,
+  getThreadIdBySessionId,
+  getSessionEventSnapshot,
+  createScheduledTask,
+  listScheduledTasks,
+  cancelScheduledTask,
+  getScheduledTask,
+  updateScheduledTask,
+  getSessionStartSourcesBySessionIds,
+  deleteChannelDirectoryById,
+  findChannelsByDirectory,
+} from '../database.js'
 import { ShareMarkdown } from '../markdown.js'
-import { parseSessionSearchPattern, findFirstSessionSearchHit, buildSessionSearchSnippet, getPartSearchTexts } from '../session-search.js'
+import {
+  parseSessionSearchPattern,
+  findFirstSessionSearchHit,
+  buildSessionSearchSnippet,
+  getPartSearchTexts,
+} from '../session-search.js'
 import { formatWorktreeName, formatAutoWorktreeName } from '../commands/new-worktree.js'
 import { WORKTREE_PREFIX } from '../commands/merge-worktree.js'
 import type { ThreadStartMarker } from '../system-message.js'
@@ -24,7 +48,22 @@ import { archiveThread, uploadFilesToDiscord, stripMentions } from '../discord-u
 import { setDataDir, setProjectsDir, getDataDir, getProjectsDir } from '../config.js'
 import { execAsync, validateWorktreeDirectory } from '../worktrees.js'
 import { upgrade, getCurrentVersion } from '../upgrade.js'
-import { getPromptPreview, parseSendAtValue, parseScheduledTaskPayload, serializeScheduledTaskPayload, type ScheduledTaskPayload } from '../task-schedule.js'
+import {
+  getPromptPreview,
+  parseSendAtValue,
+  parseScheduledTaskPayload,
+  serializeScheduledTaskPayload,
+  type ScheduledTaskPayload,
+} from '../task-schedule.js'
+import {
+  ARCHIVE_AFTER_DAYS,
+  PURGE_EVENTS_AFTER_DAYS,
+  getDiscordSnowflakeTimestamp,
+  getHousekeepingPlan,
+  getThreadLastActivity,
+  purgeSessionEventsBefore,
+  vacuumDatabase,
+} from '../housekeeping.js'
 import {
   EXIT_NO_RESTART,
   formatMemberLookupUnavailableMessage,
@@ -44,9 +83,126 @@ const cli = goke()
 
 cli
   .command(
-    'upgrade',
-    'Upgrade kimaki to the latest version and restart the running bot',
+    'housekeeping',
+    'Preview or apply retention housekeeping for threads and persisted events',
   )
+  .option('--apply', 'Archive old threads and purge old persisted events')
+  .action(async (options: { apply?: boolean }) => {
+    try {
+      await initDatabase()
+      const plan = await getHousekeepingPlan()
+      const mode = options.apply ? 'apply' : 'dry-run'
+
+      note(
+        [
+          `Mode: ${mode}`,
+          `Threads inactive for ${ARCHIVE_AFTER_DAYS}+ days: ${plan.archiveCandidates.length}`,
+          `Persisted events older than ${PURGE_EVENTS_AFTER_DAYS} days: ${plan.purgeEventCount}`,
+          `Referenced Kimaki worktrees to verify manually: ${plan.worktreeCandidates.length}`,
+          '',
+          'Archive candidates:',
+          ...plan.archiveCandidates.map(
+            (candidate) =>
+              `${candidate.threadId} (${candidate.lastActivityAt === null ? 'unknown activity time' : new Date(candidate.lastActivityAt).toISOString()})`,
+          ),
+          'Referenced worktrees:',
+          ...plan.worktreeCandidates.map(
+            (workspace) =>
+              `${workspace.thread_id}: ${workspace.workspace_directory ?? 'no directory recorded'}`,
+          ),
+          '',
+          options.apply
+            ? 'Applying thread archival and event retention. Worktrees are report-only.'
+            : 'No changes made. Re-run with --apply to archive threads and purge events.',
+        ].join('\n'),
+        'Housekeeping',
+      )
+
+      if (!options.apply) {
+        process.exit(0)
+      }
+
+      const { token: botToken } = await resolveBotCredentials()
+      const rest = createDiscordRest(botToken)
+      let archived = 0
+      let skippedForNewActivity = 0
+      const archiveFailures: string[] = []
+      for (const candidate of plan.archiveCandidates) {
+        const threadResult = await rest
+          .get(Routes.channel(candidate.threadId))
+          .catch((error) => (error instanceof Error ? error : new Error(String(error))))
+        if (threadResult instanceof Error) {
+          archiveFailures.push(`${candidate.threadId}: ${threadResult.message}`)
+          continue
+        }
+        const thread = threadResult as {
+          id: string
+          type: number
+          archived?: boolean
+          last_message_id?: string | null
+        }
+        if (!isThreadChannelType(thread.type) || thread.archived) {
+          skippedForNewActivity++
+          continue
+        }
+        const discordLastActivityAt = getDiscordSnowflakeTimestamp(
+          thread.last_message_id ?? thread.id,
+        )
+        if (discordLastActivityAt !== null && discordLastActivityAt >= plan.archiveBefore) {
+          skippedForNewActivity++
+          continue
+        }
+        const lastActivityAt = await getThreadLastActivity(candidate.threadId)
+        if (lastActivityAt === null || lastActivityAt >= plan.archiveBefore) {
+          skippedForNewActivity++
+          continue
+        }
+        const result = await rest
+          .patch(Routes.channel(candidate.threadId), {
+            body: { archived: true },
+          })
+          .catch((error) => (error instanceof Error ? error : new Error(String(error))))
+        if (result instanceof Error) {
+          archiveFailures.push(`${candidate.threadId}: ${result.message}`)
+        } else {
+          archived++
+        }
+      }
+
+      const failedThreadIds = archiveFailures.map((failure) => failure.split(':', 1)[0] ?? '')
+      const purged = await purgeSessionEventsBefore(plan.purgeEventsBefore, failedThreadIds)
+      let vacuumError: Error | undefined
+      if (purged > 0) {
+        const result = await vacuumDatabase().catch((error) =>
+          error instanceof Error ? error : new Error(String(error)),
+        )
+        if (result instanceof Error) vacuumError = result
+      }
+
+      note(
+        [
+          `Archived threads: ${archived}`,
+          `Skipped due to new activity: ${skippedForNewActivity}`,
+          `Archive failures: ${archiveFailures.length}`,
+          `Purged persisted events: ${purged}`,
+          purged > 0
+            ? vacuumError
+              ? `Database vacuum: failed (${vacuumError.message})`
+              : 'Database vacuum: complete'
+            : 'Database vacuum: not needed',
+          ...archiveFailures,
+        ].join('\n'),
+        'Housekeeping complete',
+      )
+      process.exit(archiveFailures.length === 0 && !vacuumError ? 0 : EXIT_NO_RESTART)
+    } catch (error) {
+      cliLogger.error('Housekeeping failed:', error instanceof Error ? error.stack : String(error))
+      process.exit(EXIT_NO_RESTART)
+    }
+  })
+
+cli
+  .command('upgrade', 'Upgrade kimaki to the latest version and restart the running bot')
   .option('--skip-restart', 'Only upgrade, do not restart the running bot')
   .action(async (options) => {
     try {
@@ -77,10 +233,7 @@ cli
       cliLogger.log('Restarting bot with new version...')
       process.exit(0)
     } catch (error) {
-      cliLogger.error(
-        'Upgrade failed:',
-        error instanceof Error ? error.stack : String(error),
-      )
+      cliLogger.error('Upgrade failed:', error instanceof Error ? error.stack : String(error))
       process.exit(EXIT_NO_RESTART)
     }
   })
@@ -91,20 +244,9 @@ cli
     'Merge worktree branch into default branch using worktrunk-style pipeline',
   )
   .option('-d, --directory <path>', 'Worktree directory (defaults to cwd)')
-  .option(
-    '-m, --main-repo <path>',
-    'Main repository directory (auto-detected from worktree)',
-  )
-  .option(
-    '-n, --name <name>',
-    'Worktree/branch name (auto-detected from branch)',
-  )
-  .action(
-    async (options: {
-      directory?: string
-      mainRepo?: string
-      name?: string
-    }) => {
+  .option('-m, --main-repo <path>', 'Main repository directory (auto-detected from worktree)')
+  .option('-n, --name <name>', 'Worktree/branch name (auto-detected from branch)')
+  .action(async (options: { directory?: string; mainRepo?: string; name?: string }) => {
       try {
         const { mergeWorktree } = await import('../worktrees.js')
         const worktreeDir = path.resolve(options.directory || '.')
@@ -118,9 +260,7 @@ cli
         if (!mainRepoDir) {
           try {
             // `git worktree list --porcelain` first line is always the main worktree
-            const { stdout } = await execAsync(
-              `git -C "${worktreeDir}" worktree list --porcelain`,
-            )
+          const { stdout } = await execAsync(`git -C "${worktreeDir}" worktree list --porcelain`)
             const firstLine = stdout.split('\n')[0] || ''
             // Format: "worktree /path/to/main"
             mainRepoDir = firstLine.replace(/^worktree\s+/, '').trim()
@@ -140,9 +280,7 @@ cli
         let worktreeName = options.name
         if (!worktreeName) {
           try {
-            const { stdout } = await execAsync(
-              `git -C "${worktreeDir}" symbolic-ref --short HEAD`,
-            )
+          const { stdout } = await execAsync(`git -C "${worktreeDir}" symbolic-ref --short HEAD`)
             worktreeName = stdout.trim()
           } catch {
             worktreeName = path.basename(worktreeDir)
@@ -167,9 +305,7 @@ cli
         if (result instanceof Error) {
           cliLogger.error(`Merge failed: ${result.message}`)
           if (result instanceof RebaseConflictError) {
-            cliLogger.log(
-              'Resolve the rebase conflicts, then run this command again.',
-            )
+          cliLogger.log('Resolve the rebase conflicts, then run this command again.')
           }
           process.exit(1)
         }
@@ -179,13 +315,9 @@ cli
         )
         process.exit(0)
       } catch (error) {
-        cliLogger.error(
-          'Merge failed:',
-          error instanceof Error ? error.stack : String(error),
-        )
+      cliLogger.error('Merge failed:', error instanceof Error ? error.stack : String(error))
         process.exit(EXIT_NO_RESTART)
       }
-    },
-  )
+  })
 
 export default cli

--- a/cli/src/housekeeping.test.ts
+++ b/cli/src/housekeeping.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, describe, expect, test } from 'vitest'
+import * as orm from 'drizzle-orm'
+
+import {
+  ARCHIVE_AFTER_DAYS,
+  PURGE_EVENTS_AFTER_DAYS,
+  getDiscordSnowflakeTimestamp,
+  getHousekeepingCutoffs,
+  getHousekeepingPlan,
+  purgeSessionEventsBefore,
+} from './housekeeping.js'
+import { closeDb, getDb } from './db.js'
+import * as schema from './schema.js'
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('getHousekeepingCutoffs', () => {
+  test('uses fixed retention windows from one clock value', () => {
+    const now = 1_800_000_000_000
+    const day = 24 * 60 * 60 * 1000
+
+    expect(getHousekeepingCutoffs(now)).toEqual({
+      archiveBefore: now - ARCHIVE_AFTER_DAYS * day,
+      purgeEventsBefore: now - PURGE_EVENTS_AFTER_DAYS * day,
+    })
+  })
+
+  test('reads a Discord message Snowflake activity time', () => {
+    expect(getDiscordSnowflakeTimestamp('175928847299117063')).toBe(1_462_015_105_796)
+    expect(getDiscordSnowflakeTimestamp('not-a-snowflake')).toBeNull()
+  })
+
+  test('plans and purges only events older than the retention cutoff', async () => {
+    const db = await getDb()
+    const now = 1_800_000_000_000
+    const { archiveBefore, purgeEventsBefore } = getHousekeepingCutoffs(now)
+    const oldThreadId = 'housekeeping-old-thread'
+    const recentThreadId = 'housekeeping-recent-thread'
+
+    await db
+      .delete(schema.thread_sessions)
+      .where(orm.inArray(schema.thread_sessions.thread_id, [oldThreadId, recentThreadId]))
+    await db.insert(schema.thread_sessions).values([
+      { thread_id: oldThreadId, session_id: 'housekeeping-old-session' },
+      { thread_id: recentThreadId, session_id: 'housekeeping-recent-session' },
+    ])
+    await db.insert(schema.session_events).values([
+      {
+        session_id: 'housekeeping-old-session',
+        thread_id: oldThreadId,
+        timestamp: purgeEventsBefore - 1,
+        event_index: 0,
+        event_json: '{}',
+      },
+      {
+        session_id: 'housekeeping-recent-session',
+        thread_id: recentThreadId,
+        timestamp: archiveBefore + 1,
+        event_index: 0,
+        event_json: '{}',
+      },
+    ])
+
+    const plan = await getHousekeepingPlan({ now })
+    expect(plan.archiveCandidates.map((candidate) => candidate.threadId)).toContain(oldThreadId)
+    expect(plan.archiveCandidates.map((candidate) => candidate.threadId)).not.toContain(
+      recentThreadId,
+    )
+    expect(plan.purgeEventCount).toBeGreaterThanOrEqual(1)
+
+    await expect(purgeSessionEventsBefore(purgeEventsBefore)).resolves.toBeGreaterThanOrEqual(1)
+    await expect(
+      db.query.session_events.findMany({
+        where: { thread_id: recentThreadId },
+      }),
+    ).resolves.toHaveLength(1)
+
+    await db
+      .delete(schema.thread_sessions)
+      .where(orm.inArray(schema.thread_sessions.thread_id, [oldThreadId, recentThreadId]))
+  })
+
+  test('keeps failed archive targets available for a future housekeeping retry', async () => {
+    const db = await getDb()
+    const threadId = 'housekeeping-retry-thread'
+    const sessionId = 'housekeeping-retry-session'
+    const { purgeEventsBefore } = getHousekeepingCutoffs(1_800_000_000_000)
+
+    await db
+      .delete(schema.thread_sessions)
+      .where(orm.eq(schema.thread_sessions.thread_id, threadId))
+    await db.insert(schema.thread_sessions).values({ thread_id: threadId, session_id: sessionId })
+    await db.insert(schema.session_events).values({
+      session_id: sessionId,
+      thread_id: threadId,
+      timestamp: purgeEventsBefore - 1,
+      event_index: 0,
+      event_json: '{}',
+    })
+
+    await expect(purgeSessionEventsBefore(purgeEventsBefore, [threadId])).resolves.toBe(0)
+    await expect(
+      db.query.session_events.findMany({ where: { thread_id: threadId } }),
+    ).resolves.toHaveLength(1)
+
+    await db
+      .delete(schema.thread_sessions)
+      .where(orm.eq(schema.thread_sessions.thread_id, threadId))
+  })
+})

--- a/cli/src/housekeeping.ts
+++ b/cli/src/housekeeping.ts
@@ -1,0 +1,99 @@
+import * as orm from 'drizzle-orm'
+
+import { getDb } from './db.js'
+import * as schema from './schema.js'
+
+export const ARCHIVE_AFTER_DAYS = 14
+export const PURGE_EVENTS_AFTER_DAYS = 90
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000
+const discordEpoch = 1_420_070_400_000n
+
+export function getDiscordSnowflakeTimestamp(snowflake: string) {
+  try {
+    return Number((BigInt(snowflake) >> 22n) + discordEpoch)
+  } catch {
+    return null
+  }
+}
+
+export function getHousekeepingCutoffs(now = Date.now()) {
+  return {
+    archiveBefore: now - ARCHIVE_AFTER_DAYS * millisecondsPerDay,
+    purgeEventsBefore: now - PURGE_EVENTS_AFTER_DAYS * millisecondsPerDay,
+  }
+}
+
+export async function getHousekeepingPlan({
+  now = Date.now(),
+}: {
+  now?: number
+} = {}) {
+  const db = await getDb()
+  const { archiveBefore, purgeEventsBefore } = getHousekeepingCutoffs(now)
+  const lastActivityAt = orm.max(schema.session_events.timestamp)
+  const archiveCandidates = await db
+    .select({
+      threadId: schema.thread_sessions.thread_id,
+      sessionId: schema.thread_sessions.session_id,
+      lastActivityAt,
+    })
+    .from(schema.thread_sessions)
+    .innerJoin(
+      schema.session_events,
+      orm.eq(schema.session_events.thread_id, schema.thread_sessions.thread_id),
+    )
+    .groupBy(schema.thread_sessions.thread_id, schema.thread_sessions.session_id)
+    .having(orm.lt(lastActivityAt, archiveBefore))
+
+  const [purge] = await db
+    .select({ count: orm.count() })
+    .from(schema.session_events)
+    .where(orm.lt(schema.session_events.timestamp, purgeEventsBefore))
+
+  const candidateThreadIds = new Set(archiveCandidates.map((row) => row.threadId))
+  const workspaces = await db.query.thread_workspaces.findMany({
+    where: { workspace_type: 'kimaki-worktree' },
+    columns: { thread_id: true, workspace_directory: true },
+  })
+
+  return {
+    archiveBefore,
+    purgeEventsBefore,
+    archiveCandidates,
+    purgeEventCount: purge?.count ?? 0,
+    worktreeCandidates: workspaces.filter((workspace) =>
+      candidateThreadIds.has(workspace.thread_id),
+    ),
+  }
+}
+
+export async function getThreadLastActivity(threadId: string) {
+  const db = await getDb()
+  const [row] = await db
+    .select({ lastActivityAt: orm.max(schema.session_events.timestamp) })
+    .from(schema.session_events)
+    .where(orm.eq(schema.session_events.thread_id, threadId))
+  return row?.lastActivityAt ?? null
+}
+
+export async function purgeSessionEventsBefore(
+  timestamp: number,
+  excludedThreadIds: string[] = [],
+) {
+  const db = await getDb()
+  const conditions = [orm.lt(schema.session_events.timestamp, timestamp)]
+  if (excludedThreadIds.length > 0) {
+    conditions.push(orm.notInArray(schema.session_events.thread_id, excludedThreadIds))
+  }
+  const deleted = await db
+    .delete(schema.session_events)
+    .where(orm.and(...conditions))
+    .returning({ id: schema.session_events.id })
+  return deleted.length
+}
+
+export async function vacuumDatabase() {
+  const db = await getDb()
+  await db.run(orm.sql`VACUUM`)
+}


### PR DESCRIPTION
## Related issue

Closes #188

## What changed

- Adds `kimaki housekeeping`, which defaults to a dry-run and requires `--apply` for mutations.
- Archives inactive Discord threads after 14 days, rechecking Discord and OpenCode activity immediately before each archive request.
- Purges persisted session events older than 90 days and vacuums SQLite after a successful purge.
- Preserves events for archive failures so the next run can retry safely.
- Reports database-backed Kimaki worktree references without deleting unverified user directories.

## How to test

```sh
cd cli
pnpm vitest run src/housekeeping.test.ts
pnpm tsc
pnpm dev housekeeping
```

The dry-run must not archive threads, delete events, or remove directories. Re-run with `--apply` only against a disposable test setup or after reviewing the listed candidates.
