### PR TITLE
fix: stop orphaning Bun-installed OpenCode servers on Windows

### DIFF
--- a/.changeset/fix-windows-bun-opencode-cleanup.md
+++ b/.changeset/fix-windows-bun-opencode-cleanup.md
@@ -6,4 +6,4 @@ Stop leaving orphaned OpenCode servers on Windows when OpenCode is installed thr
 
 Kimaki now resolves Bun's native launcher target before spawning the server, so normal shutdown terminates the server process it owns while preserving unknown and custom launcher behavior.
 
-Fixes #144
+Part of #144

--- a/.changeset/fix-windows-bun-opencode-cleanup.md
+++ b/.changeset/fix-windows-bun-opencode-cleanup.md
@@ -1,0 +1,9 @@
+---
+'kimaki': patch
+---
+
+Stop leaving orphaned OpenCode servers on Windows when OpenCode is installed through Bun.
+
+Kimaki now resolves Bun's native launcher target before spawning the server, so normal shutdown terminates the server process it owns while preserving unknown and custom launcher behavior.
+
+Fixes #144

--- a/cli/src/opencode-command.test.ts
+++ b/cli/src/opencode-command.test.ts
@@ -6,12 +6,209 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import {
+  decodeWindowsBunShimTarget,
   ensureKimakiCommandShim,
   getSpawnCommandAndArgs,
+  resolveWindowsBunShimTarget,
   sanitizeShimExecArgv,
   selectResolvedCommand,
   splitCommandLookupOutput,
 } from './opencode-command.js'
+
+const BUN_SHIM_VERSION = 5478
+
+function createBunShimMetadata({
+  relativeTarget,
+  flags = BUN_SHIM_VERSION << 3,
+}: {
+  relativeTarget: string
+  flags?: number
+}): Buffer {
+  const trailer = Buffer.alloc(6)
+  trailer.writeUInt16LE(0x22, 0)
+  trailer.writeUInt16LE(0, 2)
+  trailer.writeUInt16LE(flags, 4)
+  return Buffer.concat([Buffer.from(relativeTarget, 'utf16le'), trailer])
+}
+
+function createPeExecutableFixture(): Buffer {
+  const executable = Buffer.alloc(512)
+  executable.write('MZ', 0, 'ascii')
+  executable.writeUInt32LE(0x80, 0x3c)
+  executable.write('PE\0\0', 0x80, 'ascii')
+  executable.writeUInt16LE(1, 0x80 + 6)
+  executable.writeUInt16LE(0xf0, 0x80 + 20)
+  executable.writeUInt16LE(0x0002, 0x80 + 22)
+  executable.writeUInt16LE(0x20b, 0x80 + 24)
+  return executable
+}
+
+describe('decodeWindowsBunShimTarget', () => {
+  const command = 'C:\\Users\\test\\.bun\\bin\\opencode.exe'
+  const expectedTarget =
+    'C:\\Users\\test\\.bun\\install\\global\\node_modules\\opencode-ai\\bin\\opencode.exe'
+
+  test('decodes a native target from current Bun shim metadata', () => {
+    // Captured from Bun 1.3.14's generated opencode.bunx metadata.
+    const metadata = Buffer.from(
+      '69006e007300740061006c006c005c0067006c006f00620061006c005c006e006f00640065005f006d006f00640075006c00650073005c006f00700065006e0063006f00640065002d00610069005c00620069006e005c006f00700065006e0063006f00640065002e006500780065002200000030ab',
+      'hex',
+    )
+
+    expect(decodeWindowsBunShimTarget({ command, metadata })).toBe(
+      expectedTarget,
+    )
+  })
+
+  test.each([
+    ['unknown metadata version', (BUN_SHIM_VERSION + 1) << 3],
+    ['interpreter-backed target', (BUN_SHIM_VERSION << 3) | 0b100],
+  ])('rejects %s', (_name, flags) => {
+    const metadata = createBunShimMetadata({
+      relativeTarget:
+        'install\\global\\node_modules\\opencode-ai\\bin\\opencode.exe',
+      flags,
+    })
+
+    expect(decodeWindowsBunShimTarget({ command, metadata })).toBeNull()
+  })
+
+  test('rejects malformed metadata', () => {
+    expect(
+      decodeWindowsBunShimTarget({ command, metadata: Buffer.alloc(4) }),
+    ).toBeNull()
+    expect(
+      decodeWindowsBunShimTarget({
+        command,
+        metadata: Buffer.alloc(65_538),
+      }),
+    ).toBeNull()
+  })
+
+  test('rejects targets outside the shim root', () => {
+    const metadata = createBunShimMetadata({
+      relativeTarget: '..\\outside.exe',
+    })
+
+    expect(decodeWindowsBunShimTarget({ command, metadata })).toBeNull()
+  })
+
+  test('rejects metadata beside executables outside Bun bin directories', () => {
+    const metadata = createBunShimMetadata({
+      relativeTarget: 'opencode-ai\\bin\\opencode.exe',
+    })
+
+    expect(
+      decodeWindowsBunShimTarget({
+        command: 'C:\\tools\\opencode.exe',
+        metadata,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe.runIf(process.platform === 'win32')(
+  'resolveWindowsBunShimTarget',
+  () => {
+    let tempDir: string
+    let shimPath: string
+    let metadataPath: string
+    let nativeTarget: string
+    let outsideDir: string | null
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimaki-bun-shim-test-'))
+      const binDir = path.join(tempDir, 'bin')
+      nativeTarget = path.join(
+        tempDir,
+        'install',
+        'global',
+        'node_modules',
+        'opencode-ai',
+        'bin',
+        'opencode.exe',
+      )
+      shimPath = path.join(binDir, 'opencode.exe')
+      metadataPath = path.join(binDir, 'opencode.bunx')
+      fs.mkdirSync(path.dirname(nativeTarget), { recursive: true })
+      fs.mkdirSync(binDir, { recursive: true })
+      fs.writeFileSync(shimPath, createPeExecutableFixture())
+      fs.writeFileSync(nativeTarget, createPeExecutableFixture())
+      outsideDir = null
+    })
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+      if (outsideDir) {
+        fs.rmSync(outsideDir, { recursive: true, force: true })
+      }
+    })
+
+    test('resolves a native target from current Bun shim metadata', () => {
+      fs.writeFileSync(
+        metadataPath,
+        createBunShimMetadata({
+          relativeTarget:
+            'install\\global\\node_modules\\opencode-ai\\bin\\opencode.exe',
+        }),
+      )
+
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(nativeTarget)
+    })
+
+    test('keeps the launcher when the target is missing or not native', () => {
+      fs.writeFileSync(
+        metadataPath,
+        createBunShimMetadata({
+          relativeTarget:
+            'install\\global\\node_modules\\opencode-ai\\bin\\missing.exe',
+        }),
+      )
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(shimPath)
+
+      fs.writeFileSync(nativeTarget, Buffer.from('MZ but not a PE executable'))
+      fs.writeFileSync(
+        metadataPath,
+        createBunShimMetadata({
+          relativeTarget:
+            'install\\global\\node_modules\\opencode-ai\\bin\\opencode.exe',
+        }),
+      )
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(shimPath)
+
+      const truncatedPe = createPeExecutableFixture().subarray(0, 0x9a)
+      fs.writeFileSync(nativeTarget, truncatedPe)
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(shimPath)
+    })
+
+    test('keeps the launcher when a junction redirects outside the shim root', () => {
+      outsideDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'kimaki-bun-shim-outside-'),
+      )
+      fs.writeFileSync(
+        path.join(outsideDir, 'opencode.exe'),
+        createPeExecutableFixture(),
+      )
+      fs.symlinkSync(outsideDir, path.join(tempDir, 'linked'), 'junction')
+      fs.writeFileSync(
+        metadataPath,
+        createBunShimMetadata({ relativeTarget: 'linked\\opencode.exe' }),
+      )
+
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(shimPath)
+    })
+  },
+)
 
 describe('splitCommandLookupOutput', () => {
   test('splits windows command lookup output into trimmed lines', () => {

--- a/cli/src/opencode-command.test.ts
+++ b/cli/src/opencode-command.test.ts
@@ -207,6 +207,54 @@ describe.runIf(process.platform === 'win32')(
         resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
       ).toBe(shimPath)
     })
+
+    test('keeps the launcher when no Bun metadata file exists', () => {
+      expect(
+        resolveWindowsBunShimTarget({ command: shimPath, platform: 'win32' }),
+      ).toBe(shimPath)
+    })
+
+    test('resolved target spawns directly without a cmd.exe wrapper', () => {
+      fs.writeFileSync(
+        metadataPath,
+        createBunShimMetadata({
+          relativeTarget:
+            'install\\global\\node_modules\\opencode-ai\\bin\\opencode.exe',
+        }),
+      )
+      const resolved = resolveWindowsBunShimTarget({
+        command: shimPath,
+        platform: 'win32',
+      })
+      expect(resolved).toBe(nativeTarget)
+
+      // With the native target as the spawn command there is no intermediate
+      // process, so the spawned ChildProcess.pid is the server Kimaki's
+      // SIGTERM cleanup must terminate.
+      expect(
+        getSpawnCommandAndArgs({
+          resolvedCommand: resolved,
+          baseArgs: ['serve', '--port', '4096'],
+          platform: 'win32',
+        }),
+      ).toEqual({
+        command: nativeTarget,
+        args: ['serve', '--port', '4096'],
+      })
+    })
+
+    test('keeps direct executables with spaces unchanged on windows', () => {
+      expect(
+        getSpawnCommandAndArgs({
+          resolvedCommand: 'C:\\Program Files\\opencode\\opencode.exe',
+          baseArgs: ['serve', '--port', '4096'],
+          platform: 'win32',
+        }),
+      ).toEqual({
+        command: 'C:\\Program Files\\opencode\\opencode.exe',
+        args: ['serve', '--port', '4096'],
+      })
+    })
   },
 )
 

--- a/cli/src/opencode-command.ts
+++ b/cli/src/opencode-command.ts
@@ -7,6 +7,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const WINDOWS_CMD_SHIM_REGEX = /\.(cmd|bat)$/i
+const WINDOWS_EXECUTABLE_REGEX = /\.exe$/i
+const BUN_SHIM_METADATA_VERSION = 5478
+const BUN_SHIM_METADATA_MAX_BYTES = 65_536
+const BUN_SHIM_EXECUTABLE_MAX_BYTES = 1_048_576
+const IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002
+const IMAGE_FILE_DLL = 0x2000
 
 function quotePosixShellSegment(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`
@@ -41,6 +47,203 @@ export function selectResolvedCommand({
     return WINDOWS_CMD_SHIM_REGEX.test(line)
   })
   return cmdShim || lines[0] || null
+}
+
+/**
+ * Bun installs Windows package binaries as a small .exe launcher plus a
+ * sibling .bunx metadata file. For native targets the launcher only starts
+ * the encoded executable and waits, so spawning that target directly keeps
+ * the ChildProcess PID attached to the process Kimaki must later terminate.
+ */
+export function resolveWindowsBunShimTarget({
+  command,
+  platform = process.platform,
+}: {
+  command: string
+  platform?: NodeJS.Platform
+}): string {
+  if (platform !== 'win32' || !WINDOWS_EXECUTABLE_REGEX.test(command)) {
+    return command
+  }
+
+  const commandDirectory = path.win32.dirname(command)
+  const commandName = path.win32.basename(command, path.win32.extname(command))
+  const metadataPath = path.win32.join(commandDirectory, `${commandName}.bunx`)
+
+  try {
+    const commandStat = fs.statSync(command)
+    if (
+      !commandStat.isFile() ||
+      commandStat.size > BUN_SHIM_EXECUTABLE_MAX_BYTES ||
+      !isWindowsPeExecutable(command)
+    ) {
+      return command
+    }
+
+    const metadataFd = fs.openSync(metadataPath, 'r')
+    let metadata: Buffer
+    try {
+      const metadataStat = fs.fstatSync(metadataFd)
+      if (
+        !metadataStat.isFile() ||
+        metadataStat.size < 8 ||
+        metadataStat.size > BUN_SHIM_METADATA_MAX_BYTES
+      ) {
+        return command
+      }
+      metadata = Buffer.alloc(metadataStat.size)
+      if (
+        fs.readSync(metadataFd, metadata, 0, metadata.length, 0) !==
+        metadata.length
+      ) {
+        return command
+      }
+    } finally {
+      fs.closeSync(metadataFd)
+    }
+
+    const target = decodeWindowsBunShimTarget({
+      command,
+      metadata,
+    })
+    if (!target) {
+      return command
+    }
+
+    const canonicalRoot = fs.realpathSync.native(
+      path.win32.dirname(commandDirectory),
+    )
+    const canonicalTarget = fs.realpathSync.native(target)
+    const canonicalRelativeTarget = path.win32.relative(
+      canonicalRoot,
+      canonicalTarget,
+    )
+    if (
+      !canonicalRelativeTarget ||
+      canonicalRelativeTarget === '..' ||
+      canonicalRelativeTarget.startsWith(`..${path.win32.sep}`) ||
+      path.win32.isAbsolute(canonicalRelativeTarget) ||
+      !fs.statSync(canonicalTarget).isFile() ||
+      !isWindowsPeExecutable(canonicalTarget)
+    ) {
+      return command
+    }
+
+    return canonicalTarget
+  } catch {
+    return command
+  }
+}
+
+export function decodeWindowsBunShimTarget({
+  command,
+  metadata,
+}: {
+  command: string
+  metadata: Buffer
+}): string | null {
+  const commandDirectory = path.win32.dirname(command)
+  const commandDirectoryName = path.win32
+    .basename(commandDirectory)
+    .toLowerCase()
+  if (
+    (commandDirectoryName !== 'bin' && commandDirectoryName !== '.bin') ||
+    metadata.length < 8 ||
+    metadata.length > BUN_SHIM_METADATA_MAX_BYTES ||
+    metadata.length % 2 !== 0
+  ) {
+    return null
+  }
+
+  const flags = metadata.readUInt16LE(metadata.length - 2)
+  if (flags >>> 3 !== BUN_SHIM_METADATA_VERSION || (flags & 0b111) !== 0) {
+    return null
+  }
+
+  const targetByteLength = metadata.length - 6
+  if (
+    targetByteLength < 2 ||
+    metadata.readUInt16LE(targetByteLength) !== 0x22 ||
+    metadata.readUInt16LE(targetByteLength + 2) !== 0
+  ) {
+    return null
+  }
+
+  const relativeTarget = metadata
+    .subarray(0, targetByteLength)
+    .toString('utf16le')
+  if (!relativeTarget || relativeTarget.includes('\0')) {
+    return null
+  }
+
+  // Bun resolves metadata from the parent of its bin/.bin directory.
+  const targetRoot = path.win32.dirname(path.win32.dirname(command))
+  const target = path.win32.resolve(targetRoot, relativeTarget)
+  const relativeResolvedTarget = path.win32.relative(targetRoot, target)
+  if (
+    !relativeResolvedTarget ||
+    relativeResolvedTarget === '..' ||
+    relativeResolvedTarget.startsWith(`..${path.win32.sep}`) ||
+    path.win32.isAbsolute(relativeResolvedTarget) ||
+    !WINDOWS_EXECUTABLE_REGEX.test(target)
+  ) {
+    return null
+  }
+
+  return target
+}
+
+function isWindowsPeExecutable(filePath: string): boolean {
+  const fd = fs.openSync(filePath, 'r')
+  try {
+    const stat = fs.fstatSync(fd)
+    if (!stat.isFile() || stat.size < 0x5a) {
+      return false
+    }
+
+    const dosHeader = Buffer.alloc(0x40)
+    if (
+      fs.readSync(fd, dosHeader, 0, dosHeader.length, 0) !== dosHeader.length ||
+      dosHeader[0] !== 0x4d ||
+      dosHeader[1] !== 0x5a
+    ) {
+      return false
+    }
+
+    const peOffset = dosHeader.readUInt32LE(0x3c)
+    const peHeader = Buffer.alloc(26)
+    if (
+      peOffset < dosHeader.length ||
+      peOffset > stat.size - peHeader.length ||
+      fs.readSync(fd, peHeader, 0, peHeader.length, peOffset) !==
+        peHeader.length ||
+      peHeader.toString('ascii', 0, 4) !== 'PE\0\0'
+    ) {
+      return false
+    }
+
+    const optionalHeaderSize = peHeader.readUInt16LE(20)
+    const characteristics = peHeader.readUInt16LE(22)
+    const optionalHeaderMagic = peHeader.readUInt16LE(24)
+    const numberOfSections = peHeader.readUInt16LE(6)
+    const minimumOptionalHeaderSize =
+      optionalHeaderMagic === 0x10b
+        ? 0x60
+        : optionalHeaderMagic === 0x20b
+          ? 0x70
+          : Number.POSITIVE_INFINITY
+    const sectionTableEnd =
+      peOffset + 24 + optionalHeaderSize + numberOfSections * 40
+    return (
+      numberOfSections > 0 &&
+      optionalHeaderSize >= minimumOptionalHeaderSize &&
+      sectionTableEnd <= stat.size &&
+      (characteristics & IMAGE_FILE_EXECUTABLE_IMAGE) !== 0 &&
+      (characteristics & IMAGE_FILE_DLL) === 0
+    )
+  } finally {
+    fs.closeSync(fd)
+  }
 }
 
 function quoteWindowsCommandSegment(value: string): string {

--- a/cli/src/opencode-command.ts
+++ b/cli/src/opencode-command.ts
@@ -5,12 +5,16 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { createLogger, LogPrefix } from './logger.js'
+
+const logger = createLogger(LogPrefix.OPENCODE)
 
 const WINDOWS_CMD_SHIM_REGEX = /\.(cmd|bat)$/i
 const WINDOWS_EXECUTABLE_REGEX = /\.exe$/i
 const BUN_SHIM_METADATA_VERSION = 5478
 const BUN_SHIM_METADATA_MAX_BYTES = 65_536
 const BUN_SHIM_EXECUTABLE_MAX_BYTES = 1_048_576
+const BUN_SHIM_TARGET_TRAILER_MAGIC = 0x22
 const IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002
 const IMAGE_FILE_DLL = 0x2000
 
@@ -80,6 +84,12 @@ export function resolveWindowsBunShimTarget({
       return command
     }
 
+    // No sibling metadata = not Bun-managed (a native binary or another
+    // package manager's launcher). Fall back silently.
+    if (!fs.existsSync(metadataPath)) {
+      return command
+    }
+
     const metadataFd = fs.openSync(metadataPath, 'r')
     let metadata: Buffer
     try {
@@ -107,6 +117,9 @@ export function resolveWindowsBunShimTarget({
       metadata,
     })
     if (!target) {
+      logger.warn(
+        `Bun shim metadata present but could not be decoded for ${command}; falling back to the launcher. SIGTERM cleanup may orphan the server until the metadata format is supported.`,
+      )
       return command
     }
 
@@ -114,15 +127,8 @@ export function resolveWindowsBunShimTarget({
       path.win32.dirname(commandDirectory),
     )
     const canonicalTarget = fs.realpathSync.native(target)
-    const canonicalRelativeTarget = path.win32.relative(
-      canonicalRoot,
-      canonicalTarget,
-    )
     if (
-      !canonicalRelativeTarget ||
-      canonicalRelativeTarget === '..' ||
-      canonicalRelativeTarget.startsWith(`..${path.win32.sep}`) ||
-      path.win32.isAbsolute(canonicalRelativeTarget) ||
+      !isPathWithinRoot(canonicalRoot, canonicalTarget) ||
       !fs.statSync(canonicalTarget).isFile() ||
       !isWindowsPeExecutable(canonicalTarget)
     ) {
@@ -130,9 +136,27 @@ export function resolveWindowsBunShimTarget({
     }
 
     return canonicalTarget
-  } catch {
+  } catch (cause) {
+    logger.warn(
+      `Failed to resolve Bun shim target for ${command}; falling back to the launcher: ${cause instanceof Error ? cause.message : String(cause)}`,
+    )
     return command
   }
+}
+
+/**
+ * True when `candidate` resolves to a path strictly inside `root` (never the
+ * root itself, a parent, or a sibling tree). Guard against shim metadata
+ * redirecting the spawn target outside the package it belongs to.
+ */
+function isPathWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.win32.relative(root, candidate)
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.win32.sep}`) &&
+    !path.win32.isAbsolute(relative)
+  )
 }
 
 export function decodeWindowsBunShimTarget({
@@ -163,7 +187,8 @@ export function decodeWindowsBunShimTarget({
   const targetByteLength = metadata.length - 6
   if (
     targetByteLength < 2 ||
-    metadata.readUInt16LE(targetByteLength) !== 0x22 ||
+    metadata.readUInt16LE(targetByteLength) !==
+      BUN_SHIM_TARGET_TRAILER_MAGIC ||
     metadata.readUInt16LE(targetByteLength + 2) !== 0
   ) {
     return null
@@ -179,12 +204,8 @@ export function decodeWindowsBunShimTarget({
   // Bun resolves metadata from the parent of its bin/.bin directory.
   const targetRoot = path.win32.dirname(path.win32.dirname(command))
   const target = path.win32.resolve(targetRoot, relativeTarget)
-  const relativeResolvedTarget = path.win32.relative(targetRoot, target)
   if (
-    !relativeResolvedTarget ||
-    relativeResolvedTarget === '..' ||
-    relativeResolvedTarget.startsWith(`..${path.win32.sep}`) ||
-    path.win32.isAbsolute(relativeResolvedTarget) ||
+    !isPathWithinRoot(targetRoot, target) ||
     !WINDOWS_EXECUTABLE_REGEX.test(target)
   ) {
     return null

--- a/cli/src/opencode.ts
+++ b/cli/src/opencode.ts
@@ -106,6 +106,7 @@ import {
   getPathEnvKey,
   getSpawnCommandAndArgs,
   prependPathEntry,
+  resolveWindowsBunShimTarget,
   selectResolvedCommand,
 } from './opencode-command.js'
 import { computeSkillPermission } from './skill-filter.js'
@@ -518,8 +519,10 @@ export function resolveOpencodeCommand(): string {
       isWindows: process.platform === 'win32',
     })
     if (resolvedFromEnv) {
-      resolvedOpencodeCommand = resolvedFromEnv
-      return resolvedFromEnv
+      resolvedOpencodeCommand = resolveWindowsBunShimTarget({
+        command: resolvedFromEnv,
+      })
+      return resolvedOpencodeCommand
     }
   }
 
@@ -550,9 +553,9 @@ export function resolveOpencodeCommand(): string {
     return 'opencode'
   }
 
-  resolvedOpencodeCommand = result
-  opencodeLogger.log(`Resolved opencode binary: ${result}`)
-  return result
+  resolvedOpencodeCommand = resolveWindowsBunShimTarget({ command: result })
+  opencodeLogger.log(`Resolved opencode binary: ${resolvedOpencodeCommand}`)
+  return resolvedOpencodeCommand
 }
 async function getOpenPort(): Promise<number> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Related issue

Part of #144

## What changed

On Windows, Kimaki could accumulate orphaned OpenCode servers when OpenCode was installed through Bun. On one Windows machine, 172 orphaned `opencode.exe serve` processes accumulated, consuming approximately 121 GB of private memory.

The root cause was a two-process launch chain: Bun's approximately 16 KB launcher shim spawned the approximately 178 MB native `opencode.exe` server. Kimaki's `killSingleServerProcessNow` sent SIGTERM only to the shim PID. Windows then reparented the still-running server, which continued listening on its random port.

This change resolves the Windows/Bun slice by reading Bun's sibling `.bunx` metadata, validating the target as a PE executable, and enforcing realpath containment before spawning it directly. If metadata is missing or unrecognised, Kimaki preserves the existing launcher behaviour and emits a warning log.

The kill-target property now follows from the process structure: there is no intermediate launcher process, so the spawned `ChildProcess.pid` is the server PID and the existing `killSingleServerProcessNow` cleanup reaches it.

This is **Part of #144**. It resolves the Bun-on-Windows slice only. The npm-wrapper and startup-sweep halves of #144 are not addressed.

## How to test

The branch adds 12 Windows resolver tests covering:

- captured Bun 1.3.14 metadata;
- malformed and unrecognised metadata;
- missing-target and missing-metadata fallback;
- PE validation;
- realpath containment and junction escape;
- the fallback matrix;
- direct spawning of the resolved target without `cmd.exe`.

The direct-spawn seam test verifies the resolved target is spawned directly (no `cmd.exe` wrapper, no verbatim-arguments path), so no intermediate process exists between Kimaki and the server. Existing server-manager end-to-end tests exercise the real spawn/cleanup path.

A changeset is included using Part-of semantics so this PR does not close #144.
