### PR TITLE
feat(cli): add configurable model shortcut commands

### DIFF
--- a/.changeset/gentle-model-shortcuts.md
+++ b/.changeset/gentle-model-shortcuts.md
@@ -1,0 +1,5 @@
+---
+'kimaki': minor
+---
+
+Add configurable Discord model shortcuts with effort choices and optional prompts that launch isolated model-pinned sessions. Fixes #211.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Kimaki adds a layer of orchestration features on top of OpenCode. The ones worth
 - **[Shell commands](https://kimaki.dev/docs/features/shell-commands)** — prefix any message with `!` to run a shell command in the project directory.
 - **[Tunnels](https://kimaki.dev/docs/remote-access/tunnels)** — expose a local dev server to a public URL so you can view it on your phone or another machine.
 - **[Quick agent switching](https://kimaki.dev/docs/getting-started/model-switching)** — instantly change model or system prompt with a `/<name>-agent` command.
+- **[Configurable model shortcuts](https://kimaki.dev/docs/getting-started/model-switching#configurable-model-shortcuts)** — register direct model commands and launch isolated model-pinned prompts.
 
 ## How messages reach a session
 

--- a/cli/src/agent-model.e2e.test.ts
+++ b/cli/src/agent-model.e2e.test.ts
@@ -21,7 +21,7 @@ import {
   test,
   expect,
 } from 'vitest'
-import { ChannelType, Client, GatewayIntentBits, Partials, REST, Routes, SlashCommandBuilder } from 'discord.js'
+import { ChannelType, Client, GatewayIntentBits, Partials, type TextChannel } from 'discord.js'
 import { DigitalDiscord } from 'discord-digital-twin/src'
 import {
   buildDeterministicOpencodeConfig,
@@ -38,11 +38,13 @@ import {
   setChannelVerbosity,
   setChannelAgent,
   setChannelModel,
+  getChannelModel,
   getThreadSession,
   getSessionModel,
   getSessionAgent,
   getChannelAgent,
   setSessionModel,
+  setThreadSession,
   type VerbosityLevel,
 } from './database.js'
 import { getDb } from './db.js'
@@ -57,7 +59,7 @@ import {
   waitForBotMessageContaining,
   waitForFooterMessage,
 } from './test-utils.js'
-import { buildQuickAgentCommandDescription } from './commands/agent.js'
+import { registerCommands } from './discord-command-registration.js'
 
 
 const TEST_USER_ID = '200000000000000920'
@@ -67,6 +69,8 @@ const PLAN_AGENT_MODEL = 'plan-model-v2'
 const CHANNEL_MODEL = 'channel-model-v2'
 const DEFAULT_MODEL = 'deterministic-v2'
 const PROVIDER_NAME = 'deterministic-provider'
+const MODEL_SHORTCUT_NAME = 'channel-model'
+const MODEL_SHORTCUT_NO_EFFORT_NAME = 'channel-model-clean'
 
 function createRunDirectories() {
   const root = path.resolve(process.cwd(), 'tmp', 'agent-model-e2e')
@@ -259,6 +263,8 @@ describe('agent model resolution', () => {
   let discord: DigitalDiscord
   let botClient: Client
   let previousDefaultVerbosity: VerbosityLevel | null = null
+  let previousModelShortcuts = store.getState().modelShortcuts
+  let previousDiscordBaseUrl = store.getState().discordBaseUrl
   let testStartTime = Date.now()
 
   beforeAll(async () => {
@@ -269,7 +275,24 @@ describe('agent model resolution', () => {
     process.env['KIMAKI_LOCK_PORT'] = String(lockPort)
     setDataDir(directories.dataDir)
     previousDefaultVerbosity = store.getState().defaultVerbosity
-    store.setState({ defaultVerbosity: 'tools_and_text' })
+    previousModelShortcuts = store.getState().modelShortcuts
+    previousDiscordBaseUrl = store.getState().discordBaseUrl
+    store.setState({
+      defaultVerbosity: 'tools_and_text',
+      modelShortcuts: [
+        {
+          name: MODEL_SHORTCUT_NAME,
+          model: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+          defaultVariant: 'high',
+          variants: ['low', 'high', 'max'],
+        },
+        {
+          name: MODEL_SHORTCUT_NO_EFFORT_NAME,
+          model: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+          variants: [],
+        },
+      ],
+    })
 
     const digitalDiscordDbPath = path.join(
       directories.dataDir,
@@ -298,6 +321,7 @@ describe('agent model resolution', () => {
     })
 
     await discord.start()
+    store.setState({ discordBaseUrl: new URL(discord.restUrl).origin })
 
     const providerNpm = url
       .pathToFileURL(
@@ -339,24 +363,16 @@ describe('agent model resolution', () => {
     }
     providerConfig.models[AGENT_MODEL] = { name: AGENT_MODEL }
     providerConfig.models[PLAN_AGENT_MODEL] = { name: PLAN_AGENT_MODEL }
-    providerConfig.models[CHANNEL_MODEL] = { name: CHANNEL_MODEL }
+    const channelModelConfig = {
+      name: CHANNEL_MODEL,
+      variants: { low: {}, high: {}, max: {} },
+    }
+    providerConfig.models[CHANNEL_MODEL] = channelModelConfig
 
     fs.writeFileSync(
       path.join(directories.projectDirectory, 'opencode.json'),
       JSON.stringify(opencodeConfig, null, 2),
     )
-
-    // Leading /command detection only rewrites when registeredUserCommands is set
-    store.setState({
-      registeredUserCommands: [
-        {
-          name: COMMAND_SYSTEM_CHECK_NAME,
-          discordCommandName: `${COMMAND_SYSTEM_CHECK_NAME}-cmd`,
-          description: 'Test command for kimaki system prompt injection',
-          source: 'command',
-        },
-      ],
-    })
 
     // Create agent .md files with custom models
     createAgentFile({
@@ -397,33 +413,26 @@ describe('agent model resolution', () => {
       discordClient: botClient,
     })
 
-    // Register quick agent slash commands so /plan-agent and /test-agent-agent
-    // are resolvable by handleQuickAgentCommand via guild.commands.fetch().
-    const agentCommands = ['test-agent', 'plan', 'plain'].map((agentName) => {
-      return new SlashCommandBuilder()
-        .setName(`${agentName}-agent`)
-        .setDescription(
-          buildQuickAgentCommandDescription({
-            agentName,
-            description: `Switch to ${agentName} agent`,
-          }),
-        )
-        .setDMPermission(false)
-        .addStringOption((opt) =>
-          opt
-            .setName('prompt')
-            .setDescription('Send a prompt with this agent')
-            .setRequired(false),
-        )
-        .toJSON()
+    await registerCommands({
+      token: discord.botToken,
+      appId: discord.botUserId,
+      guildIds: [discord.guildId],
+      agents: ['test-agent', 'plan', 'plain'].map((name) => ({
+        name,
+        description: `Switch to ${name} agent`,
+        mode: 'primary',
+      })),
     })
-    const rest = new REST({ version: '10', api: discord.restUrl }).setToken(
-      discord.botToken,
-    )
-    await rest.put(
-      Routes.applicationGuildCommands(discord.botUserId, discord.guildId),
-      { body: agentCommands },
-    )
+    store.setState({
+      registeredUserCommands: [
+        {
+          name: COMMAND_SYSTEM_CHECK_NAME,
+          discordCommandName: `${COMMAND_SYSTEM_CHECK_NAME}-cmd`,
+          description: 'Test command for kimaki system prompt injection',
+          source: 'command',
+        },
+      ],
+    })
 
     // Pre-warm the opencode server so agent discovery happens
     const warmup = await initializeOpencodeForDirectory(
@@ -459,12 +468,211 @@ describe('agent model resolution', () => {
     delete process.env['KIMAKI_LOCK_PORT']
     delete process.env['KIMAKI_DB_URL']
     if (previousDefaultVerbosity) {
-      store.setState({ defaultVerbosity: previousDefaultVerbosity })
+      store.setState({
+        defaultVerbosity: previousDefaultVerbosity,
+        modelShortcuts: previousModelShortcuts,
+        discordBaseUrl: previousDiscordBaseUrl,
+      })
     }
     if (directories) {
       fs.rmSync(directories.dataDir, { recursive: true, force: true })
     }
   }, 5_000)
+
+  test('model shortcut sets channel model and configured effort', async () => {
+    const { id: interactionId } = await discord
+      .channel(TEXT_CHANNEL_ID)
+      .user(TEST_USER_ID)
+      .runSlashCommand({ name: MODEL_SHORTCUT_NAME })
+    await discord.channel(TEXT_CHANNEL_ID).waitForInteractionAck({ interactionId, timeout: 4_000 })
+    await waitForBotMessageContaining({
+      discord,
+      threadId: TEXT_CHANNEL_ID,
+      text: 'Model for this channel set',
+      timeout: 4_000,
+    })
+
+    expect(await discord.channel(TEXT_CHANNEL_ID).text()).toMatchInlineSnapshot(`
+      "--- from: assistant (TestBot)
+      Model for this channel set to \`deterministic-provider/channel-model-v2\` with effort \`high\`"
+    `)
+    expect(await getChannelModel(TEXT_CHANNEL_ID)).toEqual({
+      modelId: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+      variant: 'high',
+    })
+    expect(await getChannelAgent(TEXT_CHANNEL_ID)).toBe('build')
+
+    const db = await getDb()
+    await db.delete(schema.channel_models).where(orm.eq(schema.channel_models.channel_id, TEXT_CHANNEL_ID))
+    await db.delete(schema.channel_agents).where(orm.eq(schema.channel_agents.channel_id, TEXT_CHANNEL_ID))
+  })
+
+  test('model shortcut in a linked thread sets session model and explicit effort', async () => {
+    const channel = (await botClient.channels.fetch(TEXT_CHANNEL_ID)) as TextChannel
+    const starterMessage = await channel.send('Model shortcut test thread')
+    const thread = await starterMessage.startThread({ name: 'model-shortcut-test', autoArchiveDuration: 60 })
+    const sessionId = 'ses_model_shortcut_test'
+    await setThreadSession(thread.id, sessionId)
+
+    const { id: interactionId } = await discord.thread(thread.id).user(TEST_USER_ID).runSlashCommand({
+      name: MODEL_SHORTCUT_NAME,
+      options: [{ name: 'effort', type: 3, value: 'max' }],
+    })
+    await discord.thread(thread.id).waitForInteractionAck({ interactionId, timeout: 4_000 })
+    await waitForBotMessageContaining({
+      discord,
+      threadId: thread.id,
+      text: 'Model for this thread set',
+      timeout: 4_000,
+    })
+
+    expect(await discord.thread(thread.id).text()).toMatchInlineSnapshot(`
+      "--- from: assistant (TestBot)
+      Model shortcut test thread
+      Model for this thread set to \`deterministic-provider/channel-model-v2\` with effort \`max\`"
+    `)
+    expect(await getSessionModel(sessionId)).toEqual({
+      modelId: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+      variant: 'max',
+    })
+    expect(await getSessionAgent(sessionId)).toBe('build')
+  }, 20_000)
+
+  test('model shortcut rejects an unlinked thread without persisting a model', async () => {
+    const channel = (await botClient.channels.fetch(TEXT_CHANNEL_ID)) as TextChannel
+    const starterMessage = await channel.send('Unlinked model shortcut test')
+    const thread = await starterMessage.startThread({
+      name: 'unlinked-model-shortcut-test',
+      autoArchiveDuration: 60,
+    })
+    const { id: interactionId } = await discord
+      .thread(thread.id)
+      .user(TEST_USER_ID)
+      .runSlashCommand({ name: MODEL_SHORTCUT_NAME })
+    await discord.thread(thread.id).waitForInteractionAck({ interactionId, timeout: 4_000 })
+    await waitForBotMessageContaining({
+      discord,
+      threadId: thread.id,
+      text: 'not linked to an OpenCode session',
+      timeout: 4_000,
+    })
+
+    expect(await discord.thread(thread.id).text()).toMatchInlineSnapshot(`
+      "--- from: assistant (TestBot)
+      Unlinked model shortcut test
+      This thread is not linked to an OpenCode session"
+    `)
+    expect(await getThreadSession(thread.id)).toBeUndefined()
+  })
+
+  async function launchShortcutPrompt({
+    shortcutName,
+    prompt,
+    effort,
+  }: {
+    shortcutName: string
+    prompt: string
+    effort?: string
+  }) {
+    const threadIdsBefore = new Set(
+      (await discord.channel(TEXT_CHANNEL_ID).getThreads()).map((thread) => thread.id),
+    )
+    const options = [
+      ...(effort ? [{ name: 'effort', type: 3, value: effort }] : []),
+      { name: 'prompt', type: 3, value: prompt },
+    ]
+    const { id: interactionId } = await discord
+      .channel(TEXT_CHANNEL_ID)
+      .user(TEST_USER_ID)
+      .runSlashCommand({ name: shortcutName, options })
+    await discord.channel(TEXT_CHANNEL_ID).waitForInteractionAck({ interactionId, timeout: 4_000 })
+    return discord.channel(TEXT_CHANNEL_ID).waitForThread({
+      timeout: 4_000,
+      predicate: (thread) => thread.name === prompt && !threadIdsBefore.has(thread.id),
+    })
+  }
+
+  test('model shortcut prompt launches an isolated model-pinned session', async () => {
+    await setChannelAgent(TEXT_CHANNEL_ID, 'test-agent')
+    await setChannelModel({
+      channelId: TEXT_CHANNEL_ID,
+      modelId: `${PROVIDER_NAME}/${AGENT_MODEL}`,
+      variant: 'low',
+    })
+    const channelModelBefore = await getChannelModel(TEXT_CHANNEL_ID)
+    const channelAgentBefore = await getChannelAgent(TEXT_CHANNEL_ID)
+    const prompt = 'Reply with exactly: isolated-model-shortcut'
+    const thread = await launchShortcutPrompt({
+      shortcutName: MODEL_SHORTCUT_NAME,
+      prompt,
+      effort: 'max',
+    })
+    await waitForFooterMessage({
+      discord,
+      threadId: thread.id,
+      timeout: 4_000,
+      afterMessageIncludes: 'ok',
+      afterAuthorId: discord.botUserId,
+    })
+
+    expect(await discord.thread(thread.id).text()).toMatchInlineSnapshot(`
+      "--- from: assistant (TestBot)
+      » **agent-model-tester** (channel-model): Reply with exactly: isolated-model-shortcut
+      *using deterministic-provider/channel-model-v2 ⋅ build*
+      ⬥ ok
+      *project ⋅ main ⋅ Ns ⋅ N% ⋅ channel-model-v2 ⋅ **build*** <@200000000000000920>"
+    `)
+    const sessionId = await getThreadSession(thread.id)
+    expect(sessionId ? await getSessionModel(sessionId) : undefined).toEqual({
+      modelId: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+      variant: 'max',
+    })
+    expect(sessionId ? await getSessionAgent(sessionId) : undefined).toBe('build')
+    expect(await getChannelModel(TEXT_CHANNEL_ID)).toEqual(channelModelBefore)
+    expect(await getChannelAgent(TEXT_CHANNEL_ID)).toBe(channelAgentBefore)
+
+    const db = await getDb()
+    await db.delete(schema.channel_models).where(orm.eq(schema.channel_models.channel_id, TEXT_CHANNEL_ID))
+    await db.delete(schema.channel_agents).where(orm.eq(schema.channel_agents.channel_id, TEXT_CHANNEL_ID))
+  }, 20_000)
+
+  test('model shortcut without an effort clears inherited effort for an isolated prompt', async () => {
+    await setChannelModel({
+      channelId: TEXT_CHANNEL_ID,
+      modelId: `${PROVIDER_NAME}/${AGENT_MODEL}`,
+      variant: 'low',
+    })
+    const channelModelBefore = await getChannelModel(TEXT_CHANNEL_ID)
+    const prompt = 'Reply with exactly: no-inherited-effort'
+    const thread = await launchShortcutPrompt({
+      shortcutName: MODEL_SHORTCUT_NO_EFFORT_NAME,
+      prompt,
+    })
+    await waitForFooterMessage({
+      discord,
+      threadId: thread.id,
+      timeout: 4_000,
+      afterMessageIncludes: 'ok',
+      afterAuthorId: discord.botUserId,
+    })
+
+    expect(await discord.thread(thread.id).text()).toMatchInlineSnapshot(`
+      "--- from: assistant (TestBot)
+      » **agent-model-tester** (channel-model-clean): Reply with exactly: no-inherited-effort
+      *using deterministic-provider/channel-model-v2 ⋅ build*
+      ⬥ ok
+      *project ⋅ main ⋅ Ns ⋅ N% ⋅ channel-model-v2 ⋅ **build*** <@200000000000000920>"
+    `)
+    const sessionId = await getThreadSession(thread.id)
+    expect(sessionId ? await getSessionModel(sessionId) : undefined).toEqual({
+      modelId: `${PROVIDER_NAME}/${CHANNEL_MODEL}`,
+      variant: null,
+    })
+    expect(await getChannelModel(TEXT_CHANNEL_ID)).toEqual(channelModelBefore)
+
+    const db = await getDb()
+    await db.delete(schema.channel_models).where(orm.eq(schema.channel_models.channel_id, TEXT_CHANNEL_ID))
+  }, 20_000)
 
   test(
     'new thread uses agent model when channel agent is set',

--- a/cli/src/cli-parsing.test.ts
+++ b/cli/src/cli-parsing.test.ts
@@ -57,8 +57,9 @@ async function getHelpOutput() {
 async function parseRootBotOptions(argv: string[]) {
   const script = [
     "import { goke } from 'goke'",
+    "import { z } from 'zod'",
     'const cli = goke(\'kimaki\')',
-    "cli.command('', 'bot').option('--no-analytics', 'Disable analytics').option('--skip-footer-mentions', 'Do not mention the thread creator in final footers')",
+    "cli.command('', 'bot').option('--no-analytics', 'Disable analytics').option('--skip-footer-mentions', 'Do not mention the thread creator in final footers').option('--model-shortcut <shortcut>', z.array(z.string()).optional())",
     `const result = await cli.parse(${JSON.stringify(argv)}, { run: false })`,
     'process.stdout.write(JSON.stringify({ args: result.args, options: result.options }))',
   ].join(';')
@@ -74,6 +75,22 @@ async function parseRootBotOptions(argv: string[]) {
 }
 
 describe('goke CLI ID parsing', () => {
+  test('collects repeated model shortcut options', async () => {
+    const result = await parseRootBotOptions([
+      'node',
+      'kimaki',
+      '--model-shortcut',
+      'glm=zai/glm-5.3,max,low,high,max',
+      '--model-shortcut',
+      'sol=openai/gpt-5.6-sol,high,low,high,max',
+    ])
+
+    expect(result.options.modelShortcut).toEqual([
+      'glm=zai/glm-5.3,max,low,high,max',
+      'sol=openai/gpt-5.6-sol,high,low,high,max',
+    ])
+  })
+
   test('keeps large Discord IDs as strings', async () => {
     const channelId = '1234567890123456789'
     const threadId = '9876543210987654321'

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
 import { getCurrentVersion } from './upgrade.js'
 import { store } from './store.js'
 import { publicOpencodeBindRequiresPassword } from './opencode.js'
+import { parseModelShortcuts } from './model-shortcuts.js'
 import multioauthCommands from './commands/multioauth.js'
 import botCommands from './cli-commands/bot.js'
 import maintenanceCommands from './cli-commands/maintenance.js'
@@ -146,6 +147,15 @@ cli
         'Blacklist a built-in skill by name. Listed skills are hidden from the model. Repeatable: pass --disable-skill multiple times. Mutually exclusive with --enable-skill. See https://github.com/remorses/kimaki/tree/main/skills for available skills.',
       ),
   )
+  .option(
+    '--model-shortcut <name=provider/model[,default-effort[,allowed-effort...]]>',
+    z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Register a model slash-command shortcut. Repeatable. Example: --model-shortcut glm=zai/glm-5.3,max,low,high,max',
+      ),
+  )
   .action(
     async (options: {
       restartOnboarding?: boolean
@@ -171,6 +181,7 @@ cli
       allowMention?: Array<'users' | 'roles' | 'everyone'>
       enableSkill?: string[]
       disableSkill?: string[]
+      modelShortcut?: string[]
       opencodeHostname?: string
       opencodePort?: string
     }) => {
@@ -235,6 +246,11 @@ cli
         // rules via computeSkillPermission().
         const enabledSkills = options.enableSkill ?? []
         const disabledSkills = options.disableSkill ?? []
+        const modelShortcuts = parseModelShortcuts(options.modelShortcut ?? [])
+        if (modelShortcuts instanceof Error) {
+          cliLogger.error(modelShortcuts.message)
+          process.exit(EXIT_NO_RESTART)
+        }
         if (enabledSkills.length > 0 && disabledSkills.length > 0) {
           cliLogger.error(
             'Cannot use --enable-skill and --disable-skill at the same time. Use one or the other.',
@@ -322,6 +338,7 @@ cli
           ...(options.disableSync && { syncEnabled: false }),
           ...(enabledSkills.length > 0 && { enabledSkills }),
           ...(disabledSkills.length > 0 && { disabledSkills }),
+          ...(modelShortcuts.length > 0 && { modelShortcuts }),
           ...(options.allowMention && { allowedMentions: options.allowMention }),
           ...(opencodeHostname && { opencodeHostname }),
           ...(opencodePort !== undefined && { opencodePort }),

--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -9,7 +9,6 @@ import {
   StringSelectMenuBuilder,
   ActionRowBuilder,
   ChannelType,
-  ThreadAutoArchiveDuration,
   type ThreadChannel,
   type TextChannel,
   MessageFlags,
@@ -22,30 +21,20 @@ import {
   getThreadSession,
   getSessionAgent,
   getChannelAgent,
-  getChannelWorktreesEnabled,
 } from '../database.js'
 import { initializeOpencodeForDirectory } from '../opencode.js'
 import {
   resolveTextChannel,
   resolveWorkingDirectory,
   getKimakiMetadata,
-  SILENT_MESSAGE_FLAGS,
 } from '../discord-utils.js'
-import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js'
 import { createLogger, LogPrefix } from '../logger.js'
 import {
   formatModelSource,
   getCurrentModelInfo,
   type CurrentModelInfo,
 } from './model.js'
-import { isGitRepositoryRoot } from '../worktrees.js'
-import {
-  formatAutoWorktreeName,
-  createWorktreeInBackground,
-  worktreeCreatingMessage,
-} from './new-worktree.js'
-import { WORKTREE_PREFIX } from './merge-worktree.js'
-import { store } from '../store.js'
+import { handleQuickPrompt } from './quick-prompt.js'
 
 const agentLogger = createLogger(LogPrefix.AGENT)
 
@@ -571,165 +560,16 @@ async function handleQuickAgentWithPrompt({
   fallbackAgentName: string
   prompt: string
 }): Promise<void> {
-  const channel = command.channel
-  if (!channel) {
-    await command.reply({
-      content: 'This command can only be used in a channel',
-      flags: MessageFlags.Ephemeral,
-    })
-    return
-  }
-
   const resolvedAgentName =
     (await resolveQuickAgentNameFromInteraction({ command })) ||
     fallbackAgentName
-
-  const isThread = [
-    ChannelType.PublicThread,
-    ChannelType.PrivateThread,
-    ChannelType.AnnouncementThread,
-  ].includes(channel.type)
-
-  const displayText = `${prompt.slice(0, 1000)}${prompt.length > 1000 ? '...' : ''}`
-
-  if (isThread) {
-    // In a thread: enqueue the prompt and switch the existing session to this agent.
-    const thread = channel as ThreadChannel
-    const resolved = await resolveWorkingDirectory({ channel: thread })
-    if (!resolved) {
-      await command.reply({
-        content: 'Could not determine project directory for this channel',
-        flags: MessageFlags.Ephemeral,
-      })
-      return
-    }
-
-    const runtime = getOrCreateRuntime({
-      threadId: thread.id,
-      thread,
-      projectDirectory: resolved.projectDirectory,
-      sdkDirectory: resolved.workingDirectory,
-      channelId: thread.parentId || thread.id,
-      appId,
-    })
-
-    // Visible reply showing the one-shot prompt (not ephemeral, so it appears in thread).
-    await command.reply({
-      content: `» **${command.user.displayName}** (${resolvedAgentName}): ${displayText}`,
-      flags: SILENT_MESSAGE_FLAGS,
-    })
-
-    await runtime.enqueueIncoming({
-      prompt,
-      userId: command.user.id,
-      username: command.user.displayName,
-      agent: resolvedAgentName,
-      appId,
-      mode: 'opencode',
-    })
-  } else if (channel.type === ChannelType.GuildText) {
-    // In a channel: create a new thread and enqueue with the requested agent.
-    const metadata = await getKimakiMetadata(channel)
-    const projectDirectory = metadata.projectDirectory
-
-    if (!projectDirectory) {
-      await command.reply({
-        content: 'This channel is not configured with a project directory',
-        flags: MessageFlags.Ephemeral,
-      })
-      return
-    }
-
-    await command.deferReply()
-
-    // Check if worktrees should be enabled (CLI flag OR channel setting),
-    // mirroring the logic in discord-bot.ts message handler.
-    const wantsWorktrees =
-      store.getState().useWorktrees ||
-      (await getChannelWorktreesEnabled(channel.id))
-    const shouldUseWorktrees =
-      wantsWorktrees && (await isGitRepositoryRoot(projectDirectory))
-
-    if (wantsWorktrees && !shouldUseWorktrees) {
-      agentLogger.warn(
-        `[WORKTREE] Skipping automatic worktree for non-git project directory: ${projectDirectory}`,
-      )
-    }
-
-    const baseThreadName = prompt.slice(0, 80)
-    const threadName = shouldUseWorktrees
-      ? `${WORKTREE_PREFIX}${baseThreadName}`
-      : baseThreadName
-
-    const starterMessage = await channel.send({
-      content: `» **${command.user.displayName}** (${resolvedAgentName}): ${displayText}`,
-      flags: SILENT_MESSAGE_FLAGS,
-    })
-
-    const thread = await starterMessage.startThread({
-      name: threadName.slice(0, 80),
-      autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
-      reason: `${resolvedAgentName} agent prompt`,
-    })
-
-    await thread.members.add(command.user.id)
-
-    // Create worktree in background if enabled, same as discord-bot.ts
-    let worktreePromise: Promise<string | Error> | undefined
-    if (shouldUseWorktrees) {
-      const worktreeName = formatAutoWorktreeName(baseThreadName.slice(0, 50))
-      agentLogger.log(`[WORKTREE] Creating worktree: ${worktreeName}`)
-
-      const worktreeStatusMessage = await thread
-        .send({
-          content: worktreeCreatingMessage(worktreeName),
-          flags: SILENT_MESSAGE_FLAGS,
-        })
-        .catch(() => undefined)
-
-      worktreePromise = createWorktreeInBackground({
-        thread,
-        starterMessage: worktreeStatusMessage,
-        worktreeName,
-        projectDirectory,
-        rest: command.client.rest,
-      })
-    }
-
-    const worktreeResult = worktreePromise ? await worktreePromise : projectDirectory
-    if (worktreeResult instanceof Error) {
-      await command.editReply(`Worktree creation failed: ${worktreeResult.message}`)
-      return
-    }
-    const sessionDirectory = worktreeResult
-
-    await command
-      .editReply(`Sent with **${resolvedAgentName}** agent in ${thread.toString()}`)
-      .catch(() => {
-        agentLogger.warn('[AGENT] Failed to edit quick-agent reply, continuing session')
-      })
-
-    const runtime = getOrCreateRuntime({
-      threadId: thread.id,
-      thread,
-      projectDirectory,
-      sdkDirectory: sessionDirectory,
-      channelId: channel.id,
-      appId,
-    })
-
-    await runtime.enqueueIncoming({
-      prompt,
-      userId: command.user.id,
-      username: command.user.displayName,
-      agent: resolvedAgentName,
-      appId,
-      mode: 'opencode',
-    })
-  } else {
-    await command.reply({
-      content: 'This command can only be used in text channels or threads',
-      flags: MessageFlags.Ephemeral,
-    })
-  }
+  await handleQuickPrompt({
+    command,
+    appId,
+    prompt,
+    displayLabel: resolvedAgentName,
+    confirmationLabel: `**${resolvedAgentName}** agent`,
+    threadReason: `${resolvedAgentName} agent prompt`,
+    agent: resolvedAgentName,
+  })
 }

--- a/cli/src/commands/model.ts
+++ b/cli/src/commands/model.ts
@@ -197,6 +197,7 @@ export async function ensureSessionPreferencesSnapshot({
   directory,
   agentOverride,
   modelOverride,
+  variantOverride,
   force,
 }: {
   sessionId: string
@@ -206,6 +207,7 @@ export async function ensureSessionPreferencesSnapshot({
   directory?: string
   agentOverride?: string
   modelOverride?: string
+  variantOverride?: string | null
   force?: boolean
 }): Promise<void> {
   const [sessionAgentPreference, sessionModelPreference] = await Promise.all([
@@ -213,7 +215,7 @@ export async function ensureSessionPreferencesSnapshot({
     getSessionModel(sessionId),
   ])
   const shouldBootstrapSessionPreferences =
-    force || (!sessionAgentPreference && !sessionModelPreference)
+    force || Boolean(modelOverride) || (!sessionAgentPreference && !sessionModelPreference)
   if (!shouldBootstrapSessionPreferences) {
     return
   }
@@ -236,11 +238,14 @@ export async function ensureSessionPreferencesSnapshot({
   if (modelOverride) {
     const parsedModelOverride = parseModelId(modelOverride)
     if (parsedModelOverride) {
-      const bootstrappedVariant = await getVariantCascade({
-        sessionId,
-        channelId,
-        appId,
-      })
+      const bootstrappedVariant =
+        variantOverride !== undefined
+          ? variantOverride
+          : await getVariantCascade({
+              sessionId,
+              channelId,
+              appId,
+            })
       await setSessionModel({
         sessionId,
         modelId: modelOverride,

--- a/cli/src/commands/quick-prompt.ts
+++ b/cli/src/commands/quick-prompt.ts
@@ -1,0 +1,188 @@
+import {
+  ChannelType,
+  MessageFlags,
+  ThreadAutoArchiveDuration,
+  type ChatInputCommandInteraction,
+  type ThreadChannel,
+} from 'discord.js'
+import { getChannelWorktreesEnabled } from '../database.js'
+import {
+  getKimakiMetadata,
+  resolveWorkingDirectory,
+  SILENT_MESSAGE_FLAGS,
+} from '../discord-utils.js'
+import { getOrCreateRuntime } from '../session-handler/thread-session-runtime.js'
+import { store } from '../store.js'
+import { isGitRepositoryRoot } from '../worktrees.js'
+import { createLogger, LogPrefix } from '../logger.js'
+import {
+  createWorktreeInBackground,
+  formatAutoWorktreeName,
+  worktreeCreatingMessage,
+} from './new-worktree.js'
+import { WORKTREE_PREFIX } from './merge-worktree.js'
+
+const quickPromptLogger = createLogger(LogPrefix.AGENT)
+
+export async function handleQuickPrompt({
+  command,
+  appId,
+  prompt,
+  displayLabel,
+  confirmationLabel,
+  threadReason,
+  agent,
+  model,
+  variant,
+}: {
+  command: ChatInputCommandInteraction
+  appId: string
+  prompt: string
+  displayLabel: string
+  confirmationLabel: string
+  threadReason: string
+  agent?: string
+  model?: string
+  variant?: string | null
+}): Promise<void> {
+  const channel = command.channel
+  if (!channel) {
+    await command.reply({
+      content: 'This command can only be used in a channel',
+      flags: MessageFlags.Ephemeral,
+    })
+    return
+  }
+
+  const isThread = [
+    ChannelType.PublicThread,
+    ChannelType.PrivateThread,
+    ChannelType.AnnouncementThread,
+  ].includes(channel.type)
+  const displayText = `${prompt.slice(0, 1000)}${prompt.length > 1000 ? '...' : ''}`
+
+  if (isThread) {
+    const thread = channel as ThreadChannel
+    const resolved = await resolveWorkingDirectory({ channel: thread })
+    if (!resolved) {
+      await command.reply({
+        content: 'Could not determine project directory for this channel',
+        flags: MessageFlags.Ephemeral,
+      })
+      return
+    }
+
+    const runtime = getOrCreateRuntime({
+      threadId: thread.id,
+      thread,
+      projectDirectory: resolved.projectDirectory,
+      sdkDirectory: resolved.workingDirectory,
+      channelId: thread.parentId || thread.id,
+      appId,
+    })
+    await command.reply({
+      content: `» **${command.user.displayName}** (${displayLabel}): ${displayText}`,
+      flags: SILENT_MESSAGE_FLAGS,
+    })
+    await runtime.enqueueIncoming({
+      prompt,
+      userId: command.user.id,
+      username: command.user.displayName,
+      agent,
+      model,
+      variant,
+      appId,
+      mode: 'opencode',
+    })
+    return
+  }
+
+  if (channel.type !== ChannelType.GuildText) {
+    await command.reply({
+      content: 'This command can only be used in text channels or threads',
+      flags: MessageFlags.Ephemeral,
+    })
+    return
+  }
+
+  const metadata = await getKimakiMetadata(channel)
+  const projectDirectory = metadata.projectDirectory
+  if (!projectDirectory) {
+    await command.reply({
+      content: 'This channel is not configured with a project directory',
+      flags: MessageFlags.Ephemeral,
+    })
+    return
+  }
+
+  await command.deferReply()
+  const wantsWorktrees =
+    store.getState().useWorktrees || (await getChannelWorktreesEnabled(channel.id))
+  const shouldUseWorktrees = wantsWorktrees && (await isGitRepositoryRoot(projectDirectory))
+  if (wantsWorktrees && !shouldUseWorktrees) {
+    quickPromptLogger.warn(
+      `[WORKTREE] Skipping automatic worktree for non-git project directory: ${projectDirectory}`,
+    )
+  }
+
+  const baseThreadName = prompt.slice(0, 80)
+  const threadName = shouldUseWorktrees ? `${WORKTREE_PREFIX}${baseThreadName}` : baseThreadName
+  const starterMessage = await channel.send({
+    content: `» **${command.user.displayName}** (${displayLabel}): ${displayText}`,
+    flags: SILENT_MESSAGE_FLAGS,
+  })
+  const thread = await starterMessage.startThread({
+    name: threadName.slice(0, 80),
+    autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
+    reason: threadReason,
+  })
+  await thread.members.add(command.user.id)
+
+  let worktreePromise: Promise<string | Error> | undefined
+  if (shouldUseWorktrees) {
+    const worktreeName = formatAutoWorktreeName(baseThreadName.slice(0, 50))
+    quickPromptLogger.log(`[WORKTREE] Creating worktree: ${worktreeName}`)
+    const worktreeStatusMessage = await thread
+      .send({
+        content: worktreeCreatingMessage(worktreeName),
+        flags: SILENT_MESSAGE_FLAGS,
+      })
+      .catch(() => undefined)
+    worktreePromise = createWorktreeInBackground({
+      thread,
+      starterMessage: worktreeStatusMessage,
+      worktreeName,
+      projectDirectory,
+      rest: command.client.rest,
+    })
+  }
+
+  const worktreeResult = worktreePromise ? await worktreePromise : projectDirectory
+  if (worktreeResult instanceof Error) {
+    await command.editReply(`Worktree creation failed: ${worktreeResult.message}`)
+    return
+  }
+
+  await command.editReply(`Sent with ${confirmationLabel} in ${thread.toString()}`).catch(() => {
+    quickPromptLogger.warn('[COMMAND] Failed to edit quick-prompt reply, continuing session')
+  })
+
+  const runtime = getOrCreateRuntime({
+    threadId: thread.id,
+    thread,
+    projectDirectory,
+    sdkDirectory: worktreeResult,
+    channelId: channel.id,
+    appId,
+  })
+  await runtime.enqueueIncoming({
+    prompt,
+    userId: command.user.id,
+    username: command.user.displayName,
+    agent,
+    model,
+    variant,
+    appId,
+    mode: 'opencode',
+  })
+}

--- a/cli/src/discord-command-registration.ts
+++ b/cli/src/discord-command-registration.ts
@@ -477,12 +477,55 @@ export async function registerCommands({
   ]
 
   // Dynamic commands are registered in priority order:
-  // agents → user config commands → MCP prompts → skills.
+  // model shortcuts → agents → user config commands → MCP prompts → skills.
   // This ordering matters because we slice to MAX_DISCORD_COMMANDS (100) at the end,
   // so lower-priority dynamic commands get trimmed first if the total exceeds the limit.
   // Skills are last because they are the largest/most disposable set under the cap.
 
-  // 1. Agent-specific quick commands like /plan-agent, /build-agent
+  const registeredCommandNames = new Set(commands.map((command) => command.name))
+
+  // 1. Operator-defined model shortcuts like /glm and /sonnet
+  const { modelShortcuts } = store.getState()
+  for (const shortcut of modelShortcuts) {
+    if (registeredCommandNames.has(shortcut.name)) {
+      cliLogger.warn(
+        `COMMANDS: Skipping model shortcut /${shortcut.name} because that command name is already registered`,
+      )
+      continue
+    }
+    commands.push(
+      new SlashCommandBuilder()
+        .setName(shortcut.name)
+        .setDescription(truncateCommandDescription(`Switch model to ${shortcut.model}`))
+        .setDMPermission(false)
+        .addStringOption((option) => {
+          option
+            .setName('effort')
+            .setDescription('Thinking effort (uses the configured default when omitted)')
+            .setRequired(false)
+            .setMaxLength(100)
+          if (shortcut.variants.length > 0) {
+            option.addChoices(
+              ...shortcut.variants.map((variant) => ({
+                name: variant,
+                value: variant,
+              })),
+            )
+          }
+          return option
+        })
+        .addStringOption((option) =>
+          option
+            .setName('prompt')
+            .setDescription('Start a session with this model and prompt')
+            .setRequired(false),
+        )
+        .toJSON(),
+    )
+    registeredCommandNames.add(shortcut.name)
+  }
+
+  // 2. Agent-specific quick commands like /plan-agent, /build-agent
   // Filter to primary/all mode agents (same as /agent command shows), excluding hidden agents
   const primaryAgents = agents.filter(
     (a) => (a.mode === 'primary' || a.mode === 'all') && !a.hidden,
@@ -519,7 +562,7 @@ export async function registerCommands({
     )
   }
 
-  // 2. User-defined commands, MCP prompts, and skills (ordered by priority)
+  // 3. User-defined commands, MCP prompts, and skills (ordered by priority)
   // Also populate registeredUserCommands in the store for /queue-command autocomplete
   const newRegisteredCommands: RegisteredUserCommand[] = []
   // Sort: regular commands first, then MCP prompts, then skills last

--- a/cli/src/errors.ts
+++ b/cli/src/errors.ts
@@ -122,6 +122,11 @@ export class InvalidModelError extends errore.createTaggedError({
   message: 'Invalid model "$model": $reason',
 }) {}
 
+export class InvalidModelShortcutError extends errore.createTaggedError({
+  name: 'InvalidModelShortcutError',
+  message: 'Invalid model shortcut "$value": $reason',
+}) {}
+
 export class FilesystemOperationError extends errore.createTaggedError({
   name: 'FilesystemOperationError',
   message: 'Filesystem operation failed: $operation',

--- a/cli/src/interaction-handler.ts
+++ b/cli/src/interaction-handler.ts
@@ -115,6 +115,8 @@ import { hasKimakiAdminPermission, hasKimakiBotPermission } from './discord-util
 import { createLogger, LogPrefix } from './logger.js'
 import { notifyError } from './sentry.js'
 import { getChannelDirectory } from './database.js'
+import { handleModelShortcutCommand } from './model-shortcuts.js'
+import { store } from './store.js'
 
 const interactionLogger = createLogger(LogPrefix.INTERACTION)
 
@@ -443,7 +445,19 @@ export function registerInteractionHandler({
               return
           }
 
-          // Handle quick agent commands (ending with -agent suffix, but not the base /agent command)
+        const modelShortcut = store
+          .getState()
+          .modelShortcuts.find((shortcut) => shortcut.name === interaction.commandName)
+        if (modelShortcut) {
+          await handleModelShortcutCommand({
+            interaction,
+            appId,
+            shortcut: modelShortcut,
+          })
+          return
+        }
+
+        // Handle quick agent commands (ending with -agent suffix, but not the base /agent command)
           if (
             interaction.commandName.endsWith('-agent') &&
             interaction.commandName !== 'agent'

--- a/cli/src/model-shortcuts.test.ts
+++ b/cli/src/model-shortcuts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import { parseModelShortcuts } from './model-shortcuts.js'
+
+describe('parseModelShortcuts', () => {
+  test('parses model shortcuts with and without variants', () => {
+    expect(
+      parseModelShortcuts([
+        'glm=zai-coding-plan/glm-5.3,max,low,high,max',
+        'luna=openai/gpt-5.6-luna',
+      ]),
+    ).toEqual([
+      {
+        name: 'glm',
+        model: 'zai-coding-plan/glm-5.3',
+        defaultVariant: 'max',
+        variants: ['low', 'high', 'max'],
+      },
+      { name: 'luna', model: 'openai/gpt-5.6-luna', variants: [] },
+    ])
+  })
+
+  test.each([
+    ['missing separator', 'glm'],
+    ['invalid command name', 'GLM=zai/glm-5.3'],
+    ['missing provider', 'glm=glm-5.3'],
+    ['empty variant', 'glm=zai/glm-5.3,'],
+    ['reserved suffix', 'glm-agent=zai/glm-5.3'],
+    ['default absent from choices', 'glm=zai/glm-5.3,max,low,high'],
+    ['duplicate choices', 'glm=zai/glm-5.3,high,low,high,high'],
+    ['oversized default', `glm=zai/glm-5.3,${'x'.repeat(101)}`],
+    ['oversized choice', `glm=zai/glm-5.3,high,${'x'.repeat(101)}`],
+  ])('rejects %s', (_label, value) => {
+    expect(parseModelShortcuts([value])).toBeInstanceOf(Error)
+  })
+
+  test('rejects duplicate command names', () => {
+    expect(parseModelShortcuts(['glm=zai/glm-5.3', 'glm=zai/glm-5.3-flash'])).toBeInstanceOf(Error)
+  })
+})

--- a/cli/src/model-shortcuts.ts
+++ b/cli/src/model-shortcuts.ts
@@ -1,0 +1,190 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js'
+import { setChannelAgent, setChannelModel, setSessionAgent, setSessionModel } from './database.js'
+import { InvalidModelShortcutError } from './errors.js'
+import { resolveAgentCommandContext } from './commands/agent.js'
+import { handleQuickPrompt } from './commands/quick-prompt.js'
+
+export type ModelShortcut = {
+  name: string
+  model: string
+  defaultVariant?: string
+  variants: string[]
+}
+
+const DISCORD_COMMAND_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/
+const DISCORD_STRING_CHOICE_MAX_LENGTH = 100
+
+export function parseModelShortcuts(values: string[]): ModelShortcut[] | InvalidModelShortcutError {
+  const shortcuts: ModelShortcut[] = []
+  const names = new Set<string>()
+
+  for (const rawValue of values) {
+    const value = rawValue.trim()
+    const equalsIndex = value.indexOf('=')
+    if (equalsIndex <= 0 || equalsIndex === value.length - 1) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'expected name=provider/model[,default-effort[,allowed-effort...]]',
+      })
+    }
+
+    const name = value.slice(0, equalsIndex).trim()
+    if (!DISCORD_COMMAND_NAME_PATTERN.test(name)) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason:
+          'name must be 1-32 lowercase letters, numbers, or hyphens and cannot start with a hyphen',
+      })
+    }
+    if (
+      name.endsWith('-agent') ||
+      name.endsWith('-cmd') ||
+      name.endsWith('-skill') ||
+      name.endsWith('-mcp-prompt')
+    ) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'name uses a suffix reserved for existing Kimaki commands',
+      })
+    }
+    if (names.has(name)) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: `duplicate command name ${name}`,
+      })
+    }
+
+    const targetParts = value
+      .slice(equalsIndex + 1)
+      .split(',')
+      .map((part) => part.trim())
+    const model = targetParts[0] || ''
+    const defaultVariant = targetParts[1] || undefined
+    const variants = targetParts.slice(2)
+    const [providerId, ...modelParts] = model.split('/')
+    if (!providerId || modelParts.join('/').length === 0) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'model must use the provider/model format',
+      })
+    }
+    if (targetParts.length > 1 && !defaultVariant) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'default effort cannot be empty',
+      })
+    }
+    if (variants.some((variant) => !variant)) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'allowed efforts cannot be empty',
+      })
+    }
+    const configuredVariants = defaultVariant ? [defaultVariant, ...variants] : variants
+    if (configuredVariants.some((variant) => variant.length > DISCORD_STRING_CHOICE_MAX_LENGTH)) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'effort names must be at most 100 characters',
+      })
+    }
+    if (new Set(variants).size !== variants.length) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'allowed efforts cannot contain duplicates',
+      })
+    }
+    if (variants.length > 25) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'Discord supports at most 25 allowed effort choices',
+      })
+    }
+    if (defaultVariant && variants.length > 0 && !variants.includes(defaultVariant)) {
+      return new InvalidModelShortcutError({
+        value: rawValue,
+        reason: 'default effort must be included in the allowed efforts',
+      })
+    }
+
+    names.add(name)
+    shortcuts.push({
+      name,
+      model,
+      variants,
+      ...(defaultVariant ? { defaultVariant } : {}),
+    })
+  }
+
+  return shortcuts
+}
+
+export async function handleModelShortcutCommand({
+  interaction,
+  appId,
+  shortcut,
+}: {
+  interaction: ChatInputCommandInteraction
+  appId: string
+  shortcut: ModelShortcut
+}): Promise<void> {
+  const requestedVariant = interaction.options.getString('effort')?.trim()
+  if (
+    requestedVariant &&
+    shortcut.variants.length > 0 &&
+    !shortcut.variants.includes(requestedVariant)
+  ) {
+    await interaction.reply({
+      content: `Unsupported effort \`${requestedVariant}\` for \`${shortcut.model}\``,
+      flags: MessageFlags.Ephemeral,
+    })
+    return
+  }
+  const variant = requestedVariant || shortcut.defaultVariant || null
+  const prompt = interaction.options.getString('prompt')?.trim()
+  if (prompt) {
+    await handleQuickPrompt({
+      command: interaction,
+      appId,
+      prompt,
+      displayLabel: shortcut.name,
+      confirmationLabel: `**${shortcut.name}** model`,
+      threadReason: `${shortcut.name} model prompt`,
+      agent: 'build',
+      model: shortcut.model,
+      variant,
+    })
+    return
+  }
+
+  await interaction.deferReply()
+  const context = await resolveAgentCommandContext({ interaction, appId })
+  if (!context) return
+
+  if (context.isThread) {
+    if (!context.sessionId) {
+      await interaction.editReply({
+        content: 'This thread is not linked to an OpenCode session',
+      })
+      return
+    }
+    await setSessionAgent(context.sessionId, 'build')
+    await setSessionModel({
+      sessionId: context.sessionId,
+      modelId: shortcut.model,
+      variant,
+    })
+  } else {
+    await setChannelAgent(context.channelId, 'build')
+    await setChannelModel({
+      channelId: context.channelId,
+      modelId: shortcut.model,
+      variant,
+    })
+  }
+
+  const scope = context.isThread ? 'this thread' : 'this channel'
+  const variantText = variant ? ` with effort \`${variant}\`` : ''
+  await interaction.editReply({
+    content: `Model for ${scope} set to \`${shortcut.model}\`${variantText}`,
+  })
+}

--- a/cli/src/session-handler/thread-runtime-state.ts
+++ b/cli/src/session-handler/thread-runtime-state.ts
@@ -43,6 +43,7 @@ export type QueuedMessage = {
   // Set by --agent/--model/--permission flags on kimaki send or slash commands.
   agent?: string
   model?: string
+  variant?: string | null
   // Raw permission rule strings ("tool:action" or "tool:pattern:action").
   // Parsed and merged into session permissions on creation.
   permissions?: string[]

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -552,6 +552,7 @@ export type IngressInput = {
   // First-dispatch-only overrides (used when creating a new session)
   agent?: string
   model?: string
+  variant?: string | null
   /**
    * Raw permission rule strings from --permission flag ("tool:action" or
    * "tool:pattern:action"). Parsed into PermissionRuleset entries by
@@ -3077,6 +3078,7 @@ export class ThreadSessionRuntime {
         directory: this.sdkDirectory,
         agentOverride: input.agent,
         modelOverride: input.model,
+        variantOverride: input.variant,
         force: createdNewSession,
       })
 
@@ -3116,11 +3118,13 @@ export class ThreadSessionRuntime {
           }
           return { providerID: modelInfo.providerID, modelID: modelInfo.modelID }
         })().catch((e) => new OpenCodeSdkError({ operation: 'resolveModelPreference', cause: e })),
-        getVariantCascade({
-          sessionId: session.id,
-          channelId,
-          appId: resolvedAppId,
-        }),
+        input.variant !== undefined
+          ? input.variant
+          : getVariantCascade({
+              sessionId: session.id,
+              channelId,
+              appId: resolvedAppId,
+            }),
       ])
       if (modelResult instanceof Error) {
         await cleanupOnError(`Failed to resolve model: ${modelResult.message}`)
@@ -3334,6 +3338,7 @@ export class ThreadSessionRuntime {
       command: input.command,
       agent: input.agent,
       model: input.model,
+      variant: input.variant,
       permissions: input.permissions,
       injectionGuardPatterns: input.injectionGuardPatterns,
       parentSessionId: input.parentSessionId,
@@ -3885,6 +3890,7 @@ export class ThreadSessionRuntime {
       directory: this.sdkDirectory,
       agentOverride: input.agent,
       modelOverride: input.model,
+      variantOverride: input.variant,
       force: createdNewSession,
     })
 
@@ -3931,11 +3937,13 @@ export class ThreadSessionRuntime {
         }
         return { providerID: modelInfo.providerID, modelID: modelInfo.modelID }
       })().catch((e) => new OpenCodeSdkError({ operation: 'resolveModelPreference', cause: e })),
-      getVariantCascade({
-        sessionId: session.id,
-        channelId,
-        appId: resolvedAppId,
-      }),
+      input.variant !== undefined
+        ? input.variant
+        : getVariantCascade({
+            sessionId: session.id,
+            channelId,
+            appId: resolvedAppId,
+          }),
     ])
     if (earlyModelResult instanceof Error) {
       this.stopTyping()

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -6,6 +6,7 @@
 import { createStore } from 'zustand/vanilla'
 import type { VerbosityLevel } from './schema.js'
 import type { ThreadRunState } from './session-handler/thread-runtime-state.js'
+import type { ModelShortcut } from './model-shortcuts.js'
 
 // Registered user commands, populated by registerCommands() in cli.ts.
 // discordCommandName is the full sanitized Discord slash command name
@@ -176,6 +177,11 @@ export type KimakiState = {
   // Read by: /queue-command autocomplete, user-command handler dispatch.
   registeredUserCommands: RegisteredUserCommand[]
 
+  // Operator-defined Discord slash commands that select a model directly.
+  // Changes: set once at startup from repeatable --model-shortcut flags.
+  // Read by: command registration and interaction dispatch.
+  modelShortcuts: ModelShortcut[]
+
   // ── Per-thread runtime state ────────────────────────────────────────
   // The main mutable state at runtime. One ThreadRunState per active thread.
   // All mutations are immutable: each updateThread() creates a new Map + new
@@ -218,6 +224,7 @@ export const store = createStore<KimakiState>(() => ({
   discordBaseUrl: 'https://discord.com',
   gatewayToken: null,
   registeredUserCommands: [],
+  modelShortcuts: [],
   threads: new Map(),
   test: { deterministicTranscription: null },
 }))

--- a/website/src/docs/docs/getting-started/model-switching.mdx
+++ b/website/src/docs/docs/getting-started/model-switching.mdx
@@ -4,7 +4,27 @@ description: How to quickly switch models and thinking levels using agent markdo
 icon: repeat
 ---
 
-Kimaki gives you two main ways to switch models: **agent files** (`.opencode/agent/*.md`) for one-command switching, and the **`/model` slash command** for interactive selection. From `/model` you can also change the thinking level or clear an override via buttons on the same reply. Agent files are the fastest option for day-to-day use; `/model` is useful for one-off changes.
+Kimaki supports **model shortcuts**, **agent files** (`.opencode/agent/*.md`), and the interactive **`/model` slash command**. Model shortcuts switch models directly and select the standard `build` agent. Agent files combine a model with custom agent instructions and permissions. `/model` is useful for one-off interactive selection.
+
+## Configurable model shortcuts
+
+Pass one or more `--model-shortcut` options when starting Kimaki:
+
+```bash
+kimaki \
+  --model-shortcut glm=zai-coding-plan/glm-5.3,max,low,high,max \
+  --model-shortcut sol=openai/gpt-5.6-sol,high,low,medium,high,xhigh,max
+```
+
+The format is `name=provider/model[,default-effort[,allowed-effort...]]`. Each entry registers a bare Discord command such as `/glm` or `/sol`. When allowed efforts are listed, Discord shows them as choices. If no default effort is configured or selected, the shortcut clears any inherited effort instead of carrying a different model's effort forward.
+
+- Run `/glm` in a project channel to make that model the channel default for new sessions.
+- Run `/glm` in a thread to switch that thread's OpenCode session.
+- Add `effort:` to override the configured default effort.
+- Add `prompt:` in a project channel to launch a fresh, isolated thread with that model and effort. The channel's existing model and agent defaults remain unchanged.
+- Add `prompt:` in a thread to send the prompt immediately and keep that session pinned to the selected model.
+
+Model shortcuts use the standard `build` agent so they change the model without introducing custom agent instructions. Built-in command names and the `-agent`, `-cmd`, `-skill`, and `-mcp-prompt` suffixes are reserved. Restart Kimaki after changing startup options so Discord commands are re-registered.
 
 ## Why agents are faster than /model
 


### PR DESCRIPTION
## Related issue

Closes #211

## What changed

Adds repeatable `--model-shortcut` startup options that register direct Discord model commands:

```text
--model-shortcut <name=provider/model[,default-effort[,allowed-effort...]]>
```

For example:

```bash
kimaki \
  --model-shortcut glm=zai-coding-plan/glm-5.3,max,low,high,max \
  --model-shortcut sol=openai/gpt-5.6-sol,high,low,medium,high,xhigh,max
```

Each shortcut supports optional `effort` and `prompt` arguments.

- In a project channel, invoking the shortcut without a prompt sets the channel model and standard `build` agent for future sessions.
- In a linked thread, it pins that session to the selected model, effort, and `build` agent.
- With `prompt` in a project channel, it starts a new isolated thread using the shortcut model without changing channel defaults.
- With `prompt` in a thread, it sends the prompt immediately and keeps that session pinned to the selected model.
- Configured efforts become Discord choices, with the configured default used when no effort is supplied.
- If no effort is configured or supplied, inherited effort is explicitly cleared so a different model's effort is not reused.
- Built-in commands and existing dynamic-command suffixes remain reserved.

The prompt path shares the established quick-agent session/worktree implementation rather than duplicating it.

## Validation

- `tsc --noEmit`: passed
- `vitest run src/model-shortcuts.test.ts`: 11 passed
- focused repeated CLI flag test: passed
- three no-prompt Discord shortcut E2Es: passed; suite cleanup then hit the existing Windows `EPERM` temp-directory failure
- full `vitest --run -u`: 552 passed, 83 failed, 29 skipped

The broad local suite cannot currently create fresh OpenCode sessions: the new prompt tests and many existing agent, queue, voice, runtime, and worktree E2Es all fail at the shared `session.create` boundary, with additional Windows cleanup/path failures. The prompt E2Es therefore did not complete locally and are not reported as passing; CI is authoritative for those paths.
