### PR TITLE
Protect worktree creation and cleanup ownership

### DIFF
--- a/.changeset/protect-worktree-ownership.md
+++ b/.changeset/protect-worktree-ownership.md
@@ -1,0 +1,8 @@
+---
+"kimaki": patch
+---
+
+<!-- ZAI 2026-08-31 -->
+Prevent concurrent worktree creation from resetting existing branches or deleting another request's checkout, and keep dependency installation from modifying tracked lockfiles.
+
+Fixes #202

--- a/cli/src/commands/new-worktree.ts
+++ b/cli/src/commands/new-worktree.ts
@@ -39,7 +39,7 @@ import {
 } from '../worktrees.js'
 import {
   KIMAKI_WORKTREE_ADAPTER_TYPE,
-  removeWorktreeFromOwnRepository,
+  removeWorktreeCore,
   resolveGitCommit,
   resolveGitCommonDirectory,
   validateWorktreeIdentity,
@@ -219,17 +219,22 @@ async function getProjectDirectoryFromChannel(
  * Returns the workspace directory on success, or an Error if the workspace
  * feature is not available or the creation fails.
  */
-export async function tryWorkspaceCreate({
-  worktreeName,
-  projectDirectory,
-  baseCommit,
-  expectedCommonGitDirectory,
-}: {
+type WorkspaceCreateInput = {
   worktreeName: string
   projectDirectory: string
   baseCommit: string
   expectedCommonGitDirectory: string
-}): Promise<{ directory: string; workspaceId: string } | Error> {
+}
+
+// ZAI 2026-08-31: Claim managed paths before the workspace SDK can race on them.
+const workspaceCreations = new Set<string>()
+
+async function tryWorkspaceCreateUnlocked({
+  worktreeName,
+  projectDirectory,
+  baseCommit,
+  expectedCommonGitDirectory,
+}: WorkspaceCreateInput): Promise<{ directory: string; workspaceId: string } | Error> {
   const getClient = await initializeOpencodeForDirectory(projectDirectory)
   if (getClient instanceof Error) return getClient
 
@@ -251,13 +256,21 @@ export async function tryWorkspaceCreate({
       }
       return undefined
     })()
-    const gitCleanupError = fs.existsSync(worktreeDirectory)
-      ? await removeWorktreeFromOwnRepository({
-          worktreeDirectory,
-          branchName: worktreeName,
-        })
-      : undefined
-    return sdkCleanupError ?? gitCleanupError
+    const localCleanupError = await removeWorktreeCore({
+      projectDirectory,
+      worktreeDirectory,
+      branchName: worktreeName,
+      workspaceId,
+    })
+    if (sdkCleanupError && localCleanupError instanceof Error) {
+      return new Error(
+        `${sdkCleanupError.message}; local cleanup failed: ${localCleanupError.message}`,
+        {
+          cause: sdkCleanupError,
+        },
+      )
+    }
+    return sdkCleanupError ?? localCleanupError
   }
 
   const response = await client.experimental.workspace.create({
@@ -269,6 +282,7 @@ export async function tryWorkspaceCreate({
       projectDirectory,
       baseCommit,
       expectedCommonGitDirectory,
+      workspaceId,
     },
   }).catch((e) => new OpenCodeSdkError({ operation: 'workspace.create', cause: e }))
   if (response instanceof Error || response.error) {
@@ -313,6 +327,20 @@ export async function tryWorkspaceCreate({
     return identityResult
   }
   return { directory: workspace.directory, workspaceId: workspace.id }
+}
+
+export async function tryWorkspaceCreate(input: WorkspaceCreateInput) {
+  const targetDirectory = getManagedWorktreeDirectory({
+    directory: input.projectDirectory,
+    name: input.worktreeName,
+  })
+  if (workspaceCreations.has(targetDirectory)) {
+    return new Error(`Worktree creation already in progress: ${targetDirectory}`)
+  }
+  workspaceCreations.add(targetDirectory)
+  return tryWorkspaceCreateUnlocked(input).finally(() => {
+    workspaceCreations.delete(targetDirectory)
+  })
 }
 
 /**

--- a/cli/src/git-worktree-core.ts
+++ b/cli/src/git-worktree-core.ts
@@ -15,11 +15,11 @@ const SUBMODULE_INIT_TIMEOUT_MS = 20 * 60_000
 const INSTALL_TIMEOUT_MS = 60_000
 
 const LOCKFILE_TO_INSTALL_COMMAND: Array<[string, string]> = [
-  ['pnpm-lock.yaml', 'pnpm install'],
-  ['bun.lock', 'bun install'],
-  ['bun.lockb', 'bun install'],
-  ['yarn.lock', 'yarn install'],
-  ['package-lock.json', 'npm install'],
+  ['pnpm-lock.yaml', 'pnpm install --frozen-lockfile'],
+  ['bun.lock', 'bun install --frozen-lockfile'],
+  ['bun.lockb', 'bun install --frozen-lockfile'],
+  ['yarn.lock', 'yarn install --frozen-lockfile'],
+  ['package-lock.json', 'npm ci'],
 ]
 
 export type WorktreeLog = {
@@ -39,6 +39,7 @@ export type KimakiWorktreeIdentity = {
   projectDirectory: string
   baseCommit: string
   expectedCommonGitDirectory: string
+  workspaceId?: string
 }
 
 export function parseKimakiWorktreeIdentity(
@@ -47,7 +48,7 @@ export function parseKimakiWorktreeIdentity(
   if (!extra) {
     return new Error('Kimaki worktree identity is missing')
   }
-  const { projectDirectory, baseCommit, expectedCommonGitDirectory } = extra
+  const { projectDirectory, baseCommit, expectedCommonGitDirectory, workspaceId } = extra
   if (typeof projectDirectory !== 'string' || !path.isAbsolute(projectDirectory)) {
     return new Error('Kimaki worktree project directory must be absolute')
   }
@@ -60,7 +61,13 @@ export function parseKimakiWorktreeIdentity(
   ) {
     return new Error('Kimaki worktree common Git directory must be absolute')
   }
-  return { projectDirectory, baseCommit, expectedCommonGitDirectory }
+  if (
+    workspaceId !== undefined &&
+    !/^wrk_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(workspaceId)
+  ) {
+    return new Error('Kimaki worktree workspace ID is invalid')
+  }
+  return { projectDirectory, baseCommit, expectedCommonGitDirectory, workspaceId }
 }
 
 const silentLog: WorktreeLog = {
@@ -381,6 +388,26 @@ async function runDependencyInstall(directory: string, log: WorktreeLog): Promis
   }
 }
 
+function findExistingLockfiles(directory: string) {
+  return LOCKFILE_TO_INSTALL_COMMAND
+    .map(([lockfile]) => lockfile)
+    .filter((lockfile) => fs.existsSync(path.join(directory, lockfile)))
+}
+
+async function validateLockfilesClean(directory: string, lockfiles: string[]) {
+  if (lockfiles.length === 0) return
+  const result = await execAsync(
+    { command: 'git', args: ['status', '--porcelain', '--untracked-files=no', '--', ...lockfiles] },
+    { cwd: directory, timeout: 10_000 },
+  ).catch(
+    (e) => new Error('Failed to inspect tracked files after dependency install', { cause: e }),
+  )
+  if (result instanceof Error) return result
+  const changes = result.stdout.trim()
+  if (!changes) return
+  return new Error(`Dependency install modified lockfiles: ${changes.replaceAll('\n', ', ')}`)
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 export type WorktreeResult = {
@@ -390,6 +417,48 @@ export type WorktreeResult = {
 
 async function canonicalizePath(value: string) {
   return await fs.promises.realpath(value).catch(() => path.resolve(value))
+}
+
+async function resolveGitDirectory(directory: string) {
+  const result = await execAsync('git rev-parse --path-format=absolute --git-dir', {
+    cwd: directory,
+    timeout: 10_000,
+  }).catch((e) => new Error(`Failed to resolve Git directory for ${directory}`, { cause: e }))
+  if (result instanceof Error) return result
+  return canonicalizePath(result.stdout.trim())
+}
+
+// ZAI 2026-08-31: Bind destructive cleanup to the workspace that created the worktree.
+async function writeWorktreeOwner(directory: string, workspaceId: string) {
+  const gitDirectory = await resolveGitDirectory(directory)
+  if (gitDirectory instanceof Error) return gitDirectory
+  return fs.promises
+    .writeFile(path.join(gitDirectory, 'kimaki-workspace-owner'), `${workspaceId}\n`, {
+      encoding: 'utf-8',
+      flag: 'wx',
+    })
+    .catch((e) => new Error('Failed to record Kimaki worktree ownership', { cause: e }))
+}
+
+async function readWorktreeOwner(directory: string) {
+  const gitDirectory = await resolveGitDirectory(directory)
+  if (gitDirectory instanceof Error) return gitDirectory
+  const ownerPath = path.join(gitDirectory, 'kimaki-workspace-owner')
+  if (!fs.existsSync(ownerPath)) return null
+  const owner = await fs.promises
+    .readFile(ownerPath, 'utf-8')
+    .catch((e) => new Error('Failed to read Kimaki worktree ownership', { cause: e }))
+  if (owner instanceof Error) return owner
+  return owner.trim()
+}
+
+export async function validateLegacyWorktreeRemoval(directory: string) {
+  if (!fs.existsSync(directory)) return
+  const owner = await readWorktreeOwner(directory)
+  if (owner instanceof Error) return owner
+  if (owner !== null) {
+    return new Error(`Kimaki workspace-owned worktree requires SDK cleanup: ${owner}`)
+  }
 }
 
 export async function resolveGitCommit({
@@ -503,6 +572,7 @@ export async function createWorktreeCore({
   branchName,
   baseCommit,
   expectedCommonGitDirectory,
+  workspaceId,
   onProgress,
   log = silentLog,
 }: {
@@ -511,6 +581,7 @@ export async function createWorktreeCore({
   branchName: string
   baseCommit: string
   expectedCommonGitDirectory: string
+  workspaceId?: string
   onProgress?: (phase: string) => void
   log?: WorktreeLog
 }): Promise<WorktreeResult | Error> {
@@ -519,13 +590,16 @@ export async function createWorktreeCore({
   }
   await fs.promises.mkdir(path.dirname(targetDirectory), { recursive: true })
 
-  const createCmd = `git worktree add ${JSON.stringify(targetDirectory)} -B ${JSON.stringify(branchName)} ${JSON.stringify(baseCommit)}`
-  const createResult = await execAsync(createCmd, {
-    cwd: projectDirectory,
-    timeout: SUBMODULE_INIT_TIMEOUT_MS,
-  }).catch((e) =>
-    new Error(`git worktree add failed: ${formatCommandError(e)}`, { cause: e }),
-  )
+  const createResult = await execAsync(
+    {
+      command: 'git',
+      args: ['worktree', 'add', targetDirectory, '-b', branchName, baseCommit],
+    },
+    {
+      cwd: projectDirectory,
+      timeout: SUBMODULE_INIT_TIMEOUT_MS,
+    },
+  ).catch((e) => new Error(`git worktree add failed: ${formatCommandError(e)}`, { cause: e }))
   if (createResult instanceof Error) return createResult
 
   const identityResult = await validateWorktreeIdentity({
@@ -547,6 +621,35 @@ export async function createWorktreeCore({
       })
     }
     return identityResult
+  }
+
+  if (workspaceId) {
+    const ownerResult = await writeWorktreeOwner(targetDirectory, workspaceId)
+    if (ownerResult instanceof Error) {
+      const recordedOwner = await readWorktreeOwner(targetDirectory)
+      if (recordedOwner instanceof Error) {
+        return new Error(`${ownerResult.message}; cleanup ownership check failed`, {
+          cause: recordedOwner,
+        })
+      }
+      if (recordedOwner !== null && recordedOwner !== workspaceId) {
+        return new Error(`${ownerResult.message}; worktree is owned by another workspace`, {
+          cause: ownerResult,
+        })
+      }
+      const cleanupResult = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory: targetDirectory,
+        branchName,
+        workspaceId: recordedOwner === workspaceId ? workspaceId : undefined,
+      })
+      if (cleanupResult instanceof Error) {
+        return new Error(`${ownerResult.message}; cleanup failed: ${cleanupResult.message}`, {
+          cause: ownerResult,
+        })
+      }
+      return ownerResult
+    }
   }
 
   // Remove broken submodule stubs before init
@@ -580,6 +683,7 @@ export async function createWorktreeCore({
       projectDirectory,
       worktreeDirectory: targetDirectory,
       branchName,
+      workspaceId,
     })
     if (cleanupResult instanceof Error) {
       return new Error(`${submoduleValidation.message}; cleanup failed: ${cleanupResult.message}`, {
@@ -591,9 +695,26 @@ export async function createWorktreeCore({
 
   // Dependency install (non-fatal)
   onProgress?.('Installing dependencies...')
+  const lockfiles = findExistingLockfiles(targetDirectory)
   const installResult = await runDependencyInstall(targetDirectory, log)
   if (installResult instanceof Error) {
     log.error(`Dependency install failed (non-fatal): ${installResult.message}`)
+  }
+
+  const trackedFilesClean = await validateLockfilesClean(targetDirectory, lockfiles)
+  if (trackedFilesClean instanceof Error) {
+    const cleanupResult = await removeWorktreeCore({
+      projectDirectory,
+      worktreeDirectory: targetDirectory,
+      branchName,
+      workspaceId,
+    })
+    if (cleanupResult instanceof Error) {
+      return new Error(`${trackedFilesClean.message}; cleanup failed: ${cleanupResult.message}`, {
+        cause: trackedFilesClean,
+      })
+    }
+    return trackedFilesClean
   }
 
   return { directory: targetDirectory, branch: branchName }
@@ -607,20 +728,70 @@ export async function removeWorktreeCore({
   projectDirectory,
   worktreeDirectory,
   branchName,
+  workspaceId,
 }: {
   projectDirectory: string
   worktreeDirectory: string
   branchName: string
+  workspaceId?: string
 }): Promise<void | Error> {
+  if (!fs.existsSync(worktreeDirectory)) {
+    const [worktreeList, branchList] = await Promise.all([
+      execAsync(
+        { command: 'git', args: ['worktree', 'list', '--porcelain'] },
+        { cwd: projectDirectory, timeout: 10_000 },
+      ).catch((e) => new Error('Failed to inspect missing worktree registration', { cause: e })),
+      execAsync(
+        { command: 'git', args: ['branch', '--list', '--format=%(refname)', branchName] },
+        { cwd: projectDirectory, timeout: 10_000 },
+      ).catch((e) => new Error('Failed to inspect missing worktree branch', { cause: e })),
+    ])
+    if (worktreeList instanceof Error) return worktreeList
+    if (branchList instanceof Error) return branchList
+    const targetPath = path.resolve(worktreeDirectory)
+    const registered = worktreeList.stdout
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .some((line) => path.resolve(line.slice('worktree '.length)) === targetPath)
+    const branchExists = branchList.stdout
+      .split('\n')
+      .some((line) => line.trim() === `refs/heads/${branchName}`)
+    if (!registered && !branchExists) return
+    return new Error(
+      `Cannot verify worktree removal because its directory is missing (registered: ${registered}, branch exists: ${branchExists})`,
+    )
+  }
+  const owner = await readWorktreeOwner(worktreeDirectory)
+  if (owner instanceof Error) return owner
+  if (workspaceId && owner !== workspaceId) {
+    return new Error(`Kimaki worktree is owned by another workspace: ${owner ?? 'legacy'}`)
+  }
+  if (!workspaceId && owner !== null) {
+    return new Error(`Kimaki worktree requires its owner workspace ID: ${owner}`)
+  }
+  const actualBranch = await execAsync(
+    {
+      command: 'git',
+      args: ['symbolic-ref', '-q', 'HEAD'],
+    },
+    {
+      cwd: worktreeDirectory,
+      timeout: 10_000,
+    },
+  ).catch((e) => new Error('Failed to resolve worktree branch before cleanup', { cause: e }))
+  if (actualBranch instanceof Error) return actualBranch
+  if (actualBranch.stdout.trim() !== `refs/heads/${branchName}`) {
+    return new Error(`Worktree branch mismatch: ${actualBranch.stdout.trim()}`)
+  }
   const removeResult = await execAsync(
-    `git worktree remove --force ${JSON.stringify(worktreeDirectory)}`,
+    { command: 'git', args: ['worktree', 'remove', '--force', worktreeDirectory] },
     { cwd: projectDirectory, timeout: 30_000 },
   ).catch((e) => new Error(`git worktree remove failed: ${formatCommandError(e)}`, { cause: e }))
   if (removeResult instanceof Error) return removeResult
 
   if (branchName) {
     const deleteResult = await execAsync(
-      `git branch -D ${JSON.stringify(branchName)}`,
+      { command: 'git', args: ['branch', '-D', branchName] },
       { cwd: projectDirectory, timeout: 10_000 },
     ).catch((e) =>
       new Error(`git branch delete failed: ${formatCommandError(e)}`, { cause: e }),
@@ -632,11 +803,15 @@ export async function removeWorktreeCore({
 export async function removeWorktreeFromOwnRepository({
   worktreeDirectory,
   branchName,
+  workspaceId,
 }: {
   worktreeDirectory: string
   branchName: string
+  workspaceId?: string
 }): Promise<void | Error> {
-  if (!fs.existsSync(worktreeDirectory)) return
+  if (!fs.existsSync(worktreeDirectory)) {
+    return new Error(`Cannot locate repository because worktree directory is missing: ${worktreeDirectory}`)
+  }
   const listResult = await execAsync('git worktree list --porcelain', {
     cwd: worktreeDirectory,
     timeout: 10_000,
@@ -654,5 +829,6 @@ export async function removeWorktreeFromOwnRepository({
     projectDirectory: mainWorktreeLine.slice('worktree '.length),
     worktreeDirectory,
     branchName,
+    workspaceId,
   })
 }

--- a/cli/src/kimaki-workspace-adaptor.ts
+++ b/cli/src/kimaki-workspace-adaptor.ts
@@ -24,6 +24,7 @@ import {
  * from the environment instead of config.ts (which is not available in the
  * opencode server process).
  */
+// ZAI 2026-08-31: Keep adapter paths and cleanup ownership inside Kimaki's managed boundary.
 function computeWorktreeDirectory({
   projectDirectory,
   branchName,
@@ -35,14 +36,22 @@ function computeWorktreeDirectory({
   if (!dataDir) {
     return new Error('KIMAKI_DATA_DIR not set — cannot compute worktree directory')
   }
+  const prefix = 'opencode/kimaki-'
+  const managedName = branchName.startsWith(prefix) ? branchName.slice(prefix.length) : ''
+  if (
+    !managedName ||
+    managedName.includes('\\') ||
+    /[:*?"<>|]/.test(managedName) ||
+    managedName.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    return new Error(`Invalid Kimaki worktree branch: ${branchName}`)
+  }
   const projectHash = crypto
     .createHash('sha1')
     .update(projectDirectory)
     .digest('hex')
     .slice(0, 8)
-  const withoutPrefix = branchName
-    .replace(/^opencode\/kimaki-/, '')
-    .replaceAll('/', '-')
+  const withoutPrefix = managedName.replaceAll('/', '-')
   return path.join(dataDir, 'worktrees', projectHash, withoutPrefix)
 }
 
@@ -68,9 +77,7 @@ function createKimakiWorktreeAdaptor(): WorkspaceAdapter {
         projectDirectory: identity.projectDirectory,
         branchName,
       })
-      if (directory instanceof Error) {
-        return { ...info, branch: branchName }
-      }
+      if (directory instanceof Error) throw directory
       return {
         ...info,
         name: info.name || branchName,
@@ -85,12 +92,16 @@ function createKimakiWorktreeAdaptor(): WorkspaceAdapter {
       }
       const identity = getWorktreeIdentity(info)
       if (identity instanceof Error) throw identity
+      if (identity.workspaceId && identity.workspaceId !== info.id) {
+        throw new Error('Kimaki worktree workspace ID does not match OpenCode workspace ID')
+      }
       const result = await createWorktreeCore({
         projectDirectory: identity.projectDirectory,
         targetDirectory: info.directory,
         branchName: info.branch || info.name,
         baseCommit: identity.baseCommit,
         expectedCommonGitDirectory: identity.expectedCommonGitDirectory,
+        workspaceId: identity.workspaceId ?? info.id,
         // Silent log — plugin must not write to stdout/stderr
       })
       if (result instanceof Error) {
@@ -101,16 +112,31 @@ function createKimakiWorktreeAdaptor(): WorkspaceAdapter {
     async remove(info: WorkspaceInfo): Promise<void> {
       if (!info.directory) return
       const identity = getWorktreeIdentity(info)
-      const result = identity instanceof Error
-        ? await removeWorktreeFromOwnRepository({
-            worktreeDirectory: info.directory,
-            branchName: info.branch || '',
-          })
-        : await removeWorktreeCore({
-            projectDirectory: identity.projectDirectory,
-            worktreeDirectory: info.directory,
-            branchName: info.branch || '',
-          })
+      if (identity instanceof Error) {
+        const legacyResult = await removeWorktreeFromOwnRepository({
+          worktreeDirectory: info.directory,
+          branchName: info.branch || '',
+        })
+        if (legacyResult instanceof Error) throw legacyResult
+        return
+      }
+      if (identity.workspaceId && identity.workspaceId !== info.id) {
+        throw new Error('Kimaki worktree workspace ID does not match OpenCode workspace ID')
+      }
+      let result = await removeWorktreeCore({
+        projectDirectory: identity.projectDirectory,
+        worktreeDirectory: info.directory,
+        branchName: info.branch || '',
+        workspaceId: identity.workspaceId,
+      })
+      if (result instanceof Error && !identity.workspaceId) {
+        result = await removeWorktreeCore({
+          projectDirectory: identity.projectDirectory,
+          worktreeDirectory: info.directory,
+          branchName: info.branch || '',
+          workspaceId: info.id,
+        })
+      }
       if (result instanceof Error) {
         throw result
       }

--- a/cli/src/worktree-clone-isolation.e2e.test.ts
+++ b/cli/src/worktree-clone-isolation.e2e.test.ts
@@ -13,7 +13,9 @@ import {
   resolveGitCommonDirectory,
 } from './git-worktree-core.js'
 
+// ZAI 2026-08-31: Regression coverage for exact-clone and collision isolation.
 const WORKTREE_BRANCH = 'opencode/kimaki-clone-isolation'
+const COLLISION_WORKTREE_BRANCH = 'opencode/kimaki-clone-collision'
 const REJECTED_WORKTREE_BRANCH = 'opencode/kimaki-rejected-clone-isolation'
 
 async function git({ cwd, args }: { cwd: string; args: string[] }) {
@@ -142,10 +144,83 @@ test('creates a workspace from the exact requested clone and commit', async () =
         }
       `)
   } finally {
-    await requestedClient.experimental.workspace.remove({
+    const removeResponse = await requestedClient.experimental.workspace.remove({
       id: workspace.id,
       directory: requestedClone,
     })
+    if (removeResponse.error) throw new Error(JSON.stringify(removeResponse.error))
+  }
+}, 30_000)
+
+test('same-name creation keeps one winner and no failed workspace residue', async () => {
+  const requestedCommit = await git({
+    cwd: requestedClone,
+    args: ['rev-parse', 'HEAD^{commit}'],
+  })
+  const requestedCommonDirectory = await resolveGitCommonDirectory({
+    directory: requestedClone,
+  })
+  if (requestedCommonDirectory instanceof Error) throw requestedCommonDirectory
+  const warmClientResult = await initializeOpencodeForDirectory(requestedClone)
+  if (warmClientResult instanceof Error) throw warmClientResult
+  await warmClientResult().config.get({ directory: requestedClone })
+
+  const results = await Promise.all([
+    tryWorkspaceCreate({
+      worktreeName: COLLISION_WORKTREE_BRANCH,
+      projectDirectory: requestedClone,
+      baseCommit: requestedCommit,
+      expectedCommonGitDirectory: requestedCommonDirectory,
+    }),
+    tryWorkspaceCreate({
+      worktreeName: COLLISION_WORKTREE_BRANCH,
+      projectDirectory: requestedClone,
+      baseCommit: requestedCommit,
+      expectedCommonGitDirectory: requestedCommonDirectory,
+    }),
+  ])
+  const successes = results.filter((result) => !(result instanceof Error))
+  const failures = results.filter((result) => result instanceof Error)
+  const collisionDirectory = getManagedWorktreeDirectory({
+    directory: requestedClone,
+    name: COLLISION_WORKTREE_BRANCH,
+  })
+  expect({
+    successCount: successes.length,
+    failureMessages: failures.map((failure) => failure.message),
+  }).toEqual({
+    successCount: 1,
+    failureMessages: [`Worktree creation already in progress: ${collisionDirectory}`],
+  })
+
+  const clientResult = await initializeOpencodeForDirectory(requestedClone)
+  if (clientResult instanceof Error) throw clientResult
+  const client = clientResult()
+  const listResponse = await client.experimental.workspace.list({
+    directory: requestedClone,
+  })
+  if (listResponse.error) throw new Error(JSON.stringify(listResponse.error))
+  const collisionWorkspaces = (listResponse.data ?? []).filter((workspace) => {
+    return workspace.branch === COLLISION_WORKTREE_BRANCH
+  })
+
+  try {
+    expect(collisionWorkspaces).toHaveLength(1)
+    const winner = successes[0]
+    if (!winner || winner instanceof Error) throw new Error('Missing collision winner')
+    expect(fs.existsSync(winner.directory)).toBe(true)
+    await expect(git({ cwd: winner.directory, args: ['rev-parse', 'HEAD'] })).resolves.toBe(
+      requestedCommit,
+    )
+  } finally {
+    await Promise.all(
+      collisionWorkspaces.map((workspace) => {
+        return client.experimental.workspace.remove({
+          id: workspace.id,
+          directory: requestedClone,
+        })
+      }),
+    )
   }
 }, 30_000)
 

--- a/cli/src/worktrees.test.ts
+++ b/cli/src/worktrees.test.ts
@@ -3,10 +3,12 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { describe, expect, test } from 'vitest'
+import type { PluginInput, WorkspaceAdapter, WorkspaceInfo } from '@opencode-ai/plugin'
+import { describe, expect, test, vi } from 'vitest'
 import {
   buildSubmoduleReferencePlan,
   createWorktreeWithSubmodules,
+  deleteWorktree,
   execAsync,
   getManagedWorktreeDirectory,
   mergeWorktree,
@@ -16,7 +18,9 @@ import {
   validateBranchRef,
 } from './worktrees.js'
 import {
+  createWorktreeCore,
   parseGitmodulesFileContent as parseCoreGitmodulesFileContent,
+  removeWorktreeCore,
   removeWorktreeFromOwnRepository,
   resolveGitCommonDirectory,
   validateWorktreeIdentity,
@@ -28,7 +32,9 @@ import {
   shortenWorktreeSlug,
 } from './commands/new-worktree.js'
 import { setDataDir } from './config.js'
+import { kimakiWorkspaceAdaptorPlugin } from './kimaki-workspace-adaptor.js'
 
+// ZAI 2026-08-31: Regression coverage for non-destructive creation and owner-gated cleanup.
 const GIT_TIMEOUT_MS = 60_000
 
 async function git({
@@ -57,7 +63,462 @@ function createTestRoot(): string {
   return fs.mkdtempSync(path.join(tmpRoot, 'worktrees-test-'))
 }
 
+async function getKimakiWorkspaceAdapter() {
+  let adapter: WorkspaceAdapter | undefined
+  await kimakiWorkspaceAdaptorPlugin({
+    experimental_workspace: {
+      register(_type: string, registeredAdapter: WorkspaceAdapter) {
+        adapter = registeredAdapter
+      },
+    },
+  } as unknown as PluginInput)
+  if (!adapter) throw new Error('Kimaki workspace adapter was not registered')
+  return adapter
+}
+
 describe('worktrees', () => {
+  test('createWorktreeCore preserves a pre-existing branch', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'worktree')
+    const branchName = 'opencode/kimaki-existing-branch'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'first\n')
+      await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'first'] })
+      const existingBranchCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      await git({ cwd: projectDirectory, args: ['branch', branchName, existingBranchCommit] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'second\n')
+      await git({ cwd: projectDirectory, args: ['commit', '-am', 'second'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+
+      const result = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+      })
+
+      expect(result).toBeInstanceOf(Error)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).resolves.toBe(
+        existingBranchCommit,
+      )
+      expect(fs.existsSync(worktreeDirectory)).toBe(false)
+    } finally {
+      await git({
+        cwd: projectDirectory,
+        args: ['worktree', 'remove', '--force', worktreeDirectory],
+      }).catch(() => '')
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('createWorktreeCore leaves tracked files unchanged after dependency install', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'Psychology')
+    const worktreeDirectory = path.join(sandbox, 'canary-psychology')
+    const branchName = 'opencode/kimaki-clean-install'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, '.gitignore'), 'node_modules/\n')
+      fs.writeFileSync(
+        path.join(projectDirectory, 'package.json'),
+        JSON.stringify({ dependencies: {} }, null, 2) + '\n',
+      )
+      fs.writeFileSync(
+        path.join(projectDirectory, 'package-lock.json'),
+        JSON.stringify(
+          {
+            name: 'Psychology',
+            lockfileVersion: 3,
+            requires: true,
+            packages: { '': { dependencies: {} } },
+          },
+          null,
+          2,
+        ) + '\n',
+      )
+      await git({ cwd: projectDirectory, args: ['add', '.'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+
+      const result = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+      })
+      if (result instanceof Error) throw result
+
+      await expect(git({ cwd: worktreeDirectory, args: ['status', '--porcelain'] })).resolves.toBe(
+        '',
+      )
+    } finally {
+      if (fs.existsSync(worktreeDirectory)) {
+        await removeWorktreeFromOwnRepository({ worktreeDirectory, branchName })
+      }
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('createWorktreeCore rolls back when dependency install deletes a lockfile', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'worktree')
+    const branchName = 'opencode/kimaki-deleted-lockfile'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, '.gitignore'), 'node_modules/\n')
+      fs.writeFileSync(
+        path.join(projectDirectory, 'package.json'),
+        JSON.stringify(
+          {
+            scripts: {
+              postinstall: "node -e \"require('node:fs').unlinkSync('package-lock.json')\"",
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+      )
+      await execAsync('npm install --package-lock-only --ignore-scripts', {
+        cwd: projectDirectory,
+        timeout: GIT_TIMEOUT_MS,
+      })
+      await git({ cwd: projectDirectory, args: ['add', '.'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+
+      const result = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+      })
+
+      expect(result).toBeInstanceOf(Error)
+      expect(result instanceof Error ? result.message : '').toContain(
+        'Dependency install modified lockfiles',
+      )
+      expect(fs.existsSync(worktreeDirectory)).toBe(false)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).rejects.toThrow()
+    } finally {
+      await git({ cwd: projectDirectory, args: ['worktree', 'prune'] }).catch(() => '')
+      await git({ cwd: projectDirectory, args: ['branch', '-D', branchName] }).catch(() => '')
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('createWorktreeCore cleans up when recording workspace ownership fails', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'worktree')
+    const branchName = 'opencode/kimaki-owner-write-failure'
+    const workspaceId = 'wrk_11111111-1111-1111-1111-111111111111'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'owned\n')
+      await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+      const writeFile = vi
+        .spyOn(fs.promises, 'writeFile')
+        .mockRejectedValueOnce(new Error('owner marker unavailable'))
+
+      const result = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+        workspaceId,
+      })
+      writeFile.mockRestore()
+
+      expect(result).toBeInstanceOf(Error)
+      expect(fs.existsSync(worktreeDirectory)).toBe(false)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).rejects.toThrow()
+    } finally {
+      vi.restoreAllMocks()
+      await git({ cwd: projectDirectory, args: ['worktree', 'prune'] }).catch(() => '')
+      await git({ cwd: projectDirectory, args: ['branch', '-D', branchName] }).catch(() => '')
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('removeWorktreeCore requires matching workspace and branch ownership', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'worktree')
+    const branchName = 'opencode/kimaki-owned-worktree'
+    const workspaceId = 'wrk_11111111-1111-1111-1111-111111111111'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'owned\n')
+      await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+
+      const created = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+        workspaceId,
+      })
+      if (created instanceof Error) throw created
+
+      const foreignCleanup = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName,
+        workspaceId: 'wrk_22222222-2222-2222-2222-222222222222',
+      })
+      expect(foreignCleanup).toBeInstanceOf(Error)
+      expect(fs.existsSync(worktreeDirectory)).toBe(true)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).resolves.toBe(
+        baseCommit,
+      )
+
+      const tokenlessCleanup = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName,
+      })
+      expect(tokenlessCleanup).toBeInstanceOf(Error)
+
+      const legacyCleanup = await deleteWorktree({
+        projectDirectory,
+        worktreeDirectory,
+        worktreeName: branchName,
+      })
+      expect(legacyCleanup).toBeInstanceOf(Error)
+
+      const wrongBranchCleanup = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName: `${branchName}-other`,
+        workspaceId,
+      })
+      expect(wrongBranchCleanup).toBeInstanceOf(Error)
+      expect(fs.existsSync(worktreeDirectory)).toBe(true)
+
+      const ownerCleanup = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName,
+        workspaceId,
+      })
+      expect(ownerCleanup).toBeUndefined()
+      expect(fs.existsSync(worktreeDirectory)).toBe(false)
+      await expect(
+        git({ cwd: projectDirectory, args: ['rev-parse', branchName] }),
+      ).rejects.toThrow()
+    } finally {
+      await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName,
+        workspaceId,
+      })
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('removeWorktreeCore rejects a missing directory while its branch survives', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'worktree')
+    const branchName = 'opencode/kimaki-missing-directory'
+    const workspaceId = 'wrk_11111111-1111-1111-1111-111111111111'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'owned\n')
+      await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      const baseCommit = await git({ cwd: projectDirectory, args: ['rev-parse', 'HEAD'] })
+      const expectedCommonGitDirectory = await resolveGitCommonDirectory({
+        directory: projectDirectory,
+      })
+      if (expectedCommonGitDirectory instanceof Error) throw expectedCommonGitDirectory
+      const created = await createWorktreeCore({
+        projectDirectory,
+        targetDirectory: worktreeDirectory,
+        branchName,
+        baseCommit,
+        expectedCommonGitDirectory,
+        workspaceId,
+      })
+      if (created instanceof Error) throw created
+      fs.rmSync(worktreeDirectory, { recursive: true, force: true })
+
+      const result = await removeWorktreeCore({
+        projectDirectory,
+        worktreeDirectory,
+        branchName,
+        workspaceId,
+      })
+
+      expect(result).toBeInstanceOf(Error)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).resolves.toBe(
+        baseCommit,
+      )
+    } finally {
+      await git({ cwd: projectDirectory, args: ['worktree', 'prune'] }).catch(() => '')
+      await git({ cwd: projectDirectory, args: ['branch', '-D', branchName] }).catch(() => '')
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('workspace adapter removes markerless legacy worktrees with missing identity', async () => {
+    const sandbox = createTestRoot()
+    const projectDirectory = path.join(sandbox, 'project')
+    const worktreeDirectory = path.join(sandbox, 'legacy-worktree')
+    const branchName = 'opencode/kimaki-legacy-worktree'
+
+    try {
+      fs.mkdirSync(projectDirectory, { recursive: true })
+      await git({ cwd: projectDirectory, args: ['init', '-b', 'main'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['config', 'user.email', 'kimaki-tests@example.com'],
+      })
+      await git({ cwd: projectDirectory, args: ['config', 'user.name', 'Kimaki Tests'] })
+      fs.writeFileSync(path.join(projectDirectory, 'README.md'), 'legacy\n')
+      await git({ cwd: projectDirectory, args: ['add', 'README.md'] })
+      await git({ cwd: projectDirectory, args: ['commit', '-m', 'initial'] })
+      await git({
+        cwd: projectDirectory,
+        args: ['worktree', 'add', worktreeDirectory, '-b', branchName, 'HEAD'],
+      })
+      const adapter = await getKimakiWorkspaceAdapter()
+      const info: WorkspaceInfo = {
+        id: 'wrk_11111111-1111-1111-1111-111111111111',
+        type: 'kimaki-worktree',
+        name: branchName,
+        branch: branchName,
+        directory: worktreeDirectory,
+        extra: null,
+        projectID: 'legacy-project',
+      }
+
+      await adapter.remove(info)
+
+      expect(fs.existsSync(worktreeDirectory)).toBe(false)
+      await expect(git({ cwd: projectDirectory, args: ['rev-parse', branchName] })).rejects.toThrow()
+    } finally {
+      await git({ cwd: projectDirectory, args: ['worktree', 'prune'] }).catch(() => '')
+      await git({ cwd: projectDirectory, args: ['branch', '-D', branchName] }).catch(() => '')
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
+  test('workspace adapter rejects malformed branches and mismatched workspace identity', async () => {
+    const sandbox = createTestRoot()
+    const previousDataDir = process.env['KIMAKI_DATA_DIR']
+    process.env['KIMAKI_DATA_DIR'] = path.join(sandbox, 'data')
+
+    try {
+      const adapter = await getKimakiWorkspaceAdapter()
+      const baseInfo: WorkspaceInfo = {
+        id: 'wrk_11111111-1111-1111-1111-111111111111',
+        type: 'kimaki-worktree',
+        name: 'opencode/kimaki-safe',
+        branch: 'opencode/kimaki-safe',
+        directory: path.join(sandbox, 'worktree'),
+        extra: {
+          projectDirectory: path.join(sandbox, 'project'),
+          baseCommit: '1'.repeat(40),
+          expectedCommonGitDirectory: path.join(sandbox, 'project', '.git'),
+          workspaceId: 'wrk_22222222-2222-2222-2222-222222222222',
+        },
+        projectID: 'project',
+      }
+
+      expect(() => {
+        adapter.configure({
+          ...baseInfo,
+          name: 'opencode/kimaki-../escape',
+          branch: 'opencode/kimaki-../escape',
+        })
+      }).toThrow('Invalid Kimaki worktree branch')
+      await expect(adapter.create(baseInfo, {})).rejects.toThrow(
+        'Kimaki worktree workspace ID does not match OpenCode workspace ID',
+      )
+    } finally {
+      if (previousDataDir === undefined) delete process.env['KIMAKI_DATA_DIR']
+      else process.env['KIMAKI_DATA_DIR'] = previousDataDir
+      fs.rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+
   test('parseGitmodulesFileContent parses paths and urls', () => {
     const parsed = parseGitmodulesFileContent(`
 [submodule "errore"]

--- a/cli/src/worktrees.ts
+++ b/cli/src/worktrees.ts
@@ -11,6 +11,7 @@ import {
   createWorktreeCore,
   resolveGitCommit,
   resolveGitCommonDirectory,
+  validateLegacyWorktreeRemoval,
   type WorktreeResult,
 } from './git-worktree-core.js'
 import { createLogger, LogPrefix } from './logger.js'
@@ -671,6 +672,9 @@ export async function deleteWorktree({
   // Pass empty string for detached HEAD worktrees — branch deletion is skipped.
   worktreeName: string
 }): Promise<void | Error> {
+  // ZAI 2026-08-31: Legacy deletion must not bypass SDK workspace ownership.
+  const ownershipResult = await validateLegacyWorktreeRemoval(worktreeDirectory)
+  if (ownershipResult instanceof Error) return ownershipResult
   let removeResult = await git(
     projectDirectory,
     `worktree remove ${JSON.stringify(worktreeDirectory)}`,


### PR DESCRIPTION
<!-- ZAI 2026-08-31 -->
## Related issue

Closes #202

## What changed

Prevent worktree creation and failed-request cleanup from affecting another checkout.

- Replace `git worktree add -B` with `-b`, so an existing branch is rejected instead of reset.
- Claim same-process creation attempts targeting the same managed directory, leaving one winner and one clean loser.
- Record the creating workspace ID in the linked Git directory and require matching ownership plus the actual symbolic branch before destructive cleanup.
- Preserve markerless legacy cleanup while failing closed for owner-protected or unverifiable worktrees.
- Use argument-array Git execution for the changed create/remove/delete paths.
- Use frozen dependency installs and roll back creation if an existing tracked lockfile is modified or deleted.

The collision behavior intentionally rejects the requested name rather than silently selecting `-2`: the branch name is part of the requested workspace identity, and the caller can retry with another explicit name.

## How to test

Run from `cli`:

```bash
pnpm exec tsc --noEmit
pnpm vitest --run src/worktrees.test.ts -t "createWorktreeCore|removeWorktreeCore|workspace adapter"
pnpm vitest --run src/worktree-clone-isolation.e2e.test.ts
```

Observed locally:

- TypeScript: passed.
- Focused unit regressions: 8/8 passed.
- Exact-clone and collision E2E: 3/3 passed.
- Complete `worktrees.test.ts`: 29/31 passed. The two remaining failures predate this patch on Windows: the local-submodule-reference snapshot expects POSIX fixture paths, and the existing worktree-directory recognition test rejects its Windows fixture. No snapshots were updated.
