### PR TITLE
Fix Discord reply handling across OpenCode compaction

### DIFF
--- a/.changeset/fix-compaction-reply-freeze.md
+++ b/.changeset/fix-compaction-reply-freeze.md
@@ -1,0 +1,7 @@
+---
+'kimaki': patch
+---
+
+Keep OpenCode compaction summaries out of Discord reply rendering and completion tracking so the real assistant continuation can finish normally.
+
+Fixes #213

--- a/cli/src/session-handler/event-stream-state.test.ts
+++ b/cli/src/session-handler/event-stream-state.test.ts
@@ -23,6 +23,7 @@ import {
   doesLatestUserTurnHaveNaturalCompletion,
   isAssistantMessageInLatestUserTurn,
   isAssistantMessageNaturalCompletion,
+  isSummaryAssistantMessage,
   isSessionBusy,
   isAssistantTextReadyForQuestion,
   deriveLatestUnansweredQuestion,
@@ -323,6 +324,134 @@ describe('session-user-interruption', () => {
 
   test('latest user turn start time follows the follow-up user message', () => {
     expect(getCurrentTurnStartTime({ events, sessionId })).toBe(1772636335777)
+  })
+})
+
+describe('compaction summary during an active user turn', () => {
+  const sessionId = 'ses_compaction'
+  const userMessageId = 'msg_user_compaction'
+  const replyMessageId = 'msg_reply_compaction'
+  const summaryMessageId = 'msg_summary_compaction'
+
+  function assistantEvent({
+    messageId,
+    created,
+    completed,
+    summary,
+  }: {
+    messageId: string
+    created: number
+    completed?: number
+    summary?: true
+  }): EventBufferEntry {
+    return eventEntry({
+      type: 'message.updated',
+      properties: {
+        sessionID: sessionId,
+        info: {
+          id: messageId,
+          sessionID: sessionId,
+          role: 'assistant',
+          parentID: userMessageId,
+          time: { created, completed },
+          modelID: summary ? 'compaction-model' : 'reply-model',
+          providerID: 'test-provider',
+          mode: summary ? 'compaction' : 'build',
+          agent: summary ? 'compaction' : 'build',
+          path: { cwd: '/test', root: '/test' },
+          cost: summary ? 2 : 1,
+          tokens: {
+            input: summary ? 20 : 10,
+            output: 1,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          finish: completed ? 'stop' : undefined,
+          summary,
+        },
+      },
+    })
+  }
+
+  const activeEvents = [
+    eventEntry({
+      type: 'message.updated',
+      properties: {
+        sessionID: sessionId,
+        info: {
+          id: userMessageId,
+          sessionID: sessionId,
+          role: 'user',
+          time: { created: 1 },
+          agent: 'build',
+          model: { providerID: 'test-provider', modelID: 'reply-model' },
+        },
+      },
+    }),
+    assistantEvent({ messageId: replyMessageId, created: 2 }),
+    assistantEvent({
+      messageId: summaryMessageId,
+      created: 3,
+      completed: 4,
+      summary: true,
+    }),
+  ]
+
+  test('compaction completion does not replace or complete the user-facing reply', () => {
+    expect(getAssistantMessageIdsForLatestUserTurn({
+      events: activeEvents,
+      sessionId,
+    })).toEqual(new Set([replyMessageId]))
+    expect(getLatestAssistantMessageIdForLatestUserTurn({
+      events: activeEvents,
+      sessionId,
+    })).toBe(replyMessageId)
+    expect(isAssistantMessageInLatestUserTurn({
+      events: activeEvents,
+      sessionId,
+      messageId: summaryMessageId,
+    })).toBe(false)
+    expect(doesLatestUserTurnHaveNaturalCompletion({
+      events: activeEvents,
+      sessionId,
+    })).toBe(false)
+  })
+
+  test('summary identity is derivable while its billed usage remains counted', () => {
+    expect(isSummaryAssistantMessage({
+      events: activeEvents,
+      sessionId,
+      messageId: summaryMessageId,
+    })).toBe(true)
+    expect(isAssistantMessageNaturalCompletion({
+      message: getAssistantMessageById({
+        events: activeEvents,
+        sessionId,
+        messageId: summaryMessageId,
+      }),
+    })).toBe(false)
+    expect(getLatestRunInfo({ events: activeEvents, sessionId })).toEqual({
+      model: 'reply-model',
+      providerID: 'test-provider',
+      agent: 'build',
+      tokensUsed: 11,
+    })
+    expect(getLatestTurnTokenUsage({ events: activeEvents, sessionId })).toMatchObject({
+      total: 32,
+      cost: 3,
+      assistantMessageCount: 2,
+    })
+  })
+
+  test('the real continuation still completes normally after compaction', () => {
+    const completedEvents = [
+      ...activeEvents,
+      assistantEvent({ messageId: replyMessageId, created: 2, completed: 5 }),
+    ]
+    expect(doesLatestUserTurnHaveNaturalCompletion({
+      events: completedEvents,
+      sessionId,
+    })).toBe(true)
   })
 })
 

--- a/cli/src/session-handler/event-stream-state.ts
+++ b/cli/src/session-handler/event-stream-state.ts
@@ -35,6 +35,10 @@ export function getEventBufferSessionId(event: EventBufferEvent): string | undef
 type AssistantMessage = Extract<OpenCodeMessage, { role: 'assistant' }>
 type UserMessage = Extract<OpenCodeMessage, { role: 'user' }>
 
+function isUserFacingAssistantMessage(message: AssistantMessage): boolean {
+  return message.summary !== true
+}
+
 function getTaskChildSessionId({
   part,
 }: {
@@ -312,6 +316,9 @@ export function isAssistantMessageNaturalCompletion({
 }: {
   message: AssistantMessage
 }): boolean {
+  if (!isUserFacingAssistantMessage(message)) {
+    return false
+  }
   if (typeof message.time.completed !== 'number') {
     return false
   }
@@ -784,6 +791,9 @@ export function getLatestRunInfo({
     if (msg.sessionID !== sessionId || msg.role !== 'assistant') {
       continue
     }
+    if (!isUserFacingAssistantMessage(msg)) {
+      continue
+    }
     return {
       model: msg.modelID,
       providerID: msg.providerID,
@@ -828,6 +838,9 @@ export function getAssistantMessageIdsForLatestUserTurn({
     if (msg.sessionID !== sessionId || msg.role !== 'assistant') {
       continue
     }
+    if (!isUserFacingAssistantMessage(msg)) {
+      continue
+    }
     if (msg.parentID === latestUserMessage.id) {
       assistantMessageIds.add(msg.id)
     }
@@ -867,6 +880,9 @@ export function getLatestAssistantMessageIdForLatestUserTurn({
     }
     const info = event.properties.info
     if (info.sessionID !== sessionId || info.role !== 'assistant') {
+      continue
+    }
+    if (!isUserFacingAssistantMessage(info)) {
       continue
     }
     if (info.parentID !== latestUserMessage.id) {
@@ -1045,6 +1061,32 @@ export function isAssistantMessageInLatestUserTurn({
     upToIndex,
   })
   return assistantMessageIds.has(messageId)
+}
+
+export function isSummaryAssistantMessage({
+  events,
+  sessionId,
+  messageId,
+  upToIndex,
+}: {
+  events: EventBufferEntry[]
+  sessionId: string
+  messageId: string
+  upToIndex?: number
+}): boolean {
+  const end = upToIndex ?? events.length - 1
+  for (let i = end; i >= 0; i--) {
+    const event = events[i]?.event
+    if (event?.type !== 'message.updated') {
+      continue
+    }
+    const info = event.properties.info
+    if (info.sessionID !== sessionId || info.role !== 'assistant' || info.id !== messageId) {
+      continue
+    }
+    return info.summary === true
+  }
+  return false
 }
 
 // Returns a stable 1-based subtask index for candidateSessionId.

--- a/cli/src/session-handler/thread-session-runtime-summary.test.ts
+++ b/cli/src/session-handler/thread-session-runtime-summary.test.ts
@@ -1,0 +1,129 @@
+import type {
+  Event as OpenCodeEvent,
+  Message as OpenCodeMessage,
+  Part,
+} from '@opencode-ai/sdk/v2'
+import { describe, expect, test } from 'vitest'
+import type { EventBufferEntry, EventBufferEvent } from './event-stream-state.js'
+import { ThreadSessionRuntime } from './thread-session-runtime.js'
+
+type RuntimeInternals = {
+  state?: { sessionId: string }
+  eventBuffer: EventBufferEntry[]
+  partBuffer: Map<string, Map<string, Part>>
+  compactEventForEventBuffer: (event: EventBufferEvent) => EventBufferEvent | undefined
+  flushBufferedParts: () => Promise<void>
+  handleMessageUpdated: (message: OpenCodeMessage) => Promise<void>
+  handlePartUpdated: (part: Part) => Promise<void>
+  handleNaturalAssistantCompletion: () => Promise<void>
+}
+
+function summaryMessageEvent({
+  sessionId,
+  messageId,
+}: {
+  sessionId: string
+  messageId: string
+}): OpenCodeEvent {
+  return {
+    id: `evt_${messageId}`,
+    type: 'message.updated',
+    properties: {
+      sessionID: sessionId,
+      info: {
+        id: messageId,
+        sessionID: sessionId,
+        role: 'assistant',
+        parentID: 'msg_user',
+        time: { created: 2, completed: 3 },
+        modelID: 'compaction-model',
+        providerID: 'test-provider',
+        mode: 'compaction',
+        agent: 'compaction',
+        path: { cwd: '/test', root: '/test' },
+        cost: 1,
+        tokens: {
+          input: 10,
+          output: 1,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        finish: 'stop',
+        summary: true,
+      },
+    },
+  }
+}
+
+function summaryTextPart({
+  sessionId,
+  messageId,
+}: {
+  sessionId: string
+  messageId: string
+}): Part {
+  return {
+    id: `prt_${messageId}`,
+    sessionID: sessionId,
+    messageID: messageId,
+    type: 'text',
+    text: 'internal compaction summary must not reach Discord',
+    time: { start: 2, end: 3 },
+  }
+}
+
+describe('ThreadSessionRuntime compaction summary routing', () => {
+  test('drops summary message parts before fallback buffering or completion', async () => {
+    const sessionId = 'ses_main'
+    const messageId = 'msg_summary_embedded_parts'
+    const event = summaryMessageEvent({ sessionId, messageId })
+    if (event.type !== 'message.updated') {
+      throw new Error('Expected summary message event')
+    }
+    const message = {
+      ...event.properties.info,
+      parts: [summaryTextPart({ sessionId, messageId })],
+    } as unknown as OpenCodeMessage
+    const runtime = Object.create(ThreadSessionRuntime.prototype) as RuntimeInternals
+    Object.defineProperty(runtime, 'state', {
+      value: { sessionId },
+      configurable: true,
+    })
+    runtime.eventBuffer = [{ event, timestamp: 1 }]
+    runtime.partBuffer = new Map()
+    runtime.flushBufferedParts = async () => {
+      throw new Error('Summary message must not flush parts')
+    }
+    runtime.handleNaturalAssistantCompletion = async () => {
+      throw new Error('Summary message must not complete the Discord turn')
+    }
+
+    await runtime.handleMessageUpdated(message)
+
+    expect(runtime.partBuffer.size).toBe(0)
+  })
+
+  test.each([
+    ['main session', 'ses_main'],
+    ['subagent session', 'ses_child'],
+  ])('preserves summary identity and drops %s parts before buffering', async (_, sessionId) => {
+    const messageId = `msg_summary_${sessionId}`
+    const runtime = Object.create(ThreadSessionRuntime.prototype) as RuntimeInternals
+    const compacted = runtime.compactEventForEventBuffer(
+      summaryMessageEvent({ sessionId, messageId }),
+    )
+
+    expect(compacted?.type).toBe('message.updated')
+    if (!compacted || compacted.type !== 'message.updated') {
+      throw new Error('Expected compacted summary message event')
+    }
+    expect(compacted.properties.info.summary).toBe(true)
+
+    runtime.eventBuffer = [{ event: compacted, timestamp: 1 }]
+    runtime.partBuffer = new Map()
+
+    await runtime.handlePartUpdated(summaryTextPart({ sessionId, messageId }))
+
+    expect(runtime.partBuffer.size).toBe(0)
+  })
+})

--- a/cli/src/session-handler/thread-session-runtime.ts
+++ b/cli/src/session-handler/thread-session-runtime.ts
@@ -142,6 +142,7 @@ import {
   hasAssistantMessageCompletedBefore,
   isAssistantMessageInLatestUserTurn,
   isAssistantMessageNaturalCompletion,
+  isSummaryAssistantMessage,
   type EventBufferEvent,
   type EventBufferEntry,
 } from './event-stream-state.js'
@@ -1177,7 +1178,6 @@ export class ThreadSessionRuntime {
           })
         : []
       delete info.system
-      delete info.summary
       delete info.tools
       delete info.parts
       if (partsSummary.length > 0) {
@@ -1933,6 +1933,10 @@ export class ThreadSessionRuntime {
     if (msg.role !== 'assistant') {
       return
     }
+    if (msg.summary === true) {
+      logger.info(`[SKIP] message.updated for compaction summary ${msg.id}`)
+      return
+    }
     if (!sessionId) {
       return
     }
@@ -2047,8 +2051,18 @@ export class ThreadSessionRuntime {
   }
 
   private async handlePartUpdated(part: Part): Promise<void> {
-    this.storePart(part)
     const sessionId = this.state?.sessionId
+
+    if (isSummaryAssistantMessage({
+      events: this.eventBuffer,
+      sessionId: part.sessionID,
+      messageId: part.messageID,
+    })) {
+      logger.info(`[SKIP] message.part.updated for compaction summary ${part.messageID}`)
+      return
+    }
+
+    this.storePart(part)
 
     const subtaskInfo = this.getSubtaskInfoForSession(part.sessionID)
     const isSubtaskEvent = Boolean(subtaskInfo)


### PR DESCRIPTION
## Summary

- preserve OpenCode's lightweight `summary` marker in Kimaki's bounded event buffer
- keep compaction assistants out of Discord reply identity, rendering, completion, and displayed-model selection
- retain compaction token usage and cost in billing analytics
- suppress summary parts for both main and subagent sessions, including parts embedded directly in `message.updated`

## Root cause

OpenCode creates compaction work as an assistant message under the current user turn and marks it `summary: true`. Kimaki discarded that marker while compacting persisted events. The compaction assistant could then be mistaken for the user-facing response, so its completion could flush/clear the Discord turn before the real post-compaction continuation arrived.

Fixes #213

## Verification

- `tsc -p cli/tsconfig.json --noEmit` — pass
- `vitest run cli/src/session-handler/event-stream-state.test.ts cli/src/session-handler/thread-session-runtime-summary.test.ts` — 53 passed
- Three independent reviews — pass after correcting billing aggregation, subagent coverage, and the embedded-parts fallback test

The mandated full `vitest --run -u` monorepo run is not green in this Windows sandbox: 612 tests passed, 36 failed, 13 skipped, and 70 suites could not load. The failures are outside this diff and are dominated by read-only `~/.kimaki` SQLite/attachment paths, missing workspace package links and Unix executables, tunnel/OpenCode startup timeouts, and Windows permission/mode assertions. Both changed test files pass in the same environment.
