### PR TITLE
feat(cli): expose latest assistant session output

### DIFF
--- a/.changeset/expose-latest-assistant-session-output.md
+++ b/.changeset/expose-latest-assistant-session-output.md
@@ -1,0 +1,5 @@
+---
+"kimaki": minor
+---
+
+Add `--last-assistant-only` to `kimaki session read` and `kimaki session wait`.

--- a/cli/src/cli-commands/session.ts
+++ b/cli/src/cli-commands/session.ts
@@ -189,7 +189,8 @@ cli
   )
   .option('--project <path>', 'Project directory (defaults to cwd)')
   .option('--verbose', 'Show full tool inputs and outputs instead of compact summaries')
-  .action(async (sessionId: string, options: { project?: string; verbose?: boolean }) => {
+  .option('--last-assistant-only', 'Show only the latest assistant message')
+  .action(async (sessionId: string, options: { project?: string; verbose?: boolean; lastAssistantOnly?: boolean }) => {
     try {
       const projectDirectory = path.resolve(options.project || '.')
 
@@ -205,7 +206,11 @@ cli
       // Try current project first (fast path)
       const compactTools = !options.verbose
       const markdown = new ShareMarkdown(getClient())
-      const result = await markdown.generate({ sessionID: sessionId, compactTools })
+      const result = await markdown.generate({
+        sessionID: sessionId,
+        compactTools,
+        lastAssistantOnly: options.lastAssistantOnly,
+      })
       if (!(result instanceof Error)) {
         process.stdout.write(result)
         process.exit(0)
@@ -239,6 +244,7 @@ cli
         const otherResult = await otherMarkdown.generate({
           sessionID: sessionId,
           compactTools,
+          lastAssistantOnly: options.lastAssistantOnly,
         })
         if (!(otherResult instanceof Error)) {
           process.stdout.write(otherResult)
@@ -262,7 +268,8 @@ cli
     'session wait <sessionId>',
     'Wait for a session to finish, then print its conversation as markdown',
   )
-  .action(async (sessionId) => {
+  .option('--last-assistant-only', 'Show only the latest assistant message')
+  .action(async (sessionId, options) => {
     try {
       await initDatabase()
 
@@ -278,6 +285,7 @@ cli
       await waitAndOutputExistingSession({
         sessionId,
         projectDirectory,
+        lastAssistantOnly: options.lastAssistantOnly,
       })
 
       process.exit(0)

--- a/cli/src/cli-parsing.test.ts
+++ b/cli/src/cli-parsing.test.ts
@@ -1,6 +1,7 @@
 // Regression tests for CLI argument parsing around Discord ID string preservation.
 import { describe, expect, test } from 'vitest'
 import { execAsync } from './exec-async.js'
+import sessionCommands from './cli-commands/session.js'
 
 async function parseWithGoke(argv: string[]) {
   const script = [
@@ -71,6 +72,20 @@ async function parseRootBotOptions(argv: string[]) {
 }
 
 describe('goke CLI ID parsing', () => {
+  test('parses latest assistant output flags for session read and wait', async () => {
+    const readResult = await sessionCommands.parse(
+      ['node', 'kimaki', 'session', 'read', 'ses_read', '--last-assistant-only'],
+      { run: false },
+    )
+    const waitResult = await sessionCommands.parse(
+      ['node', 'kimaki', 'session', 'wait', 'ses_wait', '--last-assistant-only'],
+      { run: false },
+    )
+
+    expect(readResult.options.lastAssistantOnly).toBe(true)
+    expect(waitResult.options.lastAssistantOnly).toBe(true)
+  })
+
   test('keeps large Discord IDs as strings', async () => {
     const channelId = '1234567890123456789'
     const threadId = '9876543210987654321'

--- a/cli/src/markdown.test.ts
+++ b/cli/src/markdown.test.ts
@@ -45,6 +45,21 @@ function createMatchers(): DeterministicMatcher[] {
     },
   }
 
+  const followUpMatcher: DeterministicMatcher = {
+    id: 'follow-up-reply',
+    priority: 100,
+    when: { latestUserTextIncludes: 'follow-up markdown test' },
+    then: {
+      parts: [
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-start', id: 'follow-up-text' },
+        { type: 'text-delta', id: 'follow-up-text', delta: 'This is the latest assistant response.' },
+        { type: 'text-end', id: 'follow-up-text' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 8, totalTokens: 18 } },
+      ],
+    },
+  }
+
   const toolCallMatcher: DeterministicMatcher = {
     id: 'tool-call-reply',
     priority: 90,
@@ -72,7 +87,7 @@ function createMatchers(): DeterministicMatcher[] {
     },
   }
 
-  return [helloMatcher, toolCallMatcher, defaultMatcher]
+  return [helloMatcher, followUpMatcher, toolCallMatcher, defaultMatcher]
 }
 
 let client: OpencodeClient
@@ -80,6 +95,7 @@ let directories: ReturnType<typeof createRunDirectories>
 let testStartTime: number
 let sessionID: string
 let toolSessionID: string
+let multipleMessageSessionID: string
 
 beforeAll(async () => {
   testStartTime = Date.now()
@@ -193,6 +209,35 @@ beforeAll(async () => {
       break
     }
     await new Promise((resolve) => { setTimeout(resolve, 200) })
+  }
+
+  const multipleMessageCreateResult = await client.session.create({
+    directory: directories.projectDirectory,
+    title: 'Multiple Message Session',
+  })
+  multipleMessageSessionID = multipleMessageCreateResult.data!.id
+
+  for (const text of ['hello markdown test', 'follow-up markdown test']) {
+    await client.session.promptAsync({
+      sessionID: multipleMessageSessionID,
+      directory: directories.projectDirectory,
+      parts: [{ type: 'text', text }],
+    })
+    const responsePollStart = Date.now()
+    while (Date.now() - responsePollStart < maxWait) {
+      const msgs = await client.session.messages({
+        sessionID: multipleMessageSessionID,
+        directory: directories.projectDirectory,
+      })
+      const assistantMessages = (msgs.data || []).filter(
+        (message) => message.info.role === 'assistant',
+      )
+      const hasTextParts = assistantMessages.at(-1)?.parts.some((part) => {
+        return part.type === 'text' && part.text && !part.synthetic
+      })
+      if (hasTextParts) break
+      await new Promise((resolve) => { setTimeout(resolve, 200) })
+    }
   }
 }, 30_000)
 
@@ -346,7 +391,7 @@ test('generate markdown with lastAssistantOnly', async () => {
   const exporter = new ShareMarkdown(client)
 
   const markdownResult = await exporter.generate({
-    sessionID,
+    sessionID: multipleMessageSessionID,
     lastAssistantOnly: true,
   })
 
@@ -354,10 +399,28 @@ test('generate markdown with lastAssistantOnly', async () => {
   const markdown = errore.unwrap(markdownResult)
 
   // lastAssistantOnly should NOT include title header or conversation section header
-  expect(markdown).not.toContain('# Markdown Test Session')
+  expect(markdown).not.toContain('# Multiple Message Session')
   expect(markdown).not.toContain('## Conversation')
-  // Should contain the assistant response
+  expect(markdown).not.toContain('hello markdown test')
+  expect(markdown).not.toContain('Hello! This is a deterministic markdown test response.')
+  expect(markdown).toContain('This is the latest assistant response.')
+})
+
+test('generate markdown keeps the full multiple-message session by default', async () => {
+  const exporter = new ShareMarkdown(client)
+
+  const markdownResult = await exporter.generate({
+    sessionID: multipleMessageSessionID,
+  })
+
+  expect(errore.isOk(markdownResult)).toBe(true)
+  const markdown = errore.unwrap(markdownResult)
+
+  expect(markdown).toContain('# Multiple Message Session')
+  expect(markdown).toContain('hello markdown test')
   expect(markdown).toContain('Hello! This is a deterministic markdown test response.')
+  expect(markdown).toContain('follow-up markdown test')
+  expect(markdown).toContain('This is the latest assistant response.')
 })
 
 test('compact tools: tool calls show one-liner with line count', async () => {

--- a/cli/src/wait-session.test.ts
+++ b/cli/src/wait-session.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { waitAndOutputExistingSession, waitAndOutputSession } from './wait-session.js'
+
+const { generate, initializeOpencodeForDirectory, stdoutWrite } = vi.hoisted(() => ({
+  generate: vi.fn(async () => 'latest assistant output'),
+  initializeOpencodeForDirectory: vi.fn(),
+  stdoutWrite: vi.fn(() => true),
+}))
+
+vi.mock('./database.js', () => ({
+  getSessionEventSnapshot: vi.fn(async () => []),
+  getThreadSession: vi.fn(async () => 'ses_wait'),
+}))
+
+vi.mock('./opencode.js', () => ({ initializeOpencodeForDirectory }))
+
+vi.mock('./markdown.js', () => ({
+  ShareMarkdown: class {
+    generate = generate
+  },
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  initializeOpencodeForDirectory.mockResolvedValue(() => ({
+    session: {
+      status: vi.fn(async () => ({ data: { ses_wait: { type: 'idle' } } })),
+      messages: vi.fn(async () => ({
+        data: [
+          {
+            info: {
+              id: 'user',
+              sessionID: 'ses_wait',
+              role: 'user',
+              time: { created: 1 },
+            },
+            parts: [],
+          },
+          {
+            info: {
+              id: 'assistant',
+              sessionID: 'ses_wait',
+              role: 'assistant',
+              parentID: 'user',
+              time: { created: 2, completed: 3 },
+              finish: 'stop',
+            },
+            parts: [],
+          },
+        ],
+      })),
+    },
+  }))
+  vi.spyOn(process.stdout, 'write').mockImplementation(stdoutWrite)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  generate.mockClear()
+  initializeOpencodeForDirectory.mockClear()
+})
+
+test('passes last-assistant-only through existing-session wait output', async () => {
+  const result = waitAndOutputExistingSession({
+    sessionId: 'ses_wait',
+    projectDirectory: '/project',
+    lastAssistantOnly: true,
+  })
+
+  await vi.advanceTimersByTimeAsync(5_000)
+  await result
+
+  expect(generate).toHaveBeenCalledWith({
+    sessionID: 'ses_wait',
+    lastAssistantOnly: true,
+  })
+  expect(stdoutWrite).toHaveBeenCalledWith('latest assistant output')
+})
+
+test('keeps send wait output on the default full-session renderer path', async () => {
+  const result = waitAndOutputSession({
+    threadId: 'thread_wait',
+    projectDirectory: '/project',
+  })
+
+  await vi.advanceTimersByTimeAsync(5_000)
+  await result
+
+  expect(generate).toHaveBeenCalledWith({ sessionID: 'ses_wait' })
+})

--- a/cli/src/wait-session.ts
+++ b/cli/src/wait-session.ts
@@ -129,11 +129,13 @@ export async function waitAndOutputExistingSession({
   projectDirectory,
   completionTimeoutMs,
   waitStartedAtMs,
+  lastAssistantOnly,
 }: {
   sessionId: string
   projectDirectory: string
   completionTimeoutMs?: number
   waitStartedAtMs?: number
+  lastAssistantOnly?: boolean
 }): Promise<void> {
   waitLogger.log(`Waiting for session ${sessionId} to complete...`)
   await waitForSessionComplete({
@@ -143,15 +145,17 @@ export async function waitAndOutputExistingSession({
     waitStartedAtMs,
   })
 
-  await outputSessionMarkdown({ sessionId, projectDirectory })
+  await outputSessionMarkdown({ sessionId, projectDirectory, lastAssistantOnly })
 }
 
 async function outputSessionMarkdown({
   sessionId,
   projectDirectory,
+  lastAssistantOnly,
 }: {
   sessionId: string
   projectDirectory: string
+  lastAssistantOnly?: boolean
 }): Promise<void> {
   waitLogger.log('Generating session output...')
   const getClient = await initializeOpencodeForDirectory(projectDirectory)
@@ -165,7 +169,10 @@ async function outputSessionMarkdown({
   }
 
   const markdown = new ShareMarkdown(getClient())
-  const result = await markdown.generate({ sessionID: sessionId })
+  const result = await markdown.generate({
+    sessionID: sessionId,
+    ...(lastAssistantOnly ? { lastAssistantOnly: true } : {}),
+  })
   if (result instanceof Error) {
     throw new Error(`Failed to generate session markdown: ${result.message}`, {
       cause: result,


### PR DESCRIPTION
## Summary

Implements SAMDR-161.

- Adds `--last-assistant-only` to `kimaki session read` and forwards it through current-project and cross-project rendering.
- Adds the option to `kimaki session wait` through `waitAndOutputExistingSession` only.
- Keeps `kimaki send --wait` on the existing full-session renderer path.
- Strengthens multi-message renderer coverage and adds a minor changeset.

## Validation

- `pnpm exec vitest --run src/wait-session.test.ts src/cli-parsing.test.ts src/markdown.test.ts` — 21 passed.
- `pnpm tsc` — reaches pre-existing `discord-digital-twin` errors; no changed-file errors observed.
- Submodule pointers unchanged.

Critique: https://critique.work/v/e5f31c3b727489a312539970ed86cfa9