### PR TITLE
fix(cli): prevent callout markup from replacing thread titles

### DIFF
--- a/.changeset/sanitize-callout-thread-titles.md
+++ b/.changeset/sanitize-callout-thread-titles.md
@@ -1,0 +1,7 @@
+---
+'kimaki': patch
+---
+
+Prevent OpenCode callout markup from replacing Discord thread names. Callout wrappers are removed from generated session titles, and markup-only titles leave the existing thread name unchanged.
+
+Fixes #209

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -460,7 +460,9 @@ function getThreadNameCandidateFromSessionTitle({
   sessionTitle: string | undefined | null
   currentName: string
 }) {
-  const trimmed = sessionTitle?.trim()
+  const trimmed = sessionTitle
+    ?.replace(/<\/?callout\b[^>]*>/gi, '')
+    .trim()
   if (!trimmed) {
     return null
   }

--- a/cli/src/session-title-rename.test.ts
+++ b/cli/src/session-title-rename.test.ts
@@ -97,6 +97,42 @@ describe('deriveThreadNameFromSessionTitle', () => {
     ).toMatchInlineSnapshot(`undefined`)
   })
 
+  test('ignores a title containing only OpenCode callout markup', () => {
+    expect(
+      deriveThreadNameFromSessionTitle({
+        sessionTitle: '<callout accent="#ef4444">',
+        currentName: 'Useful existing title',
+      }),
+    ).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('ignores paired OpenCode callout markup with no title text', () => {
+    expect(
+      deriveThreadNameFromSessionTitle({
+        sessionTitle: '<callout accent="#ef4444"></callout>',
+        currentName: 'Useful existing title',
+      }),
+    ).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('keeps useful text while removing OpenCode callout wrappers', () => {
+    expect(
+      deriveThreadNameFromSessionTitle({
+        sessionTitle: '<callout accent="#ef4444">Useful title</callout>',
+        currentName: 'seed',
+      }),
+    ).toMatchInlineSnapshot(`"Useful title"`)
+  })
+
+  test('preserves a thread prefix around a multiline uppercase callout', () => {
+    expect(
+      deriveThreadNameFromSessionTitle({
+        sessionTitle: '<CALLOUT icon="info">\nUseful title\n</CALLOUT>',
+        currentName: 'btw: original title',
+      }),
+    ).toMatchInlineSnapshot(`"btw: Useful title"`)
+  })
+
   test('preserves btw: prefix from current name', () => {
     expect(
       deriveThreadNameFromSessionTitle({


### PR DESCRIPTION
## Related issue

Closes #209

## What changed

OpenCode-generated session titles can occasionally contain Kimaki `<callout>` markup. Kimaki previously copied that markup directly into the Discord thread name.

This change removes opening and closing callout tags before deriving the thread name. If a title contains only callout markup, Kimaki leaves the existing Discord thread name unchanged. Useful text inside a callout is retained, including existing `btw:`, `Fork:`, and worktree prefixes.

## How to test

From `cli`:

- `pnpm run test --run src/session-title-rename.test.ts` — 18 tests passed
- `tsc --noEmit` — passed

The focused tests cover markup-only titles, empty paired callouts, wrapped useful text, case-insensitive multiline tags, and preserved thread prefixes.

## AI disclosure

Assisted by Codex. The diff was independently reviewed for correctness and test adequacy before submission.