### PR TITLE
Guard unresolved member roles

### DIFF
--- a/cli/src/discord-utils.test.ts
+++ b/cli/src/discord-utils.test.ts
@@ -1,4 +1,9 @@
-import { Collection, PermissionsBitField, type Message } from 'discord.js'
+import {
+  Collection,
+  GuildMember,
+  PermissionsBitField,
+  type Message,
+} from 'discord.js'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   hasKimakiAdminPermission,
@@ -126,6 +131,29 @@ describe('hasKimakiBotPermission', () => {
     } as any
 
     expect(hasKimakiBotPermission(member, guild)).toBe(true)
+  })
+
+  test('ignores unresolved roles for a hydrated guild member', () => {
+    const member = Object.create(GuildMember.prototype)
+    Object.defineProperties(member, {
+      guild: { value: { ownerId: 'owner-id' } },
+      id: { value: 'member-id' },
+      permissions: {
+        value: new PermissionsBitField(
+          PermissionsBitField.Flags.Administrator,
+        ),
+      },
+      roles: {
+        value: {
+          cache: new Collection([
+            ['unresolved', undefined],
+            ['allowed', { name: 'Member' }],
+          ]),
+        },
+      },
+    })
+
+    expect(hasKimakiBotPermission(member)).toBe(true)
   })
 
   test('still blocks no-kimaki role even when allowAllUsers is enabled', () => {

--- a/cli/src/discord-utils.test.ts
+++ b/cli/src/discord-utils.test.ts
@@ -147,7 +147,15 @@ describe('hasKimakiBotPermission', () => {
         value: {
           cache: new Collection([
             ['unresolved', undefined],
-            ['allowed', { name: 'Member' }],
+            [
+              'allowed',
+              {
+                name: 'Member',
+                permissions: new PermissionsBitField(
+                  PermissionsBitField.Flags.Administrator,
+                ),
+              },
+            ],
           ]),
         },
       },

--- a/cli/src/discord-utils.test.ts
+++ b/cli/src/discord-utils.test.ts
@@ -1,8 +1,9 @@
-import { PermissionsBitField, type Message } from 'discord.js'
+import { Collection, PermissionsBitField, type Message } from 'discord.js'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   hasKimakiAdminPermission,
   hasKimakiBotPermission,
+  hasNoKimakiRole,
   resolveGuildMessageMember,
   splitMarkdownForDiscord,
 } from './discord-utils.js'
@@ -234,6 +235,34 @@ describe('hasKimakiAdminPermission', () => {
     } as any
 
     expect(hasKimakiAdminPermission(member, guild)).toBe(true)
+  })
+})
+
+describe('hasNoKimakiRole', () => {
+  test('ignores unresolved role cache entries', () => {
+    const member = {
+      roles: {
+        cache: new Collection([
+          ['unresolved', undefined],
+          ['allowed', { name: 'Member' }],
+        ]),
+      },
+    } as any
+
+    expect(hasNoKimakiRole(member)).toBe(false)
+  })
+
+  test('detects a resolved no-kimaki role', () => {
+    const member = {
+      roles: {
+        cache: new Collection([
+          ['unresolved', undefined],
+          ['blocked', { name: 'no-kimaki' }],
+        ]),
+      },
+    } as any
+
+    expect(hasNoKimakiRole(member)).toBe(true)
   })
 })
 

--- a/cli/src/discord-utils.ts
+++ b/cli/src/discord-utils.ts
@@ -149,7 +149,7 @@ export function hasNoKimakiRole(member: GuildMemberType | null): boolean {
     return false
   }
   return member.roles.cache.some(
-    (role) => role.name.toLowerCase() === 'no-kimaki',
+    (role) => role?.name.toLowerCase() === 'no-kimaki',
   )
 }
 

--- a/cli/src/discord-utils.ts
+++ b/cli/src/discord-utils.ts
@@ -123,7 +123,9 @@ function hasRoleByName(
   const target = roleName.toLowerCase()
 
   if (member instanceof GuildMember) {
-    return member.roles.cache.some((role) => role.name.toLowerCase() === target)
+    return member.roles.cache.some(
+      (role) => role?.name.toLowerCase() === target,
+    )
   }
 
   if (!guild) {

--- a/cli/src/discord-utils.ts
+++ b/cli/src/discord-utils.ts
@@ -53,10 +53,7 @@ export function hasKimakiBotPermission(
   if (store.getState().allowAllUsers) {
     return true
   }
-  const memberPermissions =
-    member instanceof GuildMember
-      ? member.permissions
-      : new PermissionsBitField(BigInt(member.permissions))
+  const memberPermissions = resolveMemberPermissions(member)
   const ownerId = member instanceof GuildMember ? member.guild.ownerId : guild?.ownerId
   const memberId = member instanceof GuildMember ? member.id : member.user.id
   const isOwner = ownerId ? memberId === ownerId : false
@@ -83,10 +80,7 @@ export function hasKimakiAdminPermission(
   if (hasNoKimaki) {
     return false
   }
-  const memberPermissions =
-    member instanceof GuildMember
-      ? member.permissions
-      : new PermissionsBitField(BigInt(member.permissions))
+  const memberPermissions = resolveMemberPermissions(member)
   const ownerId = member instanceof GuildMember ? member.guild.ownerId : guild?.ownerId
   const memberId = member instanceof GuildMember ? member.id : member.user.id
   const isOwner = ownerId ? memberId === ownerId : false
@@ -140,6 +134,20 @@ function hasRoleByName(
     }
   }
   return false
+}
+
+function resolveMemberPermissions(
+  member: GuildMemberType | APIInteractionGuildMember,
+): PermissionsBitField {
+  if (!(member instanceof GuildMember)) {
+    return new PermissionsBitField(BigInt(member.permissions))
+  }
+
+  return member.roles.cache.reduce(
+    (permissions, role) =>
+      role ? permissions.add(role.permissions) : permissions,
+    new PermissionsBitField(),
+  )
 }
 
 /**

--- a/cli/src/discord-utils.ts
+++ b/cli/src/discord-utils.ts
@@ -138,7 +138,7 @@ function hasRoleByName(
 
 function resolveMemberPermissions(
   member: GuildMemberType | APIInteractionGuildMember,
-): PermissionsBitField {
+): discord.PermissionsBitField {
   if (!(member instanceof GuildMember)) {
     return new PermissionsBitField(BigInt(member.permissions))
   }

--- a/discord-slack-bridge/src/event-translator.ts
+++ b/discord-slack-bridge/src/event-translator.ts
@@ -39,10 +39,12 @@ export function translateMessageCreate({
   event,
   guildId,
   author,
+  mentionedUsers = [],
 }: {
   event: NormalizedSlackMessageEvent
   guildId: string
   author: CachedSlackUser
+  mentionedUsers?: CachedSlackUser[]
 }): { eventName: string; data: APIMessage & { guild_id: string } } | null {
   if (!(event.channel && event.ts)) {
     return null
@@ -74,7 +76,7 @@ export function translateMessageCreate({
     edited_timestamp: null,
     tts: false,
     mention_everyone: false,
-    mentions: [],
+    mentions: mentionedUsers.map(toApiUser),
     mention_roles: [],
     attachments: mapSlackFilesToDiscordAttachments(event.files),
     embeds: [],
@@ -96,10 +98,12 @@ export function translateMessageUpdate({
   event,
   guildId,
   author,
+  mentionedUsers = [],
 }: {
   event: NormalizedSlackMessageEvent
   guildId: string
   author: CachedSlackUser
+  mentionedUsers?: CachedSlackUser[]
 }): { eventName: string; data: APIMessage & { guild_id: string } } | null {
   // message_changed has the updated message in event.message
   const inner = event.message
@@ -133,7 +137,7 @@ export function translateMessageUpdate({
     edited_timestamp: inner.editedTs ? slackTsToIso(inner.editedTs) : null,
     tts: false,
     mention_everyone: false,
-    mentions: [],
+    mentions: mentionedUsers.map(toApiUser),
     mention_roles: [],
     attachments: mapSlackFilesToDiscordAttachments(inner.files),
     embeds: [],
@@ -145,6 +149,17 @@ export function translateMessageUpdate({
   return {
     eventName: GatewayDispatchEvents.MessageUpdate,
     data: apiMessage,
+  }
+}
+
+function toApiUser(user: CachedSlackUser): APIUser {
+  return {
+    id: user.id,
+    username: user.name,
+    discriminator: DISCORD_DEFAULT_DISCRIMINATOR,
+    avatar: user.avatar ?? null,
+    bot: user.isBot,
+    global_name: user.realName,
   }
 }
 

--- a/discord-slack-bridge/src/rest-translator.ts
+++ b/discord-slack-bridge/src/rest-translator.ts
@@ -43,6 +43,7 @@ type SlackCreateChannel = NonNullable<ConversationsCreateResponse['channel']>
 type SlackUser = NonNullable<UsersInfoResponse['user']>
 type SlackMember = NonNullable<UsersListResponse['members']>[number]
 type SlackUsergroup = NonNullable<UsergroupsListResponse['usergroups']>[number]
+let nextVirtualCategoryId = 0
 import {
   ChannelType,
   ComponentType,
@@ -69,6 +70,7 @@ import {
   encodeMessageId,
   encodeThreadId,
   decodeMessageId,
+  decodeThreadId,
   resolveSlackTarget,
   slackTsToIso,
   isThreadChannelId,
@@ -347,9 +349,15 @@ export async function getMessage({
 }): Promise<APIMessage> {
   const { channel, threadTs } = resolveSlackTarget(channelId)
 
-  const targetTs = isEncodedMessageId(messageId)
-    ? decodeMessageId(messageId).ts
-    : messageId
+  // Discord addresses a thread's starter message through its parent channel
+  // using the synthetic thread ID. Slack addresses it with the thread
+  // timestamp embedded in that ID.
+  const targetTs =
+    isThreadChannelId(messageId)
+      ? decodeThreadId(messageId).threadTs
+      : isEncodedMessageId(messageId)
+        ? decodeMessageId(messageId).ts
+        : messageId
 
   if (threadTs) {
     // Thread message: use conversations.replies with inclusive range
@@ -496,6 +504,14 @@ export async function updateChannel({
   body: { name?: string; topic?: string; archived?: boolean }
   guildId: string
 }): Promise<APIChannel> {
+  if (isThreadChannelId(channelId)) {
+    // Slack threads have no independently mutable channel metadata. Preserve
+    // the virtual Discord operation without attempting to rename the parent
+    // Slack conversation with a synthetic thread ID.
+    const thread = await getChannel({ slack, channelId, guildId })
+    return body.name ? ({ ...thread, name: body.name } as APIChannel) : thread
+  }
+
   if (body.name) {
     const renameArgs = {
       channel: channelId,
@@ -589,8 +605,21 @@ export async function createChannel({
   guildId: string
   body: { name: string; type?: ChannelType }
 }): Promise<APIChannel> {
+  if (body.type === ChannelType.GuildCategory) {
+    // Slack has a flat conversation model. Keep Discord categories virtual so
+    // creating one neither requires an invalid Slack channel name nor occupies
+    // the name of its child conversation.
+    return {
+      id: `CAT_${++nextVirtualCategoryId}`,
+      type: ChannelType.GuildCategory,
+      name: body.name,
+      guild_id: guildId,
+      position: 0,
+    }
+  }
+
   const createArgs = {
-    name: body.name,
+    name: normalizeSlackChannelName(body.name),
     is_private: false,
   } satisfies ConversationsCreateArguments
   const result = await slack.conversations.create(createArgs)
@@ -604,6 +633,17 @@ export async function createChannel({
     topic: channel.topic?.value ?? null,
     position: 0,
   }
+}
+
+function normalizeSlackChannelName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^[-_]+|[-_]+$/g, '')
+      .slice(0, 80) || 'channel'
+  )
 }
 
 /**

--- a/discord-slack-bridge/src/server.ts
+++ b/discord-slack-bridge/src/server.ts
@@ -926,14 +926,6 @@ export function createBridgeApp(config: ServerConfig): BridgeAppComponents {
         message: `Unknown Channel: ${channelId}`,
       })
     }
-    if (userId !== botUserId) {
-      return errorJsonResponse({
-        status: 403,
-        error: 'missing_permissions',
-        code: 50013,
-        message: 'Missing Permissions',
-      })
-    }
     await rest.joinThreadMember({
       slack,
       threadChannelId: channelId,

--- a/discord-slack-bridge/src/server.ts
+++ b/discord-slack-bridge/src/server.ts
@@ -3523,7 +3523,8 @@ function normalizeCreateGuildChannelBody(value: unknown): {
   const channelType = readNumber(value, 'type')
   const normalizedType =
     channelType === ChannelType.GuildText ||
-    channelType === ChannelType.GuildAnnouncement
+    channelType === ChannelType.GuildAnnouncement ||
+    channelType === ChannelType.GuildCategory
       ? channelType
       : undefined
 

--- a/discord-slack-bridge/src/server.ts
+++ b/discord-slack-bridge/src/server.ts
@@ -146,6 +146,17 @@ const DISCORD_DEFAULT_DISCRIMINATOR = '0'
 const DISCORD_ZERO_PERMISSIONS = '0'
 const THREAD_TYPING_STATUS_TEXT = 'Typing...'
 
+function extractSlackMentionIds(text: string | undefined): string[] {
+  return [
+    ...new Set(
+      Array.from(
+        text?.matchAll(/<@([A-Z0-9]+)(?:\|[^>]+)?>/g) ?? [],
+        (match) => match[1]!,
+      ),
+    ),
+  ]
+}
+
 /**
  * Look up a Slack user with caching.
  * Falls back to the user ID as username if lookup fails.
@@ -1292,10 +1303,16 @@ export function createBridgeApp(config: ServerConfig): BridgeAppComponents {
           slack,
           event.message?.user ?? botUserId,
         )
+        const mentionedUsers = await Promise.all(
+          extractSlackMentionIds(event.message?.text).map((id) =>
+            lookupUser(slack, id),
+          ),
+        )
         const translated = events.translateMessageUpdate({
           event,
           guildId: workspaceId,
           author,
+          mentionedUsers,
         })
         if (translated) {
           gateway.broadcast(translated.eventName, translated.data)
@@ -1334,6 +1351,9 @@ export function createBridgeApp(config: ServerConfig): BridgeAppComponents {
       // New message
       const userId = event.user ?? event.botId ?? botUserId
       const author = await lookupUser(slack, userId)
+      const mentionedUsers = await Promise.all(
+        extractSlackMentionIds(event.text).map((id) => lookupUser(slack, id)),
+      )
 
       // If this message is a thread reply and we haven't seen this thread,
       // emit THREAD_CREATE first
@@ -1364,6 +1384,7 @@ export function createBridgeApp(config: ServerConfig): BridgeAppComponents {
         event,
         guildId: workspaceId,
         author,
+        mentionedUsers,
       })
       if (translated) {
         gateway.broadcast(translated.eventName, translated.data)

--- a/discord-slack-bridge/tests/channels.e2e.test.ts
+++ b/discord-slack-bridge/tests/channels.e2e.test.ts
@@ -1,6 +1,7 @@
 // E2E: Channel operations through the bridge.
 
 import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { ChannelType } from 'discord-api-types/v10'
 import { setupE2E, teardownE2E, type E2EContext } from './e2e-setup.js'
 
 describe('channels', () => {
@@ -33,5 +34,22 @@ describe('channels', () => {
     const ch = await ctx.client.channels.fetch(channelId)
     expect(ch).toBeDefined()
     expect(ch!.id).toBe(channelId)
+  })
+
+  test('creates the default channel hierarchy with Slack-compatible names', async () => {
+    const guild = ctx.client.guilds.cache.first()!
+    const category = await guild.channels.create({
+      name: 'Kimaki',
+      type: ChannelType.GuildCategory,
+    })
+    const channel = await guild.channels.create({
+      name: 'Kimaki General',
+      type: ChannelType.GuildText,
+      parent: category,
+    })
+
+    expect(category.name).toBe('Kimaki')
+    expect(channel.name).toBe('kimaki-general')
+    expect(await ctx.twin.channel(channel.id).getMessages()).toEqual([])
   })
 })

--- a/discord-slack-bridge/tests/event-translator.test.ts
+++ b/discord-slack-bridge/tests/event-translator.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, test } from 'vitest'
 import {
   translateChannelDelete,
   translateChannelRename,
+  translateMessageCreate,
+  translateMessageUpdate,
   translateMemberJoinedChannel,
   translateReaction,
 } from '../src/event-translator.js'
@@ -48,6 +50,62 @@ describe('translateReaction', () => {
 
     // Thread channel IDs encode both channel and thread_ts (20+ digits)
     expect(translated.data.channel_id).toBe(encodeThreadId('C123', '1700000000.123456'))
+  })
+})
+
+describe('message mentions', () => {
+  const author = {
+    id: 'U_AUTHOR',
+    name: 'alice',
+    realName: 'Alice',
+    isBot: false,
+  }
+  const bot = {
+    id: 'U_BOT',
+    name: 'north',
+    realName: 'North',
+    isBot: true,
+  }
+
+  test('includes Slack mentions in message create payloads', () => {
+    const translated = translateMessageCreate({
+      event: {
+        type: 'app_mention',
+        channel: 'C123',
+        user: author.id,
+        text: '<@U_BOT> start a session',
+        ts: '1700000001.123456',
+      },
+      guildId: 'T123',
+      author,
+      mentionedUsers: [bot],
+    })
+
+    expect(translated?.data.mentions).toEqual([
+      expect.objectContaining({ id: 'U_BOT', username: 'north', bot: true }),
+    ])
+  })
+
+  test('includes Slack mentions in message update payloads', () => {
+    const translated = translateMessageUpdate({
+      event: {
+        type: 'message',
+        subtype: 'message_changed',
+        channel: 'C123',
+        message: {
+          user: author.id,
+          text: '<@U_BOT> edited prompt',
+          ts: '1700000001.123456',
+        },
+      },
+      guildId: 'T123',
+      author,
+      mentionedUsers: [bot],
+    })
+
+    expect(translated?.data.mentions).toEqual([
+      expect.objectContaining({ id: 'U_BOT', username: 'north', bot: true }),
+    ])
   })
 })
 

--- a/discord-slack-bridge/tests/thread-members.e2e.test.ts
+++ b/discord-slack-bridge/tests/thread-members.e2e.test.ts
@@ -70,6 +70,13 @@ describe('thread member routes', () => {
     `)
   })
 
+  test('adding a Slack user to a thread is a successful no-op', async () => {
+    const thread = await channel.threads.create({ name: 'thread-member-add' })
+    const aliceId = ctx.twin.resolveUserId('alice')
+
+    await expect(thread.members.add(aliceId)).resolves.toBe(aliceId)
+  })
+
   test('unknown thread returns Discord unknown channel error payload', async () => {
     const unknownThreadId = 'C_UNKNOWN_THREAD'
     const response = await fetch(

--- a/discord-slack-bridge/tests/threads.e2e.test.ts
+++ b/discord-slack-bridge/tests/threads.e2e.test.ts
@@ -69,6 +69,30 @@ describe('threads: Discord → Slack', () => {
     expect(texts).toContain('Reply B')
   })
 
+  test('fetches a newly created thread starter message', async () => {
+    const thread = await channel.threads.create({
+      name: 'Starter message',
+    })
+
+    const starter = await (thread as ThreadChannel).fetchStarterMessage()
+    expect(starter.content).toBe('Starter message')
+  })
+
+  test('renames a virtual thread without renaming its Slack conversation', async () => {
+    const thread = await channel.threads.create({
+      name: 'Slack starter',
+    })
+
+    const renamed = await (thread as ThreadChannel).setName('OpenCode title')
+    expect(renamed.name).toBe('OpenCode title')
+
+    const channelId = ctx.twin.resolveChannelId('threads-test')
+    const messages = await ctx.twin.channel(channelId).getMessages()
+    expect(messages.find((message) => message.ts === decodeThreadId(thread.id).threadTs)?.text).toBe(
+      'Slack starter',
+    )
+  })
+
   test('startThread from message uses message threads endpoint', async () => {
     const parent = await channel.send('Parent message for thread')
 


### PR DESCRIPTION
## Summary

- ignore unresolved entries in hydrated member role caches
- derive member permissions only from resolved roles
- protect general permission checks and `no-kimaki` detection
- treat Slack thread-member additions as successful no-ops, matching Slack thread semantics
- model Discord categories virtually over Slack’s flat conversation model
- normalize Discord channel names to Slack-compatible names
- resolve starter-message fetches from synthetic thread IDs
- treat virtual thread renames as successful without renaming the parent Slack conversation

Fixes #196.

## Verification

- `pnpm --filter discord-slack-bridge exec vitest run tests/channels.e2e.test.ts tests/threads.e2e.test.ts` (9 tests passed)
- `pnpm --filter discord-slack-bridge exec vitest run tests/thread-members.e2e.test.ts` (3 tests passed)
- `pnpm --filter kimaki exec vitest run src/discord-utils.test.ts -t "permission|allows any member|unresolved"` (4 focused tests passed)
- production-shaped Slack gateway milestone: one human mention created one Slack thread, reached OpenCode, returned an assistant answer, and follow-up messages reused the same session

`pnpm --filter discord-slack-bridge run build` remains blocked by pre-existing Discord API type drift in `gateway-session-manager.ts`: `APIApplication.flags_new` is required by the installed type package. The changed bridge files compile through Vitest transforms and pass their behavioral E2E coverage.

## Integration status

This remains draft until the rebuilt standalone runtime proves cold wake, same-thread continuity, specialist handoff, authorized WordPress mutation, and read-back. Usage reporting is owned by the upstream AI gateway response adapter rather than this bridge.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode diagnosed the Slack gateway failures, implemented the generic role-cache, thread-member, virtual-channel, starter-message, and thread-rename compatibility fixes, added regression coverage, and ran the focused verification. Chris Huber remains responsible for every line.