### PR TITLE
fix: force restart when bot child hangs

### DIFF
--- a/.changeset/fix-stuck-child-restart.md
+++ b/.changeset/fix-stuck-child-restart.md
@@ -1,0 +1,5 @@
+---
+'kimaki': patch
+---
+
+Recover automatically when the bot process hangs while shutting down for a self-restart.

--- a/cli/src/bin.ts
+++ b/cli/src/bin.ts
@@ -20,6 +20,7 @@ import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { createRestartSupervisor } from './restart-supervisor.js'
 
 const HEAP_SNAPSHOT_DIR = path.join(os.homedir(), '.kimaki', 'heap-snapshots')
 
@@ -34,84 +35,37 @@ if (process.env.__KIMAKI_CHILD || isSubcommand || isHelpFlag) {
 } else {
   console.error('no subcommand detected. kimaki will automatically restart on crash')
   console.error()
-  const EXIT_NO_RESTART = 64
-  const MAX_RAPID_RESTARTS = 5
-  const RAPID_RESTART_WINDOW_MS = 60_000
-  const RESTART_DELAY_MS = 2_000
-
-  const restartTimestamps: number[] = []
-  let child: ReturnType<typeof spawn> | null = null
-  // Track when we forwarded a termination signal so we don't restart after graceful shutdown
-  let shutdownRequested = false
-
-  function start() {
-    if (!fs.existsSync(HEAP_SNAPSHOT_DIR)) {
-      fs.mkdirSync(HEAP_SNAPSHOT_DIR, { recursive: true })
-    }
-    const heapArgs = [
-      `--heapsnapshot-near-heap-limit=3`,
-      `--diagnostic-dir=${HEAP_SNAPSHOT_DIR}`,
-    ]
-    const args = [...heapArgs, ...process.execArgv, ...process.argv.slice(1)]
-    child = spawn(
-      process.argv[0]!,
-      args,
-      {
-        stdio: 'inherit',
+  const supervisor = createRestartSupervisor({
+    spawnChild: () => {
+      if (!fs.existsSync(HEAP_SNAPSHOT_DIR)) {
+        fs.mkdirSync(HEAP_SNAPSHOT_DIR, { recursive: true })
+      }
+      const heapArgs = [
+        `--heapsnapshot-near-heap-limit=3`,
+        `--diagnostic-dir=${HEAP_SNAPSHOT_DIR}`,
+      ]
+      const args = [...heapArgs, ...process.execArgv, ...process.argv.slice(1)]
+      return spawn(process.argv[0]!, args, {
+        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         env: { ...process.env, __KIMAKI_CHILD: '1' },
-      },
-    )
-
-    child.on('exit', (code, signal) => {
-      if (code === 0 || code === EXIT_NO_RESTART || shutdownRequested) {
-        process.exit(code ?? 0)
-        return
-      }
-
-      const now = Date.now()
-      restartTimestamps.push(now)
-      while (
-        restartTimestamps.length > 0 &&
-        restartTimestamps[0]! < now - RAPID_RESTART_WINDOW_MS
-      ) {
-        restartTimestamps.shift()
-      }
-
-      if (restartTimestamps.length > MAX_RAPID_RESTARTS) {
-        console.error(
-          `[kimaki] Crash loop detected (${MAX_RAPID_RESTARTS} crashes in ${RAPID_RESTART_WINDOW_MS / 1000}s), exiting`,
-        )
-        process.exit(1)
-        return
-      }
-
-      const reason = signal ? `signal ${signal}` : `code ${code}`
-      // Progressive backoff: 2s, 4s, 8s, 16s, capped at 30s.
-      // Prevents hammering DNS/gateway during sustained network outages.
-      const delay = Math.min(
-        RESTART_DELAY_MS * 2 ** (restartTimestamps.length - 1),
-        30_000,
-      )
-      console.error(
-        `[kimaki] Process exited with ${reason}, restarting in ${(delay / 1000).toFixed(0)}s...`,
-      )
-      setTimeout(start, delay)
-    })
-  }
+      })
+    },
+    exitProcess: (code) => process.exit(code),
+    logError: (message) => console.error(message),
+  })
 
   // Forward signals to child so graceful shutdown and heap snapshots work.
   // SIGTERM/SIGINT mark shutdownRequested so we don't restart after graceful exit.
   for (const sig of ['SIGTERM', 'SIGINT'] as const) {
     process.on(sig, () => {
-      shutdownRequested = true
-      child?.kill(sig)
+      supervisor.requestShutdown(sig)
     })
   }
   for (const sig of ['SIGUSR1', 'SIGUSR2'] as const) {
     process.on(sig, () => {
-      child?.kill(sig)
+      supervisor.forwardSignal(sig)
     })
   }
 
-  start()
+  supervisor.start()
 }

--- a/cli/src/discord-bot.ts
+++ b/cli/src/discord-bot.ts
@@ -51,6 +51,7 @@ import {
   type ThreadStartMarker,
 } from './system-message.js'
 import YAML from 'yaml'
+import * as errore from 'errore'
 import {
   getFileAttachments,
   getTextAttachments,
@@ -144,6 +145,10 @@ import path from 'node:path'
 import dedent from 'string-dedent'
 import { createLogger, formatErrorWithStack, LogPrefix } from './logger.js'
 import { writeHeapSnapshot, startHeapMonitor } from './heap-monitor.js'
+import {
+  RESTART_REQUEST_MESSAGE_TYPE,
+  type RestartRequestMessage,
+} from './restart-supervisor.js'
 import { startTaskRunner } from './task-runner.js'
 // Increase connection pool to prevent deadlock when multiple sessions have open SSE streams.
 // Each session's event.subscribe() holds a connection; without enough connections,
@@ -1635,6 +1640,22 @@ export async function startDiscordBot({
     }
     selfRestarting = true
     discordLogger.log(`Self-restarting (reason: ${reason})...`)
+    const sendToParent = process.send?.bind(process)
+    if (sendToParent && process.connected) {
+      const message: RestartRequestMessage = {
+        type: RESTART_REQUEST_MESSAGE_TYPE,
+        reason,
+      }
+      const sendResult = errore.try(() =>
+        sendToParent(message, (error) => {
+          if (!error) return
+          discordLogger.warn('Failed to notify restart wrapper:', error.message)
+        }),
+      )
+      if (sendResult instanceof Error) {
+        discordLogger.warn('Failed to notify restart wrapper:', sendResult.message)
+      }
+    }
     try {
       await handleShutdown(reason, { skipExit: true })
     } catch (error) {

--- a/cli/src/restart-supervisor.test.ts
+++ b/cli/src/restart-supervisor.test.ts
@@ -1,0 +1,234 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createRestartSupervisor, RESTART_REQUEST_MESSAGE_TYPE } from './restart-supervisor.js'
+
+class FakeChild extends EventEmitter {
+  readonly killSignals: Array<NodeJS.Signals | number | undefined> = []
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killSignals.push(signal)
+    return true
+  }
+}
+
+function createHarness() {
+  const children: FakeChild[] = []
+  const exitProcess = vi.fn<(code: number) => void>()
+  const logError = vi.fn<(message: string) => void>()
+  const supervisor = createRestartSupervisor({
+    spawnChild: () => {
+      const child = new FakeChild()
+      children.push(child)
+      return child
+    },
+    exitProcess,
+    logError,
+    restartDeadlineMs: 1_000,
+    restartDelayMs: 100,
+  })
+
+  supervisor.start()
+  return { children, exitProcess, logError, supervisor }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('restart supervisor', () => {
+  test('force-kills and replaces a child stuck after requesting restart', () => {
+    vi.useFakeTimers()
+    const { children } = createHarness()
+    const firstChild = children[0]!
+
+    firstChild.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'gateway-reconnect-limit',
+    })
+    vi.advanceTimersByTime(1_000)
+
+    expect(firstChild.killSignals).toEqual(['SIGKILL'])
+
+    firstChild.emit('exit', null, 'SIGKILL')
+    vi.advanceTimersByTime(99)
+    expect(children).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(children).toHaveLength(2)
+  })
+
+  test('keeps the first deadline when duplicate restart requests arrive', () => {
+    vi.useFakeTimers()
+    const { children } = createHarness()
+    const child = children[0]!
+
+    child.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'gateway-reconnect-limit',
+    })
+    vi.advanceTimersByTime(750)
+    child.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'SIGUSR2',
+    })
+    vi.advanceTimersByTime(250)
+
+    expect(child.killSignals).toEqual(['SIGKILL'])
+  })
+
+  test('clears the deadline when the child exits normally', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess } = createHarness()
+    const child = children[0]!
+
+    child.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'SIGUSR2',
+    })
+    child.emit('exit', 0, null)
+    vi.runAllTimers()
+
+    expect(child.killSignals).toEqual([])
+    expect(children).toHaveLength(1)
+    expect(exitProcess).toHaveBeenCalledWith(0)
+  })
+
+  test('uses normal backoff when a restart-requesting child exits by itself', () => {
+    vi.useFakeTimers()
+    const { children } = createHarness()
+    const firstChild = children[0]!
+
+    firstChild.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'SIGUSR2',
+    })
+    firstChild.emit('exit', 1, null)
+    vi.advanceTimersByTime(100)
+
+    expect(firstChild.killSignals).toEqual([])
+    expect(children).toHaveLength(2)
+  })
+
+  test('clears the shutdown deadline when external graceful shutdown completes', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess, supervisor } = createHarness()
+    const child = children[0]!
+
+    supervisor.requestShutdown('SIGTERM')
+    expect(child.killSignals).toEqual(['SIGTERM'])
+
+    vi.advanceTimersByTime(999)
+    child.emit('exit', null, 'SIGTERM')
+    vi.advanceTimersByTime(1)
+
+    expect(child.killSignals).toEqual(['SIGTERM'])
+    expect(children).toHaveLength(1)
+    expect(exitProcess).toHaveBeenCalledWith(0)
+  })
+
+  test('force-kills a child stuck during external shutdown without respawning', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess, supervisor } = createHarness()
+    const child = children[0]!
+
+    supervisor.requestShutdown('SIGTERM')
+    vi.advanceTimersByTime(1_000)
+
+    expect(child.killSignals).toEqual(['SIGTERM', 'SIGKILL'])
+
+    child.emit('exit', null, 'SIGKILL')
+    vi.runAllTimers()
+    expect(children).toHaveLength(1)
+    expect(exitProcess).toHaveBeenCalledWith(0)
+  })
+
+  test('preserves an armed self-restart deadline when external shutdown arrives', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess, supervisor } = createHarness()
+    const child = children[0]!
+
+    child.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'gateway-reconnect-limit',
+    })
+    vi.advanceTimersByTime(750)
+    supervisor.requestShutdown('SIGTERM')
+    vi.advanceTimersByTime(250)
+
+    expect(child.killSignals).toEqual(['SIGTERM', 'SIGKILL'])
+
+    child.emit('exit', null, 'SIGKILL')
+    vi.runAllTimers()
+    expect(children).toHaveLength(1)
+    expect(exitProcess).toHaveBeenCalledWith(0)
+  })
+
+  test('preserves progressive restart backoff for ordinary crashes', () => {
+    vi.useFakeTimers()
+    const { children } = createHarness()
+
+    children[0]!.emit('exit', 1, null)
+    vi.advanceTimersByTime(100)
+    expect(children).toHaveLength(2)
+
+    children[1]!.emit('exit', 1, null)
+    vi.advanceTimersByTime(199)
+    expect(children).toHaveLength(2)
+    vi.advanceTimersByTime(1)
+    expect(children).toHaveLength(3)
+  })
+
+  test('does not restart after the no-restart exit code', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess } = createHarness()
+
+    children[0]!.emit('exit', 64, null)
+    vi.runAllTimers()
+
+    expect(children).toHaveLength(1)
+    expect(exitProcess).toHaveBeenCalledWith(64)
+  })
+
+  test('exits after the rapid crash-loop cutoff', () => {
+    vi.useFakeTimers()
+    const { children, exitProcess } = createHarness()
+
+    for (let index = 0; index < 5; index++) {
+      children[index]!.emit('exit', 1, null)
+      vi.runOnlyPendingTimers()
+    }
+    children[5]!.emit('exit', 1, null)
+
+    expect(children).toHaveLength(6)
+    expect(exitProcess).toHaveBeenCalledWith(1)
+  })
+
+  test('ignores malformed IPC and messages from a stale child generation', () => {
+    vi.useFakeTimers()
+    const { children } = createHarness()
+    const firstChild = children[0]!
+
+    firstChild.emit('message', { type: RESTART_REQUEST_MESSAGE_TYPE })
+    vi.advanceTimersByTime(1_000)
+    expect(firstChild.killSignals).toEqual([])
+
+    firstChild.emit('exit', 1, null)
+    vi.advanceTimersByTime(100)
+    firstChild.emit('message', {
+      type: RESTART_REQUEST_MESSAGE_TYPE,
+      reason: 'stale-generation',
+    })
+    vi.advanceTimersByTime(1_000)
+
+    expect(firstChild.killSignals).toEqual([])
+    expect(children).toHaveLength(2)
+  })
+
+  test('forwards SIGUSR signals to the current child', () => {
+    const { children, supervisor } = createHarness()
+
+    supervisor.forwardSignal('SIGUSR1')
+    supervisor.forwardSignal('SIGUSR2')
+
+    expect(children[0]!.killSignals).toEqual(['SIGUSR1', 'SIGUSR2'])
+  })
+})

--- a/cli/src/restart-supervisor.ts
+++ b/cli/src/restart-supervisor.ts
@@ -1,0 +1,164 @@
+import type { ChildProcess } from 'node:child_process'
+import type { EventEmitter } from 'node:events'
+
+export const RESTART_REQUEST_MESSAGE_TYPE = 'kimaki:restart-requested'
+
+export interface RestartRequestMessage {
+  type: typeof RESTART_REQUEST_MESSAGE_TYPE
+  reason: string
+}
+
+export function isRestartRequestMessage(message: unknown): message is RestartRequestMessage {
+  if (typeof message !== 'object' || message === null) {
+    return false
+  }
+
+  const candidate = message as Record<string, unknown>
+  return candidate.type === RESTART_REQUEST_MESSAGE_TYPE && typeof candidate.reason === 'string'
+}
+
+type SupervisorChild = EventEmitter & Pick<ChildProcess, 'kill'>
+
+interface RestartSupervisorOptions {
+  spawnChild: () => SupervisorChild
+  exitProcess: (code: number) => void
+  logError: (message: string) => void
+  now?: () => number
+  setTimer?: typeof setTimeout
+  clearTimer?: typeof clearTimeout
+  restartDeadlineMs?: number
+  restartDelayMs?: number
+  rapidRestartWindowMs?: number
+  maxRapidRestarts?: number
+}
+
+export function createRestartSupervisor({
+  spawnChild,
+  exitProcess,
+  logError,
+  now = Date.now,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  restartDeadlineMs = 15_000,
+  restartDelayMs = 2_000,
+  rapidRestartWindowMs = 60_000,
+  maxRapidRestarts = 5,
+}: RestartSupervisorOptions) {
+  const EXIT_NO_RESTART = 64
+  const restartTimestamps: number[] = []
+  let child: SupervisorChild | null = null
+  let childExitDeadline: ReturnType<typeof setTimeout> | null = null
+  let scheduledRestart: ReturnType<typeof setTimeout> | null = null
+  let shutdownRequested = false
+
+  function clearChildExitDeadline() {
+    if (childExitDeadline) {
+      clearTimer(childExitDeadline)
+      childExitDeadline = null
+    }
+  }
+
+  function clearScheduledRestart() {
+    if (scheduledRestart) {
+      clearTimer(scheduledRestart)
+      scheduledRestart = null
+    }
+  }
+
+  function armChildExitDeadline(currentChild: SupervisorChild, reason: string) {
+    if (child !== currentChild || childExitDeadline) {
+      return
+    }
+
+    // The deadline belongs to this child generation and is never extended.
+    // An external shutdown therefore preserves any self-restart countdown
+    // that is already in progress.
+    logError(`[kimaki] Waiting up to ${restartDeadlineMs / 1000}s for child shutdown (${reason})`)
+    childExitDeadline = setTimer(() => {
+      childExitDeadline = null
+      if (child !== currentChild) {
+        return
+      }
+
+      logError(
+        `[kimaki] Child did not exit within ${restartDeadlineMs / 1000}s (${reason}); force-killing it`,
+      )
+      currentChild.kill('SIGKILL')
+    }, restartDeadlineMs)
+    childExitDeadline.unref?.()
+  }
+
+  function start() {
+    if (shutdownRequested) {
+      return
+    }
+
+    scheduledRestart = null
+    const currentChild = spawnChild()
+    child = currentChild
+
+    currentChild.on('message', (message: unknown) => {
+      if (shutdownRequested || !isRestartRequestMessage(message)) return
+      armChildExitDeadline(currentChild, `restart requested: ${message.reason}`)
+    })
+
+    currentChild.on('exit', (code, signal) => {
+      if (child !== currentChild) {
+        return
+      }
+
+      child = null
+      clearChildExitDeadline()
+
+      if (code === 0 || code === EXIT_NO_RESTART || shutdownRequested) {
+        exitProcess(code ?? 0)
+        return
+      }
+
+      const timestamp = now()
+      restartTimestamps.push(timestamp)
+      while (
+        restartTimestamps.length > 0 &&
+        restartTimestamps[0]! < timestamp - rapidRestartWindowMs
+      ) {
+        restartTimestamps.shift()
+      }
+
+      if (restartTimestamps.length > maxRapidRestarts) {
+        logError(
+          `[kimaki] Crash loop detected (${maxRapidRestarts} crashes in ${rapidRestartWindowMs / 1000}s), exiting`,
+        )
+        exitProcess(1)
+        return
+      }
+
+      const reason = signal ? `signal ${signal}` : `code ${code}`
+      const delay = Math.min(restartDelayMs * 2 ** (restartTimestamps.length - 1), 30_000)
+      logError(
+        `[kimaki] Process exited with ${reason}, restarting in ${(delay / 1000).toFixed(0)}s...`,
+      )
+      scheduledRestart = setTimer(start, delay)
+    })
+  }
+
+  function requestShutdown(signal: 'SIGTERM' | 'SIGINT') {
+    if (shutdownRequested) {
+      return
+    }
+
+    shutdownRequested = true
+    clearScheduledRestart()
+    if (child) {
+      armChildExitDeadline(child, `received ${signal}`)
+      child.kill(signal)
+    } else {
+      exitProcess(0)
+    }
+  }
+
+  function forwardSignal(signal: 'SIGUSR1' | 'SIGUSR2') {
+    child?.kill(signal)
+  }
+
+  return { forwardSignal, requestShutdown, start }
+}


### PR DESCRIPTION
## Summary

- notify the restart wrapper over IPC before the bot begins graceful cleanup
- enforce a per-child 15-second exit deadline for self-restarts and external shutdown
- preserve the existing progressive backoff, crash-loop cutoff, and no-restart exit behavior

## Problem

After sustained Discord gateway failures, the bot can finish its JavaScript cleanup but hang while Node joins native worker threads during `process.exit()`. The wrapper previously waited indefinitely for the child `exit` event, leaving Kimaki running from the process manager's perspective but offline in Discord.

The child now announces an intentional restart before cleanup. If that specific child generation does not exit before the deadline, the wrapper force-kills it and continues through the existing restart/backoff path. Graceful SIGTERM and SIGINT shutdowns use the same bounded exit guarantee without respawning.

## Testing

- `pnpm tsc`
- `pnpm exec vitest --run src/restart-supervisor.test.ts` (12 tests)
- full CLI suite: 493 passed, 17 skipped; one unrelated queue timing assertion failed on its first observation and passed when rerun with the repository CI retry policy
- independent implementation review, including a corrected shutdown/deadline lifecycle edge case
